### PR TITLE
chore(repo): add initial public project snapshot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,120 @@
+name: Bug report
+description: Report a defect in aionetx's runtime, lifecycle, or API behavior.
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        Before filing, please check:
+        - **Questions or usage help** belong in [Discussions -> Q&A](https://github.com/MarcusKorinth/aionetx/discussions/categories/q-a), not here.
+        - **Security vulnerabilities** must be reported privately via [GitHub Private Vulnerability Reporting](https://github.com/MarcusKorinth/aionetx/security/advisories/new) or the email fallback in `SECURITY.md`. Do not file them as public issues.
+        - Search [existing issues](https://github.com/MarcusKorinth/aionetx/issues?q=is%3Aissue) to see if the bug is already tracked.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear, concise description of what is broken.
+      placeholder: e.g. "Calling `client.stop()` from inside an event handler leaves the dispatcher task alive."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: |
+        A self-contained snippet or steps to reproduce the bug. Please keep it as small as possible
+        - ideally fewer than 30 lines, using only `aionetx` and the standard library.
+      render: python
+      placeholder: |
+        import asyncio
+        from aionetx import AsyncioNetworkFactory
+        # ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen if the bug were fixed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead? Include tracebacks or stderr output verbatim if any.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: aionetx-version
+    attributes:
+      label: aionetx version
+      description: Output of `python -c "import aionetx, importlib.metadata; print(importlib.metadata.version('aionetx'))"`
+      placeholder: e.g. 0.1.0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python version
+      description: If the bug is specific to a version, note it here; otherwise pick the one you reproduced with.
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
+        - Other / multiple (please specify in Additional context)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (please specify in Additional context)
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack trace
+      description: Relevant logs, stack traces, or event-handler output. Remove anything sensitive before pasting.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that would help diagnose the bug (network environment, container runtime, proxies, unusual firewall/NAT setup, etc.).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues and confirmed this bug is not already reported.
+          required: true
+        - label: This is a defect in aionetx itself, not a usage question (usage questions belong in Discussions Q&A).
+          required: true
+        - label: This is not a security vulnerability (security vulnerabilities must be reported privately - see `SECURITY.md`).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, usage help, design discussions
+    url: https://github.com/MarcusKorinth/aionetx/discussions/categories/q-a
+    about: Please ask questions and discuss usage patterns in Discussions Q&A rather than opening an issue. Bugs and concrete feature proposals still belong in this tracker.
+  - name: Ideas and brainstorming
+    url: https://github.com/MarcusKorinth/aionetx/discussions
+    about: For early-stage ideas that are not yet a concrete feature proposal, use Discussions. Open a feature request here only when you have a specific behavior change in mind.
+  - name: Report a security vulnerability
+    url: https://github.com/MarcusKorinth/aionetx/security/advisories/new
+    about: Do not file public issues for suspected vulnerabilities. Use GitHub Private Vulnerability Reporting, or see SECURITY.md for the email fallback.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Propose a concrete behavior change or new capability for aionetx.
+title: "[feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature.
+
+        Before filing, please check:
+        - **Early-stage ideas and "wouldn't it be cool if..."** belong in [Discussions → Ideas](https://github.com/MarcusKorinth/aionetx/discussions). Open a feature request issue only when you have a concrete behavior change in mind (you can describe inputs, outputs, and user-visible API).
+        - aionetx is a deliberately narrow **raw-byte asyncio transport library**. Features that belong in higher-layer frameworks (HTTP, messaging, TLS, service-mesh concerns) are generally out of scope — see the "What this library is not for" section in README.
+        - Search [existing issues](https://github.com/MarcusKorinth/aionetx/issues?q=is%3Aissue) to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What pain point does this address? Describe the use case, not the solution yet.
+      placeholder: e.g. "When using the TCP client with reconnect, I cannot observe whether the current attempt is still within the initial backoff window or has moved to steady state."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: The concrete behavior change. Include the user-visible API surface you have in mind (types, method signatures, event names).
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case context
+      description: Where in your application does this help? A realistic scenario helps evaluate whether the change belongs in aionetx or in a layer above it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Considered alternatives
+      description: Other approaches you weighed (workarounds, different API shapes, doing nothing) and why you chose the proposal above.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, prior discussions, or similar APIs in other libraries.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: I have searched existing issues and discussions and confirmed this is not already proposed.
+          required: true
+        - label: This proposal is about raw-byte transport behavior (lifecycle, events, backpressure, reconnect, multicast, typing) — not a higher-layer protocol concern.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python package dependencies (dev extras in pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "python"
+    # Group all dev dep bumps into a single PR to reduce noise
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      action-updates:
+        patterns:
+          - "*"
+      security-patches:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to aionetx.
+
+Before opening the PR, please:
+  - Run `ruff check .` and `mypy src` locally.
+  - Run the relevant test slice (at minimum: `pytest -q -m "not multicast and not slow and not integration"`).
+  - Update `CHANGELOG.md` under `[Unreleased]` if the change is user-visible.
+  - If this changes a documented public contract, update `README.md` and the relevant docs in the same PR.
+
+Keep the PR focused on one concern. Refactoring-only and behavior-change PRs are easier to review when they are not mixed.
+-->
+
+## Summary
+
+<!-- One or two sentences describing *what* changes and *why*. The why is the important part. -->
+
+## Changes
+
+<!-- Bullet list of user-visible or behavior-visible changes. Skip implementation minutiae. -->
+
+-
+
+## Related issue
+
+<!-- "Closes #123" auto-closes the issue on merge. "Relates to #123" links without closing. Leave blank if none. -->
+
+## Checklist
+
+- [ ] Tests added or updated for new or changed behavior (or explicitly explain why none are needed).
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
+- [ ] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
+- [ ] `ruff check .` passes locally.
+- [ ] `mypy src` passes locally.
+- [ ] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,509 @@
+﻿name: ci
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Weekly SHA-pin validation every Monday at 07:00 UTC
+    - cron: "0 7 * * 1"
+
+jobs:
+  # Calibration note:
+  # - Required lanes are runtime trust, integration confidence, packaging/release, and static analysis.
+  # - Non-blocking lanes are docs/process hygiene, optional environment-sensitive checks, and observability-only reports.
+  # Tier: packaging/release verification (installed-artifact portability and metadata)
+  cross_platform_portability_smoke:
+    name: Required â€” packaging/release cross-platform portability smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install build tool
+        run: |
+          python -m pip install --upgrade pip build twine
+      - name: Build artifacts
+        run: python -m build
+      - name: Validate artifact metadata
+        run: python -m twine check dist/*
+      - name: Install wheel and run portability smoke + semantic mini-suite
+        run: |
+          python scripts/ci/install_single_artifact.py "dist/*.whl" --force-reinstall --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+      - name: Install sdist and run portability smoke + semantic mini-suite
+        run: |
+          python -m pip uninstall -y aionetx
+          python scripts/ci/install_single_artifact.py "dist/*.tar.gz" --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+  build_install_verify:
+    name: Required â€” packaging/release build+install verify (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install build tool
+        run: |
+          python -m pip install --upgrade pip build twine
+      - name: Build artifacts
+        run: python -m build
+      - name: Validate artifact metadata
+        run: python -m twine check dist/*
+      - name: Install wheel and verify import
+        run: |
+          python scripts/ci/install_single_artifact.py "dist/*.whl" --force-reinstall --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+      - name: Install sdist and verify import
+        run: |
+          python -m pip uninstall -y aionetx
+          python scripts/ci/install_single_artifact.py "dist/*.tar.gz" --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+  # Tier: API symbol stability (always-on, no path filter â€” lesson from f8c2ae2 regression)
+  api_symbol_stability:
+    name: Required â€” API symbol stability gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run API symbol stability test (merge-blocking gate)
+        run: pytest tests/unit/test_api_symbol_sources.py -k "api_symbol" --tb=short -q
+
+  # Tier: static correctness checks
+  ruff_checks:
+    name: Required â€” static correctness Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
+  mypy_supported_bounds:
+    name: Required â€” static correctness Mypy (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Mypy
+        run: mypy src
+
+  # Tier: runtime-semantic trust gates
+  required_behavior_tests:
+    name: Required â€” runtime trust required behavior tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required behavior test slice
+        run: pytest -q -m "not multicast and not slow and not integration" --timeout=60
+
+  # Tier: adversarial lifecycle gate
+  behavior_critical_tests:
+    name: Required â€” adversarial lifecycle behavior_critical gate (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [required_behavior_tests]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run behavior_critical adversarial lifecycle tests
+        run: pytest -m behavior_critical --tb=short -q --timeout=60
+
+  # Tier: integration confidence
+  integration_tests_supported_bounds:
+    name: Required â€” integration confidence tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [required_behavior_tests]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run integration tests on supported bounds (exclude environment-sensitive multicast)
+        run: pytest -q -m "integration and not multicast and not slow" --timeout=60
+
+  integration_smoke_tests_intermediate_versions:
+    name: Required â€” integration confidence smoke (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [required_behavior_tests]
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required integration smoke slice on intermediate supported versions
+        run: pytest -q -m "integration_smoke and not multicast and not slow" --timeout=60
+
+  integration_semantic_tests_intermediate_versions:
+    name: Required â€” integration confidence semantic shard (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [required_behavior_tests]
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Validate required integration semantic shard contract
+        run: python scripts/ci/assert_integration_semantic_shard.py
+      - name: Run required integration semantic shard on intermediate supported versions
+        run: pytest -q -m "integration_semantic and not multicast and not slow" --timeout=60
+
+  # Tier: focused runtime reliability contracts
+  reliability_smoke_tests:
+    name: Required â€” runtime trust reliability smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [required_behavior_tests]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required reliability smoke tests
+        run: pytest -q -m "reliability_smoke" --timeout=60
+
+  multicast_contract_required:
+    name: Required â€” runtime trust deterministic multicast contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [required_behavior_tests]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required deterministic multicast contract
+        run: pytest -q tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py::test_multicast_start_failure_cleans_dispatcher_and_state --timeout=60
+
+  # Tier: release-confidence aggregate gate
+  required_suite_with_coverage:
+    name: Required â€” runtime trust required suite with coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [cross_platform_portability_smoke, ruff_checks, mypy_supported_bounds, api_symbol_stability, integration_tests_supported_bounds, integration_smoke_tests_intermediate_versions, integration_semantic_tests_intermediate_versions, required_behavior_tests, behavior_critical_tests, reliability_smoke_tests, multicast_contract_required]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required test suite with coverage
+        run: pytest -q -m "not multicast and not slow" --cov=aionetx --cov-report=term-missing --cov-fail-under=85 --timeout=60
+
+  ci_profile_gate:
+    name: Required â€” CI trust gate profile passed
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [required_suite_with_coverage, build_install_verify]
+    steps:
+      - name: Summarize required CI trust envelope
+        run: |
+          echo "Required CI trust gate profile completed."
+          echo "- required runtime trust, integration confidence, packaging/release, and static checks passed"
+          echo "- non-blocking secondary lanes are intentionally out-of-envelope"
+
+  # Tier: supply-chain integrity â€” SHA pin validation (non-blocking, scheduled + workflow changes)
+  validate_sha_pins:
+    name: Non-blocking â€” validate workflow SHA pins match tag comments
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    # Run on the weekly schedule, or whenever a workflow file is pushed/PR'd.
+    # GitHub Actions does not support path filters on `schedule`, so we guard
+    # per-push/PR runs with an `if` expression checking changed paths.
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && contains(toJSON(github.event.commits.*.modified), '.github/workflows/')) ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Validate SHA pins in workflow files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/ci/check_sha_pins.py
+      - name: Warn if SHA pin validation failed
+        if: failure()
+        run: |
+          echo "WARNING: One or more workflow SHA pins do not match their tag comments."
+          echo "Update the SHA in the uses: line to match the tag's current commit SHA."
+
+  # Tier: reproducible build verification (weekly schedule only â€” not required on every PR)
+  verify_reproducible_build:
+    name: Non-blocking â€” wheel reproducibility verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+      - name: Capture deterministic build timestamp
+        id: build_epoch
+        shell: bash
+        run: echo "epoch=$(git log -1 --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
+      - name: First wheel build
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: |
+          python -m build --wheel --outdir dist1/
+      - name: Second wheel build (independent repeat)
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: |
+          python -m build --wheel --outdir dist2/
+      - name: Compare wheel SHA-256 hashes (byte-identical check)
+        run: |
+          python - <<'EOF'
+          import hashlib, pathlib, sys
+          def sha256(p):
+              return hashlib.sha256(p.read_bytes()).hexdigest()
+          w1 = sorted(pathlib.Path("dist1").glob("*.whl"))
+          w2 = sorted(pathlib.Path("dist2").glob("*.whl"))
+          if not w1 or not w2:
+              print("ERROR: no wheel files found in dist1/ or dist2/", file=sys.stderr)
+              sys.exit(1)
+          if len(w1) != len(w2):
+              print(f"ERROR: wheel count mismatch: {len(w1)} vs {len(w2)}", file=sys.stderr)
+              sys.exit(1)
+          ok = True
+          for a, b in zip(w1, w2):
+              ha, hb = sha256(a), sha256(b)
+              if ha == hb:
+                  print(f"OK  {a.name}  {ha}")
+              else:
+                  print(f"FAIL {a.name}: {ha} != {hb}", file=sys.stderr)
+                  ok = False
+          sys.exit(0 if ok else 1)
+          EOF
+      - name: Warn if wheels are not reproducible
+        if: failure()
+        run: |
+          echo "WARNING: Wheel builds are not byte-identical under the same SOURCE_DATE_EPOCH."
+          echo "Check for embedded timestamps, random seeds, or non-deterministic sorting."
+
+  # Tier: optional environment-sensitive/slow checks (non-blocking)
+  multicast_tests_non_blocking:
+    name: Non-blocking â€” environment-sensitive multicast checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [required_behavior_tests]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run multicast tests
+        run: pytest -q -m "multicast" --timeout=10
+      - name: Warn if multicast tests failed
+        if: failure()
+        run: |
+          echo "WARNING: Multicast tests failed. This job is non blocking but should be reviewed before release."
+
+  slow_tests_non_blocking:
+    name: Non-blocking â€” slow checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [integration_tests_supported_bounds]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run slow tests
+        run: pytest -q -m "slow and not multicast and not reliability_smoke" --timeout=20
+
+  # Tier: documentation / example executability (non-blocking)
+  examples_smoke_non_blocking:
+    name: Non-blocking â€” examples executability smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [required_behavior_tests]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run examples smoke
+        run: python scripts/ci/examples_smoke.py
+      - name: Warn if examples smoke failed
+        if: failure()
+        run: |
+          echo "WARNING: Examples smoke failed. Non-blocking but should be reviewed before release."
+
+  # Permanent readability lane: consolidates outcomes from secondary
+  # non-blocking checks without affecting required trust semantics.
+  property_tests_non_blocking:
+    name: Non-blocking - property-based settings tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [required_behavior_tests]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev-hypothesis]
+      - name: Run property-based settings tests
+        run: pytest -q tests/unit/test_settings_property_based.py --timeout=60
+      - name: Warn if property tests failed
+        if: failure()
+        run: |
+          echo "WARNING: Property-based settings tests failed. This lane is non blocking but should be reviewed."
+
+  ci_non_blocking_summary:
+    name: Non-blocking â€” CI secondary signal summary
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - multicast_tests_non_blocking
+      - slow_tests_non_blocking
+      - examples_smoke_non_blocking
+      - property_tests_non_blocking
+      - ci_profile_gate
+    continue-on-error: true
+    steps:
+      - name: Summarize non-blocking CI lanes
+        run: |
+          echo "Non-blocking CI lane summary:"
+          echo "- multicast checks: ${{ needs.multicast_tests_non_blocking.result }}"
+          echo "- slow checks: ${{ needs.slow_tests_non_blocking.result }}"
+          echo "- examples smoke: ${{ needs.examples_smoke_non_blocking.result }}"
+          echo "- property-based settings tests: ${{ needs.property_tests_non_blocking.result }}"
+          echo "These lanes are visible but not part of the required CI trust envelope."
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   # - Non-blocking lanes are docs/process hygiene, optional environment-sensitive checks, and observability-only reports.
   # Tier: packaging/release verification (installed-artifact portability and metadata)
   cross_platform_portability_smoke:
-    name: Required â€” packaging/release cross-platform portability smoke (${{ matrix.os }})
+    name: Required - packaging/release cross-platform portability smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -51,7 +51,7 @@ jobs:
           python -m pip check
 
   build_install_verify:
-    name: Required â€” packaging/release build+install verify (${{ matrix.python-version }})
+    name: Required - packaging/release build+install verify (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -87,9 +87,9 @@ jobs:
           python scripts/ci/installed_artifact_semantic_minisuite.py
           python -m pip check
 
-  # Tier: API symbol stability (always-on, no path filter â€” lesson from f8c2ae2 regression)
+  # Tier: API symbol stability (always-on, no path filter - lesson from f8c2ae2 regression)
   api_symbol_stability:
-    name: Required â€” API symbol stability gate
+    name: Required - API symbol stability gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -106,7 +106,7 @@ jobs:
 
   # Tier: static correctness checks
   ruff_checks:
-    name: Required â€” static correctness Ruff
+    name: Required - static correctness Ruff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -124,7 +124,7 @@ jobs:
         run: ruff format --check .
 
   mypy_supported_bounds:
-    name: Required â€” static correctness Mypy (${{ matrix.python-version }})
+    name: Required - static correctness Mypy (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -144,7 +144,7 @@ jobs:
 
   # Tier: runtime-semantic trust gates
   required_behavior_tests:
-    name: Required â€” runtime trust required behavior tests (${{ matrix.python-version }})
+    name: Required - runtime trust required behavior tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -164,7 +164,7 @@ jobs:
 
   # Tier: adversarial lifecycle gate
   behavior_critical_tests:
-    name: Required â€” adversarial lifecycle behavior_critical gate (${{ matrix.python-version }})
+    name: Required - adversarial lifecycle behavior_critical gate (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [required_behavior_tests]
@@ -185,7 +185,7 @@ jobs:
 
   # Tier: integration confidence
   integration_tests_supported_bounds:
-    name: Required â€” integration confidence tests (${{ matrix.python-version }})
+    name: Required - integration confidence tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [required_behavior_tests]
@@ -205,7 +205,7 @@ jobs:
         run: pytest -q -m "integration and not multicast and not slow" --timeout=60
 
   integration_smoke_tests_intermediate_versions:
-    name: Required â€” integration confidence smoke (${{ matrix.python-version }})
+    name: Required - integration confidence smoke (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [required_behavior_tests]
@@ -225,7 +225,7 @@ jobs:
         run: pytest -q -m "integration_smoke and not multicast and not slow" --timeout=60
 
   integration_semantic_tests_intermediate_versions:
-    name: Required â€” integration confidence semantic shard (${{ matrix.python-version }})
+    name: Required - integration confidence semantic shard (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [required_behavior_tests]
@@ -248,7 +248,7 @@ jobs:
 
   # Tier: focused runtime reliability contracts
   reliability_smoke_tests:
-    name: Required â€” runtime trust reliability smoke
+    name: Required - runtime trust reliability smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [required_behavior_tests]
@@ -265,7 +265,7 @@ jobs:
         run: pytest -q -m "reliability_smoke" --timeout=60
 
   multicast_contract_required:
-    name: Required â€” runtime trust deterministic multicast contract
+    name: Required - runtime trust deterministic multicast contract
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [required_behavior_tests]
@@ -283,7 +283,7 @@ jobs:
 
   # Tier: release-confidence aggregate gate
   required_suite_with_coverage:
-    name: Required â€” runtime trust required suite with coverage
+    name: Required - runtime trust required suite with coverage
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [cross_platform_portability_smoke, ruff_checks, mypy_supported_bounds, api_symbol_stability, integration_tests_supported_bounds, integration_smoke_tests_intermediate_versions, integration_semantic_tests_intermediate_versions, required_behavior_tests, behavior_critical_tests, reliability_smoke_tests, multicast_contract_required]
@@ -300,7 +300,7 @@ jobs:
         run: pytest -q -m "not multicast and not slow" --cov=aionetx --cov-report=term-missing --cov-fail-under=85 --timeout=60
 
   ci_profile_gate:
-    name: Required â€” CI trust gate profile passed
+    name: Required - CI trust gate profile passed
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [required_suite_with_coverage, build_install_verify]
@@ -311,9 +311,9 @@ jobs:
           echo "- required runtime trust, integration confidence, packaging/release, and static checks passed"
           echo "- non-blocking secondary lanes are intentionally out-of-envelope"
 
-  # Tier: supply-chain integrity â€” SHA pin validation (non-blocking, scheduled + workflow changes)
+  # Tier: supply-chain integrity - SHA pin validation (non-blocking, scheduled + workflow changes)
   validate_sha_pins:
-    name: Non-blocking â€” validate workflow SHA pins match tag comments
+    name: Non-blocking - validate workflow SHA pins match tag comments
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -339,9 +339,9 @@ jobs:
           echo "WARNING: One or more workflow SHA pins do not match their tag comments."
           echo "Update the SHA in the uses: line to match the tag's current commit SHA."
 
-  # Tier: reproducible build verification (weekly schedule only â€” not required on every PR)
+  # Tier: reproducible build verification (weekly schedule only - not required on every PR)
   verify_reproducible_build:
-    name: Non-blocking â€” wheel reproducibility verification
+    name: Non-blocking - wheel reproducibility verification
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -399,7 +399,7 @@ jobs:
 
   # Tier: optional environment-sensitive/slow checks (non-blocking)
   multicast_tests_non_blocking:
-    name: Non-blocking â€” environment-sensitive multicast checks
+    name: Non-blocking - environment-sensitive multicast checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [required_behavior_tests]
@@ -421,7 +421,7 @@ jobs:
           echo "WARNING: Multicast tests failed. This job is non blocking but should be reviewed before release."
 
   slow_tests_non_blocking:
-    name: Non-blocking â€” slow checks
+    name: Non-blocking - slow checks
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [integration_tests_supported_bounds]
@@ -440,7 +440,7 @@ jobs:
 
   # Tier: documentation / example executability (non-blocking)
   examples_smoke_non_blocking:
-    name: Non-blocking â€” examples executability smoke
+    name: Non-blocking - examples executability smoke
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [required_behavior_tests]
@@ -486,7 +486,7 @@ jobs:
           echo "WARNING: Property-based settings tests failed. This lane is non blocking but should be reviewed."
 
   ci_non_blocking_summary:
-    name: Non-blocking â€” CI secondary signal summary
+    name: Non-blocking - CI secondary signal summary
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: codeql
+
+on:
+  push:
+    branches: ["main", "release-readiness"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Run weekly on Monday at 08:00 UTC independent of push activity.
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL — Python security analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # CodeQL is always non-blocking for pre-release; results appear in the
+    # Security tab without gating the required CI trust envelope.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: python
+          # Use the default security-and-quality query suite for broad coverage.
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   analyze:
-    name: CodeQL — Python security analysis
+    name: CodeQL - Python security analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # CodeQL is always non-blocking for pre-release; results appear in the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,623 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: "Where to publish after verification"
+        required: true
+        default: "none"
+        type: choice
+        options:
+          - none
+          - testpypi
+          - dry-run
+      release_version:
+        description: "Required for TestPyPI publish: expected pyproject version (example: 0.1.0)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # Calibration note:
+  # - Release workflow contains required trust gates only.
+  # - Docs/process hygiene and observability-only lanes are intentionally kept in the CI workflow.
+  # Tier: release provenance
+  verify_tag_version:
+    name: Verify tag matches pyproject version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify release provenance
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')
+        env:
+          TAG_NAME: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_TARGET: ${{ github.event.inputs.publish_target }}
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+        run: python scripts/ci/validate_release_provenance.py
+
+  # Tier: packaging/release verification
+  cross_platform_portability_smoke:
+    name: Release trust gate — cross-platform portability smoke (${{ matrix.os }})
+    needs: [verify_tag_version]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Capture deterministic build timestamp
+        id: build_epoch
+        shell: bash
+        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+
+      - name: Install build tool
+        run: |
+          python -m pip install --upgrade pip build twine
+
+      - name: Build artifacts
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: python -m build
+
+      - name: Validate artifact metadata
+        run: python -m twine check dist/*
+
+      - name: Install wheel and run portability smoke + semantic mini-suite
+        run: |
+          python scripts/ci/install_single_artifact.py "dist/*.whl" --force-reinstall --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+      - name: Install sdist and run portability smoke + semantic mini-suite
+        run: |
+          python -m pip uninstall -y aionetx
+          python scripts/ci/install_single_artifact.py "dist/*.tar.gz" --no-deps
+          python -c "import aionetx; print(aionetx.__name__)"
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+  # Tier: static correctness checks
+  api_symbol_stability:
+    name: Release trust gate - API symbol stability
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run API symbol stability test
+        run: pytest tests/unit/test_api_symbol_sources.py -k "api_symbol" --tb=short -q
+
+  ruff_checks:
+    name: Release trust gate — Ruff
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
+  mypy_supported_bounds:
+    name: Release trust gate — Mypy (${{ matrix.python-version }})
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Mypy
+        run: mypy src
+
+  # Tier: runtime-semantic trust gates
+  required_behavior_tests:
+    name: Release trust gate — required behavior tests (${{ matrix.python-version }})
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required behavior test slice
+        run: pytest -q -m "not multicast and not slow and not integration" --timeout=60
+
+  behavior_critical_tests:
+    name: Release trust gate - adversarial lifecycle behavior_critical gate (${{ matrix.python-version }})
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run behavior_critical adversarial lifecycle tests
+        run: pytest -m behavior_critical --tb=short -q --timeout=60
+
+  # Tier: integration confidence
+  integration_tests_supported_bounds:
+    name: Release trust gate — integration tests (${{ matrix.python-version }})
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run integration tests on supported bounds (exclude environment-sensitive multicast)
+        run: pytest -q -m "integration and not multicast and not slow" --timeout=60
+
+  integration_smoke_tests_intermediate_versions:
+    name: Release trust gate — integration smoke tests (${{ matrix.python-version }})
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required integration smoke slice on intermediate supported versions
+        run: pytest -q -m "integration_smoke and not multicast and not slow" --timeout=60
+
+  integration_semantic_tests_intermediate_versions:
+    name: Release trust gate — integration semantic shard (${{ matrix.python-version }})
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Validate required integration semantic shard contract
+        run: python scripts/ci/assert_integration_semantic_shard.py
+      - name: Run required integration semantic shard on intermediate supported versions
+        run: pytest -q -m "integration_semantic and not multicast and not slow" --timeout=60
+
+  # Tier: focused runtime reliability contracts
+  reliability_smoke_tests:
+    name: Release trust gate — reliability smoke tests
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required reliability smoke tests
+        run: pytest -q -m "reliability_smoke" --timeout=60
+
+  multicast_contract_required:
+    name: Release trust gate — deterministic multicast contract
+    needs: [required_behavior_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required deterministic multicast contract
+        run: pytest -q tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py::test_multicast_start_failure_cleans_dispatcher_and_state --timeout=60
+
+  # Tier: runtime trust aggregate gate
+  required_suite_with_coverage:
+    name: Release trust gate — required suite with coverage
+    needs: [api_symbol_stability, ruff_checks, mypy_supported_bounds, integration_tests_supported_bounds, integration_smoke_tests_intermediate_versions, integration_semantic_tests_intermediate_versions, required_behavior_tests, behavior_critical_tests, reliability_smoke_tests, multicast_contract_required]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run required test suite with coverage
+        run: pytest -q -m "not multicast and not slow" --cov=aionetx --cov-report=term-missing --cov-fail-under=85 --timeout=60
+
+  # Tier: reproducible build verification (release runs only)
+  verify_reproducible_build:
+    name: Release trust gate — wheel reproducibility
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+      - name: Capture deterministic build timestamp
+        id: build_epoch
+        shell: bash
+        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+      - name: First wheel build
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: python -m build --wheel --outdir dist1/
+      - name: Second wheel build (independent repeat)
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: python -m build --wheel --outdir dist2/
+      - name: Compare wheel SHA-256 hashes (byte-identical check)
+        run: |
+          python - <<'EOF'
+          import hashlib, pathlib, sys
+          def sha256(p):
+              return hashlib.sha256(p.read_bytes()).hexdigest()
+          w1 = sorted(pathlib.Path("dist1").glob("*.whl"))
+          w2 = sorted(pathlib.Path("dist2").glob("*.whl"))
+          if not w1 or not w2:
+              print("ERROR: no wheel files found in dist1/ or dist2/", file=sys.stderr)
+              sys.exit(1)
+          if len(w1) != len(w2):
+              print(f"ERROR: wheel count mismatch: {len(w1)} vs {len(w2)}", file=sys.stderr)
+              sys.exit(1)
+          ok = True
+          for a, b in zip(w1, w2):
+              ha, hb = sha256(a), sha256(b)
+              if ha == hb:
+                  print(f"OK  {a.name}  {ha}")
+              else:
+                  print(f"FAIL {a.name}: {ha} != {hb}", file=sys.stderr)
+                  ok = False
+          sys.exit(0 if ok else 1)
+          EOF
+
+  release_profile_gate:
+    name: Release trust gate profile passed
+    needs: [required_suite_with_coverage, cross_platform_portability_smoke, verify_reproducible_build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Confirm release profile gate completion
+        run: |
+          echo "Release profile trust gate completed."
+          echo "- release workflow contains required trust gates only"
+          echo "- CI-only non-blocking secondary lanes remain outside release trust gates by design"
+
+  release_codeql_gate:
+    name: Release trust gate — CodeQL alerts
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Capture deterministic build timestamp
+        id: build_epoch
+        shell: bash
+        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+      - name: Skip CodeQL release gate for non-tag runs
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "Skipping CodeQL release gate because this run is not publishing a tagged release ref."
+      - name: Fail on open high/critical CodeQL alerts for release ref
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.ref }}
+        run: python scripts/ci/check_release_codeql_gate.py
+
+  verify_and_build:
+    name: Verify and build release artifacts
+    needs: [release_profile_gate, release_codeql_gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Capture deterministic build timestamp
+        id: build_epoch
+        shell: bash
+        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+          python -m pip install build twine
+
+      - name: Build artifacts from source
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
+        run: python -m build
+
+      - name: Validate artifact metadata
+        run: python -m twine check dist/*
+
+      - name: Install wheel and run installed-artifact smoke + semantic mini-suite
+        run: |
+          python scripts/ci/install_single_artifact.py "dist/*.whl" --force-reinstall --no-deps
+          # Keep release installed-artifact verification at CI parity.
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+      - name: Install sdist and run installed-artifact smoke + semantic mini-suite
+        run: |
+          python -m pip uninstall -y aionetx
+          python scripts/ci/install_single_artifact.py "dist/*.tar.gz" --no-deps
+          python -c "from importlib import resources; typed_marker = resources.files('aionetx').joinpath('py.typed'); assert typed_marker.is_file(), 'py.typed not found in installed aionetx package'"
+          python scripts/ci/installed_artifact_smoke.py
+          python scripts/ci/installed_artifact_semantic_minisuite.py
+          python -m pip check
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dist
+          path: dist/*
+          if-no-files-found: error
+
+  # Tier: supply-chain trust (SBOM + SLSA provenance — tag-triggered only)
+  generate_sbom:
+    name: Generate SBOM (SPDX JSON)
+    needs: verify_and_build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          path: dist
+          format: spdx-json
+          output-file: aionetx-sbom.spdx.json
+          artifact-name: aionetx-sbom.spdx.json
+
+  attest_provenance:
+    name: Attest SLSA provenance
+    needs: verify_and_build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write      # required for OIDC token to sign provenance
+      attestations: write  # required to write attestation records
+      contents: read
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Attest build provenance (wheel)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*.whl
+
+      - name: Attest build provenance (sdist)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*.tar.gz
+
+  publish:
+    name: Publish package (OIDC trusted publishing)
+    needs: [verify_and_build, attest_provenance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: pypi
+      url: https://pypi.org/project/aionetx/
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Publish to PyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+
+  publish_testpypi:
+    name: Publish package to TestPyPI (OIDC trusted publishing)
+    needs: verify_and_build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi'
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/aionetx/
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Publish to TestPyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  github_release:
+    name: Attach dist to GitHub Release
+    needs: [publish, generate_sbom]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aionetx-sbom.spdx.json
+          path: release-sbom
+
+      - name: Create GitHub release and upload artifacts
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        with:
+          files: |
+            dist/*
+            release-sbom/aionetx-sbom.spdx.json
+          generate_release_notes: true
+
+  github_release_dry_run:
+    name: Create dry-run GitHub Release draft with dist assets
+    needs: verify_and_build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'dry-run'
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Create draft GitHub release with assets (dry run)
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        with:
+          tag_name: dry-run-${{ github.run_id }}
+          target_commitish: ${{ github.sha }}
+          name: Dry Run Release ${{ github.run_id }}
+          body: |
+            Dry-run release created via workflow_dispatch with `publish_target=dry-run`.
+            This release is a draft and should be deleted after verification.
+          files: dist/*
+          draft: true
+          prerelease: true
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   # Tier: packaging/release verification
   cross_platform_portability_smoke:
-    name: Release trust gate — cross-platform portability smoke (${{ matrix.os }})
+    name: Release trust gate - cross-platform portability smoke (${{ matrix.os }})
     needs: [verify_tag_version]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
@@ -123,7 +123,7 @@ jobs:
         run: pytest tests/unit/test_api_symbol_sources.py -k "api_symbol" --tb=short -q
 
   ruff_checks:
-    name: Release trust gate — Ruff
+    name: Release trust gate - Ruff
     needs: [verify_tag_version]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -142,7 +142,7 @@ jobs:
         run: ruff format --check .
 
   mypy_supported_bounds:
-    name: Release trust gate — Mypy (${{ matrix.python-version }})
+    name: Release trust gate - Mypy (${{ matrix.python-version }})
     needs: [verify_tag_version]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -163,7 +163,7 @@ jobs:
 
   # Tier: runtime-semantic trust gates
   required_behavior_tests:
-    name: Release trust gate — required behavior tests (${{ matrix.python-version }})
+    name: Release trust gate - required behavior tests (${{ matrix.python-version }})
     needs: [verify_tag_version]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -204,7 +204,7 @@ jobs:
 
   # Tier: integration confidence
   integration_tests_supported_bounds:
-    name: Release trust gate — integration tests (${{ matrix.python-version }})
+    name: Release trust gate - integration tests (${{ matrix.python-version }})
     needs: [required_behavior_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -224,7 +224,7 @@ jobs:
         run: pytest -q -m "integration and not multicast and not slow" --timeout=60
 
   integration_smoke_tests_intermediate_versions:
-    name: Release trust gate — integration smoke tests (${{ matrix.python-version }})
+    name: Release trust gate - integration smoke tests (${{ matrix.python-version }})
     needs: [required_behavior_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -244,7 +244,7 @@ jobs:
         run: pytest -q -m "integration_smoke and not multicast and not slow" --timeout=60
 
   integration_semantic_tests_intermediate_versions:
-    name: Release trust gate — integration semantic shard (${{ matrix.python-version }})
+    name: Release trust gate - integration semantic shard (${{ matrix.python-version }})
     needs: [required_behavior_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -267,7 +267,7 @@ jobs:
 
   # Tier: focused runtime reliability contracts
   reliability_smoke_tests:
-    name: Release trust gate — reliability smoke tests
+    name: Release trust gate - reliability smoke tests
     needs: [required_behavior_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -284,7 +284,7 @@ jobs:
         run: pytest -q -m "reliability_smoke" --timeout=60
 
   multicast_contract_required:
-    name: Release trust gate — deterministic multicast contract
+    name: Release trust gate - deterministic multicast contract
     needs: [required_behavior_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -302,7 +302,7 @@ jobs:
 
   # Tier: runtime trust aggregate gate
   required_suite_with_coverage:
-    name: Release trust gate — required suite with coverage
+    name: Release trust gate - required suite with coverage
     needs: [api_symbol_stability, ruff_checks, mypy_supported_bounds, integration_tests_supported_bounds, integration_smoke_tests_intermediate_versions, integration_semantic_tests_intermediate_versions, required_behavior_tests, behavior_critical_tests, reliability_smoke_tests, multicast_contract_required]
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -320,7 +320,7 @@ jobs:
 
   # Tier: reproducible build verification (release runs only)
   verify_reproducible_build:
-    name: Release trust gate — wheel reproducibility
+    name: Release trust gate - wheel reproducibility
     needs: [verify_tag_version]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -381,7 +381,7 @@ jobs:
           echo "- CI-only non-blocking secondary lanes remain outside release trust gates by design"
 
   release_codeql_gate:
-    name: Release trust gate — CodeQL alerts
+    name: Release trust gate - CodeQL alerts
     needs: [verify_tag_version]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -465,7 +465,7 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  # Tier: supply-chain trust (SBOM + SLSA provenance — tag-triggered only)
+  # Tier: supply-chain trust (SBOM + SLSA provenance - tag-triggered only)
   generate_sbom:
     name: Generate SBOM (SPDX JSON)
     needs: verify_and_build

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly run, independent of push activity.
+    - cron: "0 6 * * 1"
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: OpenSSF Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Non-blocking for the CI trust envelope; findings surface in the
+    # Security tab and in the public Scorecard viewer.
+    continue-on-error: true
+
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,13 @@
+# Attributions
+
+`aionetx` is released under the MIT License. See [LICENSE](LICENSE).
+
+Runtime dependency surface:
+
+- None. The published library has zero runtime dependencies.
+
+Development and release tooling:
+
+- Python packaging, test, typing, linting, and CI tools are used during
+  development and release automation and remain licensed by their respective
+  upstream projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable user-visible changes to `aionetx` are documented in this file.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-24
+
+Initial public alpha release.
+
+### Added
+
+- asyncio-first TCP client and server transport primitives
+- UDP sender, UDP receiver, and IPv4 multicast receiver primitives
+- explicit lifecycle events, event delivery settings, and backpressure policies
+- optional TCP client reconnect and heartbeat support
+- tests, examples, typing metadata, and CI/release verification gates

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,218 @@
+# Contributing to aionetx
+
+Thanks for contributing.
+
+## Start here
+
+1. read `README.md` for usage and scope
+2. read `docs/architecture.md` for canonical semantics and invariants
+3. keep changes minimal, explicit, and reviewable
+
+By participating in this project you agree to abide by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Project-specific expectations
+
+These rules are critical and must be preserved:
+
+- preserve lifecycle and event-ordering semantics
+- keep the transport boundary strict:
+  - no protocol parsing, framing, or business logic in transport code
+- add or update tests when behavior changes
+- update documentation when user-visible behavior or guarantees change
+
+## Development workflow
+
+### Branching strategy
+
+- `main` should remain integration-ready and green
+- no direct commits to `main`
+- keep each pull request focused on one concern
+- avoid mixing refactors and behavior changes unless the coupling is real and
+  unavoidable
+
+### Branch naming
+
+Use the following pattern:
+
+```text
+<type>/<short-description>
+```
+
+Examples:
+
+```text
+feat/tcp-reconnect-backoff
+fix/duplicate-close-event
+refactor/event-dispatch
+docs/readme-installation
+test/reconnect-behavior
+chore/repo-bootstrap
+```
+
+### Working process
+
+1. create a branch from `main`
+2. implement your change
+3. write clean commits
+4. ensure tests pass
+5. open a pull request
+
+## Commit message policy
+
+This project uses Conventional Commits.
+
+### Format
+
+```text
+<type>(<scope>): <summary>
+
+[optional body]
+
+[optional footer]
+```
+
+### Header rules
+
+- use imperative mood, for example `add`, not `added`
+- do not end the header with a period
+- maximum 72 characters
+- keep it concise and descriptive
+- scope is recommended but optional
+
+Examples:
+
+```text
+feat(factory): add multicast receiver creation helper
+fix(tcp): prevent duplicate connection closed event
+refactor(events): split dispatch and validation logic
+docs(readme): clarify lifecycle model
+```
+
+### Allowed types
+
+```text
+feat      new functionality
+fix       bug fix
+refactor  internal restructuring without behavior change
+docs      documentation changes
+test      tests
+build     build system or dependencies
+ci        CI/CD changes
+perf      performance improvements
+chore     maintenance tasks
+revert    revert previous commit
+```
+
+### Commit body guidelines
+
+The commit body should explain context, not repeat the diff.
+
+It should answer:
+
+- why was this change necessary?
+- what was changed conceptually?
+
+Recommended structure:
+
+```text
+Why:
+- describe the problem or motivation
+
+What:
+- describe the key changes
+- mention important design decisions
+```
+
+### When a body is required
+
+A commit body is required for:
+
+- `feat`
+- `fix`
+- `refactor`
+- any change affecting behavior, API, lifecycle, or semantics
+
+A commit body is optional for:
+
+- `docs`
+- small `test` changes
+- trivial `chore` or `ci` updates
+
+### Line length
+
+- header: max 72 characters
+- body: wrap at 72 characters per line
+
+### Footer
+
+Use footers for metadata when relevant:
+
+```text
+BREAKING CHANGE: description
+Refs: #123
+Closes: #123
+```
+
+## Pull requests
+
+### General rules
+
+- pull requests must be focused on a single concern
+- avoid mixing refactoring and behavior changes
+- prefer small to medium-sized pull requests
+- ensure the change is reviewable
+
+### PR title
+
+PR titles should follow Conventional Commits:
+
+```text
+<type>(<scope>): <summary>
+```
+
+### PR expectations
+
+Before opening a PR:
+
+- tests pass
+- documentation is updated if needed
+- changes are cleanly structured
+
+A good PR should clearly explain:
+
+- what was changed
+- why it was changed
+- any important side effects or constraints
+
+## Testing
+
+- add tests for new behavior
+- add regression tests for bug fixes
+- ensure the relevant test slice passes before opening a pull request
+- run `ruff check .` and `mypy src` for changes that affect source code or API
+
+## Documentation
+
+Documentation must be updated when:
+
+- behavior changes
+- APIs change
+- guarantees or invariants change
+
+## Versioning
+
+This project follows Semantic Versioning:
+
+- `fix` -> patch
+- `feat` -> minor
+- breaking changes -> major
+
+## Final notes
+
+- prefer clarity over cleverness
+- prefer explicit design over implicit behavior
+- prefer behaviorally strong tests over incidental implementation checks
+
+Consistency in history and structure is critical for long-term
+maintainability.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 MarBoKor
+Copyright (c) 2026 Marcus Korinth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,889 @@
 # aionetx
+
+[![CI](https://img.shields.io/github/actions/workflow/status/MarcusKorinth/aionetx/ci.yml?branch=main&label=ci)](https://github.com/MarcusKorinth/aionetx/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/MarcusKorinth/aionetx/blob/main/pyproject.toml)
+[![Coverage gate](https://img.shields.io/badge/coverage%20gate-%E2%89%A585%25-brightgreen)](https://github.com/MarcusKorinth/aionetx/blob/main/.github/workflows/ci.yml)
+[![Typing](https://img.shields.io/badge/typing-py.typed-blueviolet)](https://github.com/MarcusKorinth/aionetx/blob/main/src/aionetx/py.typed)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/MarcusKorinth/aionetx/badge)](https://securityscorecards.dev/viewer/?uri=github.com/MarcusKorinth/aionetx)
+
+`aionetx` is an asyncio-first transport library for reusable TCP and UDP communication primitives.
+
+It provides explicit lifecycle management and structured event delivery for networking code that would otherwise require manual coordination with raw `asyncio` (startup/shutdown, reconnect handling, and event routing).
+
+Protocol framing, parsing, and business logic remain in your application.
+
+> **Design principle:** hide the plumbing, not the semantics. Startup, shutdown, reconnect, and event delivery are handled for you; connection lifecycle, error visibility, and byte boundaries are not.
+
+---
+
+## Development status
+
+`aionetx` is a **pre-1.0 transport library**. Its public API may still evolve when changes materially improve long-term transport, lifecycle, or observability quality.
+
+- the project is usable for real integration work, but API/runtime details may still change when they improve the long-term transport boundary
+- it is not advertised as production-ready; production adoption should pin a version, test the exact transport paths used, and treat `0.x` releases as pre-stable
+- semantic contracts (lifecycle clarity, event ordering, explicit failure behavior) are treated as the design center
+- changes in `0.x` should be deliberate, documented, and justified by a clearer long-term transport boundary
+
+---
+
+## Table of Contents
+
+- [Development status](#development-status)
+- [Why this project exists](#why-this-project-exists)
+- [What this library is for](#what-this-library-is-for)
+- [What this library is not for](#what-this-library-is-not-for)
+- [When to use aionetx](#when-to-use-aionetx)
+- [When not to use aionetx](#when-not-to-use-aionetx)
+- [Positioning and comparison](#positioning-and-comparison)
+- [Quick start (factory-first)](#quick-start-factory-first)
+- [Recommended entry path (start here)](#recommended-entry-path-start-here)
+- [Core concepts](#core-concepts)
+  - [Transport roles and capability matrix](#transport-roles-and-capability-matrix)
+  - [Lifecycle model](#lifecycle-model)
+  - [Unified event integration](#unified-event-integration)
+  - [Event delivery and backpressure](#event-delivery-and-backpressure)
+- [Practical examples](#practical-examples)
+  - [Buffer TCP chunks into fixed-size frames (1359 bytes)](#1-buffer-tcp-chunks-into-fixed-size-frames-1359-bytes)
+  - [Receive bytes with one handler](#2-receive-bytes-with-one-handler)
+  - [Reconnect + heartbeat client](#3-reconnect--heartbeat-client)
+  - [UDP sender/receiver usage](#4-udp-senderreceiver-usage)
+- [Public API overview](#public-api-overview)
+- [Verification posture and portability](#verification-posture-and-portability)
+- [Testing helpers (`aionetx.testing`)](#testing-helpers-aionetxtesting)
+- [FAQ](#faq)
+- [Documentation map](#documentation-map)
+- [Installation and local development](#installation-and-local-development)
+- [Logging and troubleshooting](#logging-and-troubleshooting)
+- [Production checklist](#production-checklist)
+
+---
+
+## Why this project exists
+
+`asyncio` gives excellent low-level networking primitives, but production transport code often repeats the same difficult parts:
+
+- lifecycle orchestration (`start`/`stop`/shutdown paths)
+- reconnect loops and heartbeat scheduling
+- event dispatch plumbing and backpressure behavior
+- consistent error surfacing and observability
+
+`aionetx` packages those recurring concerns into explicit, reusable transport primitives. It reduces repetitive code without hiding behavior that operators and developers must reason about.
+
+---
+
+## What this library is for
+
+Use `aionetx` when you want:
+
+- TCP client and server transport primitives
+- UDP receiver and sender primitives
+- UDP multicast receiver support
+- explicit lifecycle visibility for managed transports
+- event-driven integration through one async callback contract
+- configurable dispatch mode and backpressure policy
+- optional reconnect for TCP clients and optional heartbeat for managed TCP roles
+
+Canonical scope reference: `docs/architecture.md` (**Purpose and boundary**).
+
+---
+
+## What this library is not for
+
+`aionetx` intentionally does **not** implement:
+
+- message framing or protocol boundaries for TCP
+- protocol parsers/state machines (MQTT/Modbus/HTTP/etc.)
+- serialization/deserialization
+- business logic and domain workflows
+
+Those belong in higher layers. For detailed in-scope/out-of-scope and deferred-area criteria, see `docs/architecture.md` (**Purpose and boundary** + **Current limitations and explicit non-goals**).
+
+---
+
+## When to use aionetx
+
+- custom TCP/UDP protocols
+- systems requiring explicit lifecycle control
+- event-driven network processing
+- applications where testability and determinism matter
+
+## When not to use aionetx
+
+- simple scripts where raw asyncio is sufficient
+- HTTP/REST services (use higher-level frameworks)
+- cases where lifecycle and event structure are unnecessary
+
+---
+
+## Positioning and comparison
+
+`aionetx` sits between low-level `asyncio` primitives and higher-level protocol or application frameworks.
+
+### Compared to raw asyncio
+
+`asyncio` provides flexible but low-level building blocks for networking.  
+In real-world systems, this typically leads to repeated implementation of:
+
+- lifecycle coordination (`start` / `stop` / shutdown behavior)
+- reconnect logic and retry loops
+- event routing and handler dispatch
+- backpressure and error propagation
+
+`aionetx` standardizes these concerns into explicit, reusable transport components while keeping behavior visible and controllable.
+
+It does not replace `asyncio`, but structures its usage.
+
+---
+
+### Compared to higher-level frameworks
+
+Higher-level frameworks (e.g. HTTP servers, messaging libraries, protocol-specific stacks) usually provide:
+
+- built-in protocol handling
+- serialization / deserialization
+- domain-level abstractions
+
+`aionetx` intentionally does not operate at that level.
+
+It focuses strictly on transport concerns:
+- connection lifecycle
+- byte-level data flow
+- event delivery
+- reconnect and heartbeat behavior
+
+Protocol handling remains entirely in user code.
+
+---
+
+### When this abstraction is useful
+
+`aionetx` is most useful when:
+
+- you implement custom TCP or UDP protocols
+- you need explicit control over connection lifecycle
+- you want structured event-driven integration
+- you require deterministic and testable transport behavior
+- you want to avoid reimplementing transport plumbing across projects
+
+If your use case is fully covered by an existing high-level framework, using that framework is usually the better choice.
+
+---
+
+## Quick start (factory-first)
+
+The recommended entrypoint is `AsyncioNetworkFactory`. The tiny client below
+assumes a TCP server is already listening on `127.0.0.1:9000`; for a fully
+self-contained roundtrip, use
+[`examples/tcp_echo_server_and_client.py`](examples/tcp_echo_server_and_client.py).
+
+```python
+import asyncio
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    TcpClientSettings,
+)
+
+
+class Handler(BaseNetworkEventHandler):
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        print(f"{event.resource_id} -> {event.data!r}")
+
+
+async def main() -> None:
+    factory = AsyncioNetworkFactory()
+
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(host="127.0.0.1", port=9000),
+        event_handler=Handler(),
+    )
+
+    await client.start()
+    try:
+        conn = await client.wait_until_connected(timeout_seconds=5.0)
+        await conn.send(b"hello")
+    finally:
+        await client.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+`wait_until_connected()` is timeout-aware and unblocks deterministically if the client stops before becoming ready.
+
+---
+
+## Recommended entry path (start here)
+
+If you are new to `aionetx`, start with this small subset of root exports before exploring the full curated API surface.
+
+| Tier | Name | Purpose | When to use |
+| --- | --- | --- | --- |
+| Stable/common | `AsyncioNetworkFactory` | Factory-first entrypoint for constructing transport objects. | Always start here for new integrations. |
+| Stable/common | `TcpClientSettings` | Configuration dataclass for TCP clients. | When creating outbound TCP client transports. |
+| Stable/common | `TcpServerSettings` | Configuration dataclass for TCP servers. | When accepting inbound TCP connections. |
+| Stable/common | `UdpReceiverSettings` | Configuration dataclass for UDP receive endpoints. | When listening for datagrams (unicast UDP). |
+| Stable/common | `UdpSenderSettings` | Configuration dataclass for UDP send endpoints. | When sending datagrams without managed receive lifecycle. |
+| Stable/common | `EventDeliverySettings` | Dispatcher mode, buffering, and handler-failure policy controls. | When tuning ordering/throughput/backpressure behavior. |
+| Stable/common | `TcpReconnectSettings` | Explicit reconnect policy controls for TCP clients. | When client reconnect behavior must be deterministic and observable. |
+| Stable/common | `TcpHeartbeatSettings` | TCP heartbeat scheduling configuration. | When link-liveness probing is needed at the transport layer. |
+| Stable/common | `HeartbeatProviderProtocol` | Heartbeat payload provider contract. | When heartbeat bytes must be generated dynamically. |
+| Stable/common | `MulticastReceiverSettings` | Configuration dataclass for UDP multicast receive endpoints. | When listening to multicast groups. |
+| Stable/common | `BytesReceivedEvent` | Canonical payload event for incoming byte streams. | When implementing TCP receive behavior in handlers. |
+| Stable/common | `NetworkEvent` | Unified event type contract for `on_event`. | When authoring direct event-driven handlers. |
+| Stable/common | `BaseNetworkEventHandler` | Convenience typed hooks (`on_bytes_received`, `on_connection_closed`, etc.). | When avoiding manual `isinstance` dispatch in handlers. |
+| Stable/common | `ComponentLifecycleState` | Canonical lifecycle enum (`STOPPED/STARTING/RUNNING/STOPPING`). | When checking lifecycle state directly in code/tests. |
+
+This guide focuses on the default package-root path. Advanced protocol and policy surfaces remain available from `aionetx.api`.
+
+Compatibility note: import advanced protocol surfaces from `aionetx.api` (for example `TcpClientProtocol`, `TcpServerProtocol`, `UdpReceiverProtocol`, `UdpSenderProtocol`).
+
+The consolidated API-boundary and decision rationale now lives in `docs/architecture.md`.
+
+The API remains intentionally evolvable while the transport boundary is still being finalized, but changes should be rare, explicit, and semantically motivated.
+
+---
+
+## Core concepts
+
+### Transport roles and capability matrix
+
+| Transport | Managed lifecycle events | Connection metadata events | Reconnect | Heartbeat | Sending |
+| --- | --- | --- | --- | --- | --- |
+| TCP client | Yes | Yes | Optional | Optional | Via active connection |
+| TCP server | Yes | Yes (per accepted connection) | N/A | Optional (per connection) | Broadcast + per connection |
+| UDP receiver | Yes | Yes | N/A | N/A | No |
+| UDP multicast receiver | Yes | Yes | N/A | N/A | No |
+| UDP sender | No managed lifecycle stream | No connection metadata stream | N/A | N/A | Yes (`send`) |
+
+`UdpSenderProtocol` is intentionally asymmetric: it is a lightweight datagram sender, not a managed event-emitting transport.
+
+### Lifecycle model
+
+Managed components use four explicit states to make startup, shutdown, and transitions observable and testable:
+
+- `STOPPED`
+- `STARTING`
+- `RUNNING`
+- `STOPPING`
+
+Lifecycle state is observable via `component.lifecycle_state` and `ComponentLifecycleChangedEvent`.
+
+Transition semantics include guarded startup rollback and stop-during-startup behavior. Lifecycle authority is consolidated in `docs/architecture.md`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> STOPPED
+    STOPPED --> STARTING
+    STARTING --> RUNNING
+    STARTING --> STOPPING: stop requested
+    STARTING --> STOPPED: startup rollback
+    RUNNING --> STOPPING
+    STOPPING --> STOPPED
+```
+
+### Unified event integration
+
+The core integration contract is:
+
+```python
+async def on_event(self, event: NetworkEvent) -> None: ...
+```
+
+All events flow through this single method.
+
+`NetworkEvent` is the public typing union for supported event dataclasses.  
+It is a **type-level contract**, not a shared runtime base class.
+
+`NetworkEvent` is an **open union**: new event dataclasses may be added in
+minor releases. Handler code should therefore always keep a catch-all
+fallback (`else:` on an `isinstance` chain, `case _:` on `match`) so a
+future union extension does not silently break your code. Existing event
+field shapes are stable and any addition is called out in `CHANGELOG.md`.
+`BaseNetworkEventHandler` already handles this correctly — its typed
+hooks are optional overrides and unknown event types fall back to a
+default no-op. Removing an event type is a breaking change (reserved for
+major releases, or during pre-1.0 for minor bumps with an explicit
+**Removed** CHANGELOG entry). Do **not** use `typing.assert_never`
+against this union; it assumes a closed taxonomy.
+
+`BaseNetworkEventHandler` provides typed convenience hooks such as `on_bytes_received`, `on_connection_opened`, and `on_connection_closed`. These are internally dispatched from `on_event(...)`.
+
+This means:
+
+- `on_event(...)` is the true public integration contract  
+- typed hook methods are optional convenience layers  
+- both approaches are equivalent in capability  
+- direct API method failures (for example `send(...)` when closed/invalid) are
+  raised as explicit exceptions at the call site; managed background failures
+  are surfaced through events such as `NetworkErrorEvent`
+
+Constructor and factory boundaries validate that the handler contract is async and raise clear `TypeError` for invalid handlers.
+
+---
+
+#### Event flow
+
+```mermaid
+flowchart TD
+    T["Transport emits event dataclass"] --> C["Call handler.on_event(event)"]
+
+    C --> B{"Handler is BaseNetworkEventHandler?"}
+
+    B -- No --> O["Application-defined on_event handles event"]
+
+    B -- Yes --> D["BaseNetworkEventHandler.on_event"]
+    D --> R["Internal dispatch by event type"]
+    R --> H["Typed hook: on_bytes_received / on_connection_opened / ..."]
+    H --> A["Application override logic"]
+```
+
+- All events are first delivered to `on_event(...)`
+- If you implement your own handler, you handle events directly in `on_event(...)`
+- If you subclass `BaseNetworkEventHandler`, it performs an internal dispatch to typed hook methods
+
+---
+
+#### Example using the core contract directly
+
+This form uses the protocol contract only (any object with async `on_event(...)`).
+
+```python
+from aionetx import BytesReceivedEvent, NetworkEvent
+
+
+class Handler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            print("rx", event.resource_id, event.data)
+```
+
+---
+
+#### Example using typed convenience hooks (recommended)
+
+```python
+from aionetx import BaseNetworkEventHandler, BytesReceivedEvent
+
+
+class Handler(BaseNetworkEventHandler):
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        print("rx", event.resource_id, event.data)
+```
+
+---
+
+Common event types:
+
+- `BytesReceivedEvent`
+- `ConnectionOpenedEvent`
+- `ConnectionClosedEvent`
+- `NetworkErrorEvent`
+- `ComponentLifecycleChangedEvent`
+
+Canonical identity field for filtering and routing is always `event.resource_id`.
+For a complete, versioned event surface, treat `NetworkEvent` plus curated
+exports in `aionetx` / `aionetx.api` as authoritative.
+
+### Event delivery and backpressure
+
+Each managed transport settings object includes `event_delivery`.
+
+```python
+from aionetx import (
+    EventDeliverySettings,
+    TcpServerSettings,
+)
+from aionetx.api import EventBackpressurePolicy, EventDispatchMode
+
+settings = TcpServerSettings(
+    host="127.0.0.1",
+    port=9000,
+    max_connections=64,
+    event_delivery=EventDeliverySettings(
+        dispatch_mode=EventDispatchMode.BACKGROUND,
+        backpressure_policy=EventBackpressurePolicy.BLOCK,
+        max_pending_events=1024,
+    ),
+)
+```
+
+Dispatch modes:
+
+- `INLINE`: handler runs in the emitter path
+- `BACKGROUND` (default): events go through an internal dispatcher queue
+
+Backpressure policies in `BACKGROUND` mode:
+
+- `BLOCK` (default)
+- `DROP_OLDEST`
+- `DROP_NEWEST`
+
+Per-connection handler execution remains sequential. Cross-connection concurrency depends on topology and dispatcher sharing.
+In practice: a single shared BACKGROUND dispatcher worker serializes handler execution across that component, while isolated dispatcher paths can execute concurrently.
+
+Handler failure policy is configurable via `EventDeliverySettings.handler_failure_policy`:
+
+- `log_only` (default)
+- `emit_error_event`
+- `stop_component`
+- `raise_in_inline_mode`
+
+Dispatcher phase behavior in `BACKGROUND` mode is explicit:
+
+- before the dispatcher worker starts, emission falls back to inline delivery
+- during steady state, events are delivered by the background worker task
+- after dispatcher stop begins, newly emitted events are intentionally dropped to guarantee deterministic shutdown completion
+
+This shutdown-phase drop behavior is a documented exception to steady-state
+overload policy.
+
+Operational diagnostics for concrete asyncio implementations now make drop causes
+explicit at runtime:
+
+- backpressure drops are tracked separately for `DROP_OLDEST` and `DROP_NEWEST`
+- shutdown-phase drops are tracked separately from overload drops
+- dispatcher runtime stats include enqueue volume, handler dispatch attempts, and queue depth peak/current snapshots
+
+Concrete asyncio TCP components expose this as `dispatcher_runtime_stats`.
+
+Use those diagnostics to distinguish overload tuning problems from intentional
+deterministic-shutdown cutoffs.
+
+For lifecycle/cancellation/shutdown contract details, see `docs/architecture.md` and the runtime/integration tests in `tests/`.
+
+---
+
+## Practical examples
+
+### 1) Buffer TCP chunks into fixed-size frames (1359 bytes)
+
+TCP is stream-oriented. Receive boundaries do not correspond to send boundaries.
+
+If your application protocol uses fixed-size frames, do framing in your handler layer.
+
+```python
+from aionetx.api import BytesReceivedEvent, ConnectionClosedEvent, NetworkEvent
+
+
+FRAME_SIZE = 1359
+
+
+class FixedFrameHandler:
+    def __init__(self) -> None:
+        self._buffers: dict[str, bytearray] = {}
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            buf = self._buffers.setdefault(event.resource_id, bytearray())
+            buf.extend(event.data)
+
+            while len(buf) >= FRAME_SIZE:
+                frame = bytes(buf[:FRAME_SIZE])
+                del buf[:FRAME_SIZE]
+                await self.process_frame(event.resource_id, frame)
+
+        elif isinstance(event, ConnectionClosedEvent):
+            self._buffers.pop(event.resource_id, None)
+
+    async def process_frame(self, resource_id: str, frame: bytes) -> None:
+        assert len(frame) == FRAME_SIZE
+        print(resource_id, "frame", len(frame))
+```
+
+This example intentionally uses the core `on_event(...)` contract because it coordinates two event types (`BytesReceivedEvent` and `ConnectionClosedEvent`) in one buffer state machine. The same framing boundary still applies when using typed hooks via `BaseNetworkEventHandler`.
+
+For a longer runnable framing example, see [examples/tcp_framing_length_prefix.py](examples/tcp_framing_length_prefix.py).
+
+### 2) Receive bytes with one handler
+
+This example uses only the core contract (`on_event`). The typed `on_bytes_received(...)` hook shown earlier is a convenience form of the same integration model.
+
+```python
+from aionetx import BytesReceivedEvent, NetworkEvent
+
+
+class Handler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            payload: bytes = event.data
+            print("rx", event.resource_id, payload)
+```
+
+### 3) Reconnect + heartbeat client
+
+```python
+import asyncio
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    TcpHeartbeatSettings,
+    TcpReconnectSettings,
+    TcpClientSettings,
+)
+from aionetx.api import (
+    ConnectionClosedEvent,
+    HeartbeatProviderProtocol,
+    HeartbeatRequest,
+    HeartbeatResult,
+    NetworkEvent,
+)
+
+
+class Handler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, ConnectionClosedEvent):
+            print("closed", event.resource_id)
+        else:
+            print(type(event).__name__)
+
+
+class Provider(HeartbeatProviderProtocol):
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(
+            should_send=True,
+            payload=f"HB:{request.connection_id}".encode(),
+        )
+
+
+async def main() -> None:
+    client = AsyncioNetworkFactory().create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=9000,
+            reconnect=TcpReconnectSettings(enabled=True, initial_delay_seconds=0.2),
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+        ),
+        event_handler=Handler(),
+        heartbeat_provider=Provider(),
+    )
+
+    await client.start()
+    try:
+        conn = await client.wait_until_connected(timeout_seconds=5.0)
+        await conn.send(b"hello")
+        await asyncio.sleep(0.2)
+    finally:
+        await client.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The runnable version of this example also exists at [examples/tcp_reconnect_with_heartbeat.py](examples/tcp_reconnect_with_heartbeat.py).
+
+### 4) UDP sender/receiver usage
+
+```python
+import asyncio
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+
+
+class Handler(BaseNetworkEventHandler):
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        print("udp datagram", event.data, event.remote_host, event.remote_port)
+
+
+async def main() -> None:
+    factory = AsyncioNetworkFactory()
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=20010),
+        event_handler=Handler(),
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=20010),
+    )
+
+    await receiver.start()
+    try:
+        await sender.send(b"hello over udp")
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+## Public API overview
+
+The public API is intentionally small and structured around a few core entry points and configuration objects.
+
+Primary root exports include:
+
+- `AsyncioNetworkFactory`
+- settings dataclasses: `TcpClientSettings`, `TcpServerSettings`, `UdpReceiverSettings`, `UdpSenderSettings`, `MulticastReceiverSettings`
+- `TcpReconnectSettings`, `TcpHeartbeatSettings`, `HeartbeatProviderProtocol`
+- `EventDeliverySettings`
+- `BytesReceivedEvent`, `NetworkEvent`
+- `BaseNetworkEventHandler`, `ComponentLifecycleState`
+
+Advanced protocol typing surfaces (for example `TcpClientProtocol`,
+`TcpServerProtocol`, `UdpReceiverProtocol`, `UdpSenderProtocol`) are curated
+under `aionetx.api`.
+
+Import-path note: protocol and policy-specific symbols should be imported from
+`aionetx.api` (for example `ConnectionClosedEvent`, `EventDispatchMode`,
+`EventBackpressurePolicy`).
+
+### Export tier interpretation (documentation only)
+
+Across curated exports in `aionetx` and `aionetx.api`, this documentation uses two guidance tiers:
+
+- **Stable/common**: preferred entrypoints for most users and codebases (factory-first setup, core settings, and standard event handling).
+- **Stable/advanced**: curated but expert-facing symbols used for explicit protocol typing and lower-level transport control.
+
+These labels are not separate versioning schemes. They are usage guidance only.
+
+For the canonical boundary and decision set, see `docs/architecture.md`.
+
+| Tier | Typical examples | Guidance |
+| --- | --- | --- |
+| Stable/common | Package-root defaults such as `AsyncioNetworkFactory`, transport settings dataclasses, and `BytesReceivedEvent` | Preferred long-lived integration path for most applications. |
+| Stable/advanced | `aionetx.api` explicit protocol contracts and optional policy/configuration types | Use when you need explicit contracts and lower-level control. |
+
+### API boundary policy
+
+- Curated exports from `aionetx` and `aionetx.api` (`PUBLIC_API`) define the public API boundary.
+- `aionetx.api._*` and `aionetx.implementations.*` remain internal/unstable.
+- `aionetx.testing` is intentionally a test-helper namespace outside root curated exports.
+
+Canonical API boundary details now live in `docs/architecture.md`.
+
+Recommended usage hierarchy:
+
+1. import from `aionetx` for normal integration
+2. import from `aionetx.api` for explicit contract and type surfaces
+3. avoid reliance on `aionetx.implementations.*` in user-facing integrations
+
+### Compatibility policy
+
+`aionetx` is pre-1.0 (`0.x`).
+
+- No backward-compatibility guarantee is provided before `1.0`.
+- Factory-first package-root onboarding remains the preferred day-to-day integration path.
+- Compatibility-impacting changes should be called out clearly in `CHANGELOG.md`, and sustained upgrade-path guidance belongs in `docs/breaking_changes/` when needed.
+
+Compatibility details are documented directly in `docs/architecture.md`, `README.md`, and `CHANGELOG.md`.
+
+---
+
+## Verification posture and portability
+
+Transport support in this README means API and runtime support. It does **not** imply identical CI evidence tiers.
+
+At a glance:
+
+- Required runtime trust gates focus on deterministic transport semantics and packaging/release confidence.
+- Environment-sensitive lanes (for example multicast integration in some environments) are intentionally non-blocking and must be read as lower-confidence evidence.
+- Non-blocking CI lanes are secondary signals, not runtime-semantic proof.
+- Current datagram and multicast transport scope is IPv4-only. Full IPv6 transport support is out of scope for the current release line.
+- Multicast uses `SO_REUSEADDR` for practical cross-platform binding, but Windows socket reuse semantics differ from Unix-like systems. Treat multicast co-binding behavior on Windows as environment-sensitive and verify it in your deployment target.
+
+Verification interpretation summary is provided here; architecture-level rationale is in `docs/architecture.md`.
+
+### Platform support and timing
+
+aionetx runs on Linux, macOS, and Windows. Some runtime behavior differs per platform, and timing guarantees are explicitly best-effort. Before deploying to latency-sensitive or regulated contexts, review:
+
+- [`docs/platform_notes.md`](docs/platform_notes.md) - socket bind reuse/exclusivity semantics, multicast binding notes, and the UDP `sock_sendto()` / `sock_recvfrom()` fallback on Windows `ProactorEventLoop` (per-operation wake latency up to ~20 ms)
+- [`docs/timing_and_latency.md`](docs/timing_and_latency.md) - what aionetx does and does not guarantee about reconnect, heartbeat, and datagram timing; suitability and non-suitability guidance for regulated, safety-adjacent, and latency-sensitive contexts
+- [`docs/logging.md`](docs/logging.md) - logger hierarchy, structured context keys, warnings to alert on, and a minimal `dictConfig` snippet
+
+### How to read CI at a glance
+
+- Treat the **required/profile gates** as the primary signal: they cover runtime-semantic behavior, integration confidence, and packaging/release verification.
+- A green required/profile envelope means the most important transport and release checks passed on the defined matrix.
+- **Non-blocking lanes** (environment-sensitive checks) are still useful, but they are secondary signals by design.
+- CI green is a meaningful trust indicator for the repository’s stated scope; it is not a universal guarantee for every environment or workload shape.
+
+---
+
+## Testing helpers (`aionetx.testing`)
+
+The package includes helpers for transport-focused async tests:
+
+- `RecordingEventHandler`
+- `AwaitableRecordingEventHandler`
+- `wait_for_condition`
+
+```python
+import socket
+
+import pytest
+
+from aionetx import AsyncioNetworkFactory, UdpReceiverSettings, UdpSenderSettings
+from aionetx.testing import RecordingEventHandler, wait_for_condition
+
+
+def unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_captures_datagram() -> None:
+    port = unused_udp_port()
+    factory = AsyncioNetworkFactory()
+    handler = RecordingEventHandler()
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=handler,
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    await receiver.start()
+    try:
+        await sender.send(b"ping")
+        await wait_for_condition(
+            lambda: bool(handler.received_events),
+            timeout_seconds=2.0,
+        )
+        assert handler.received_events[0].data == b"ping"
+    finally:
+        await sender.stop()
+        await receiver.stop()
+```
+
+---
+
+## FAQ
+
+<details>
+<summary><strong>Why doesn’t aionetx implement framing or parsing for me?</strong></summary>
+
+Because framing and protocol parsing are application and protocol concerns, not transport concerns. Keeping that boundary strict makes transport behavior reusable across very different protocols and prevents hidden protocol assumptions in the transport layer.
+
+</details>
+
+<details>
+<summary><strong>Why is UDP sender intentionally asymmetric?</strong></summary>
+
+UDP sender is a minimal datagram send primitive (`send(...)` + idempotent `stop()`). It intentionally does not expose managed lifecycle streams or connection metadata events, because one-shot UDP sends do not have TCP-like connection lifecycle semantics.
+
+</details>
+
+<details>
+<summary><strong>Why one unified event callback instead of many required methods?</strong></summary>
+
+One callback (`on_event`) keeps the integration contract stable and small across transports. If you want typed hooks, `BaseNetworkEventHandler` provides them while preserving the same underlying contract.
+
+</details>
+
+<details>
+<summary><strong>What do lifecycle guarantees mean—and not mean?</strong></summary>
+
+Lifecycle states and transitions are explicit, observable, and monotonic for managed components. They do not imply protocol-level correctness, message completeness, or business-level delivery guarantees.
+
+</details>
+
+<details>
+<summary><strong>When should I choose INLINE vs BACKGROUND event delivery?</strong></summary>
+
+- Use `INLINE` for local debugging or prototyping where direct call-path behavior is useful
+- Use `BACKGROUND + BLOCK` as a reliability-first production default
+- Use bounded-loss policies (`DROP_OLDEST` or `DROP_NEWEST`) only when dropping under burst pressure is acceptable by design
+
+</details>
+
+<details>
+<summary><strong>Should I choose aionetx or direct asyncio transports?</strong></summary>
+
+Choose direct `asyncio` if you need very custom low-level control and are comfortable owning lifecycle, event, and reconnect plumbing yourself. Choose `aionetx` when you want those concerns standardized with explicit semantics and reusable APIs.
+
+</details>
+
+---
+
+## Documentation map
+
+- `README.md`: public overview, core semantics, event flow, and practical usage examples
+- `docs/architecture.md`: canonical architecture, constraints, consolidated decisions (formerly ADR knowledge), and current limitations
+- `docs/platform_notes.md`: platform-specific runtime behavior (socket bind reuse/exclusivity, UDP fallback polling on Windows)
+- `docs/timing_and_latency.md`: timing envelope, what aionetx guarantees and does not, suitability statement
+- `docs/logging.md`: logger hierarchy, structured context, recommended levels, and a minimal `dictConfig`
+- `docs/breaking_changes/README.md`: compatibility-note format and expectations for supported upgrade-path changes
+- `CHANGELOG.md`: user-visible changes per release, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+- `SECURITY.md`: supported versions, private vulnerability reporting channels, and security-scope boundaries
+- `SUPPORT.md`: how to get help, report issues, and ask questions
+- `CONTRIBUTING.md`: concise contribution workflow
+- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1, community standards, and enforcement contact
+
+---
+
+## Installation and local development
+
+Install the released package:
+
+```bash
+pip install aionetx
+```
+
+Install from a local checkout:
+
+```bash
+pip install .
+```
+
+Editable development install:
+
+```bash
+pip install -e .[dev]
+```
+
+### IDE note for `src/` layout projects
+
+If your IDE reports `unresolved reference aionetx` from a plain checkout:
+
+1. mark `src` as a sources root
+2. ensure the project interpreter is active
+3. prefer editable install for local development
+
+---
+
+## Logging and troubleshooting
+
+`aionetx` uses standard Python logging (`aionetx.*`).
+
+Enable debug logs during bring-up and troubleshooting:
+
+```python
+import logging
+
+logging.getLogger("aionetx").setLevel(logging.DEBUG)
+```
+
+TCP reminder: `send()` boundaries are not receive boundaries. Always implement explicit framing in your protocol layer.
+
+For the full logger hierarchy, structured context keys, recommended levels, and a ready-to-use `dictConfig`, see [`docs/logging.md`](docs/logging.md).
+
+---
+
+## Production checklist
+
+- choose `EventDeliverySettings` intentionally (`BACKGROUND + BLOCK` is a solid default)
+- keep handler code non-blocking; offload slow work
+- implement explicit TCP framing (length-prefix, delimiter, or fixed-size)
+- set reconnect and heartbeat parameters deliberately for your environment
+- enable debug logs during integration, then lower verbosity in steady state
+- add app-level integration tests for framing, reconnect, and shutdown behavior
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Policy
+
+`aionetx` is a raw-byte asyncio transport library. The sections below
+describe which versions receive security fixes, how to report a
+suspected vulnerability privately, and which classes of report fall
+outside the project's security scope by design.
+
+## Supported Versions
+
+Until `aionetx` reaches `1.0.0`, only the **latest published `0.y.x`
+release** receives security fixes. Earlier pre-release versions are
+not supported; upgrade to the current release.
+
+After `1.0.0`, security fixes will be backported to the latest minor
+line and the previous minor line (`N` and `N-1`). Older lines will be
+announced as end-of-life in `CHANGELOG.md` when they stop receiving
+fixes.
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub issues for suspected
+vulnerabilities.** Open the
+[Security tab of the repository](https://github.com/MarcusKorinth/aionetx/security)
+and click **"Report a vulnerability"** so a fix can be prepared before
+the details become public. This creates a private advisory draft that
+is visible only to the maintainers and the reporter until it is
+published.
+
+When reporting, please include:
+
+- A description of the issue and the impact you believe it has.
+- The affected `aionetx` version(s) and the Python version.
+- A minimal reproduction (code snippet, pcap, or step-by-step) if
+  possible.
+- Any suggested mitigations you are aware of.
+
+## Response Expectations
+
+This project is maintained by a single developer on a best-effort
+basis. Realistic commitments:
+
+- **Acknowledgement:** within 7 calendar days of the report.
+- **Triage and initial assessment:** within 14 calendar days.
+- **Fix timeline:** depends on severity and complexity; high-severity
+  issues are prioritised over other work.
+- **Coordinated disclosure window:** typically up to 90 days from the
+  report, extendable by mutual agreement if a fix requires deeper
+  rework. Credit is given to the reporter in the advisory unless the
+  reporter asks to stay anonymous.
+
+## Out of Scope
+
+The following are **not** treated as security vulnerabilities because
+they reflect deliberate architectural choices of a raw-byte transport
+library, not defects:
+
+- **No authentication, authorization, or transport-layer encryption.**
+  `aionetx` exposes raw TCP/UDP/multicast byte streams. Peer identity,
+  integrity, and confidentiality are the responsibility of the
+  application layer built on top (for example, TLS via
+  `asyncio.start_tls`, DTLS, or application-level signing). Reports of
+  the form "an attacker can send bytes to an open port" will be
+  closed as out of scope.
+- **Denial of service from malformed or flooding peer traffic on
+  untrusted transports.** Backpressure, rate limiting, and peer-trust
+  decisions are delegated to the user's event handler and higher-layer
+  protocol logic. `aionetx`'s backpressure primitives (`BLOCK`,
+  `DROP_OLDEST`, `DROP_NEWEST`) are explicitly user-selectable
+  policies, not a promise of DoS immunity.
+- **Port reuse, interface binding, or privileged-port behavior** on
+  platforms where those are OS-level policies. `aionetx` exposes the
+  OS socket semantics faithfully; misconfiguration at deployment time
+  is a deployment concern.
+- **Behavior of third-party dependencies.** `aionetx` has zero runtime
+  dependencies outside the Python standard library; if you observe a
+  vulnerability in `cpython`'s asyncio or socket stack, please report
+  it to the Python Security Response Team instead.
+
+In-scope examples (report these privately):
+
+- Memory-safety or reference-cycle bugs that cause runaway resource
+  consumption under normal asyncio usage.
+- Logic errors in lifecycle or cleanup that leak sockets, file
+  descriptors, or asyncio tasks in ways the user cannot recover from.
+- Any path where `aionetx` itself (not the user's handler) crashes the
+  event loop or the Python process under well-formed peer input.
+
+## Coordinated Disclosure
+
+Once a fix is available and released, the maintainers will publish a
+GitHub Security Advisory referencing the affected versions, the CVE
+(if one is assigned), the fixed version, and credits. Reporters are
+welcome to publish their own write-up once the advisory is public.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,49 @@
+# Getting Support
+
+Thanks for using aionetx. This document describes where to direct each type
+of request so you reach the right channel quickly.
+
+## Bugs
+
+Open a GitHub issue:
+<https://github.com/MarcusKorinth/aionetx/issues>
+
+Please include:
+
+- aionetx version (`pip show aionetx`)
+- Python version and OS
+- the event-loop policy if non-default (for example `WindowsSelectorEventLoopPolicy`)
+- a minimal reproducer, expected behavior, and actual behavior
+- relevant log output at `DEBUG` level for the `aionetx` logger (see
+  [`docs/logging.md`](docs/logging.md))
+
+## Security vulnerabilities
+
+**Do not** open a public issue for security reports. Follow the private
+reporting channel in [`SECURITY.md`](SECURITY.md).
+
+## Questions and usage help
+
+Start a thread in GitHub Discussions Q&A:
+<https://github.com/MarcusKorinth/aionetx/discussions/categories/q-a>
+
+Before asking, please check:
+
+- [`README.md`](README.md) - core semantics and examples
+- [`docs/architecture.md`](docs/architecture.md) - lifecycle and event model
+- [`docs/platform_notes.md`](docs/platform_notes.md) - platform-specific
+  behavior, especially if you are on Windows
+- [`docs/timing_and_latency.md`](docs/timing_and_latency.md) - what aionetx
+  does and does not guarantee about timing
+- [`examples/`](examples/) - runnable end-to-end scripts
+
+## Feature requests and design discussions
+
+Use GitHub Discussions for early design conversations and usage-shape
+questions. Open a GitHub issue once you have a concrete bug report or a
+specific behavior change in mind.
+
+## Commercial support
+
+There is no commercial support offering at this time. aionetx is maintained
+on a best-effort basis under the MIT license.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,307 @@
+﻿# Architecture
+
+This document is the canonical architectural contract for `aionetx`.
+
+It replaces scattered ADR history with one current-state record of decisions, boundaries, and limitations.
+
+## 1) Purpose and boundary
+
+`aionetx` is an asyncio-first transport library for reusable TCP/UDP primitives with explicit lifecycle semantics and event-driven integration.
+
+Core principle: **hide plumbing, not semantics**.
+
+### In scope
+
+- TCP client/server transports
+- UDP receiver/sender transports
+- UDP multicast receiver transport
+- managed lifecycle publication
+- event delivery and bounded backpressure policies
+- explicit reconnect behavior
+- explicit heartbeat scheduling behavior
+- transport-level failure surfacing and canonical identifiers
+
+### Out of scope
+
+- protocol framing/parsing
+- serialization/deserialization
+- message schemas
+- business/domain logic
+- application-level retry orchestration
+- hidden recovery/implicit lifecycle transitions
+
+## 2) Lifecycle contract (authoritative)
+
+Managed components expose exactly four public lifecycle states:
+
+- `STOPPED`
+- `STARTING`
+- `RUNNING`
+- `STOPPING`
+
+No public `FAILED` lifecycle state exists.
+
+### Legal transitions
+
+- `STOPPED -> STARTING`
+- `STARTING -> RUNNING`
+- `STARTING -> STOPPING`
+- `STARTING -> STOPPED` (startup rollback)
+- `RUNNING -> STOPPING`
+- `STOPPING -> STOPPED`
+
+State transitions must remain monotonic and understandable. Concurrent lifecycle calls must converge without illegal transitions.
+
+Failures are surfaced through events (network/reconnect/close/error), not via a separate lifecycle enum.
+
+### Lifecycle invariants
+
+The following invariants are part of the public contract and are relied on by
+the semantic test suite:
+
+- Once `stop()` returns with state `STOPPED`, no further user callback is
+  invoked from the component's internal tasks.
+- `STOPPING` is a terminal-in-progress state, not a re-entrant steady state:
+  repeated stop requests converge on the same shutdown path instead of creating
+  new transition branches.
+- Lifecycle publication remains monotonic: managed components do not publish
+  illegal backward transitions.
+- Terminal lifecycle publication happens at most once per shutdown sequence.
+
+## 3) Event model contract
+
+Primary integration contract:
+
+```python
+async def on_event(self, event: NetworkEvent) -> None
+```
+
+`BaseNetworkEventHandler` is a convenience layer over this contract.
+
+### Dispatch guarantees
+
+- Sequential dispatch per connection
+- No concurrent event execution inside one connection stream
+- Deterministic per-connection ordering
+- Cross-connection concurrency is topology/dispatch-mode dependent, not universally guaranteed
+
+### Callback semantics
+
+- `ConnectionOpenedEvent` is published before the first
+  `BytesReceivedEvent` for the same connection.
+- Connection close callbacks run before the corresponding
+  `ConnectionClosedEvent` is emitted.
+- Re-entrant shutdown requests from callbacks/handlers must converge safely on
+  the same close or stop operation.
+- Handler failures remain observable: depending on the configured failure
+  policy they either surface as `NetworkErrorEvent`, as
+  `HandlerFailurePolicyStopEvent`, or as an inline exception in the caller.
+
+### Event Type Evolution
+
+`NetworkEvent` is an **open** `TypeAlias` union: new event dataclasses may
+be added in minor releases as the observability surface grows. Stability
+guarantees are:
+
+- Existing event dataclasses and their field shapes are stable â€” fields
+  are not renamed, retyped, or removed without a deprecation cycle and a
+  CHANGELOG entry when compatibility expectations change.
+- Additions to the union are called out under **Added** in the CHANGELOG.
+- Removing an event type is breaking and reserved for major releases unless a
+  carefully justified compatibility reset is explicitly documented in the
+  changelog and upgrade notes.
+
+Handler code must stay forward-compatible: always keep an `else:` branch
+on `isinstance` chains and a `case _:` arm on `match` statements.
+`typing.assert_never` is intentionally not safe against this union
+because it assumes a closed taxonomy. `BaseNetworkEventHandler` and
+`TypedEventRouter` handle the open union correctly out-of-the-box:
+`BaseNetworkEventHandler` falls back to its default no-op `on_event` for
+unknown types; `TypedEventRouter` returns `False` from `dispatch()` and
+does nothing.
+
+## 4) Event delivery and backpressure
+
+Event delivery is explicit, bounded, and configurable.
+
+- bounded queueing only (no hidden unbounded buffering)
+- explicit backpressure policy selection
+- overload behavior must remain observable
+
+Policies are transport settings concerns, not hidden runtime heuristics.
+
+## 5) Reconnect strategy
+
+Reconnect is explicit and configurable.
+
+- never implicit
+- must remain observable through events
+- must not mask terminal failures
+- policy stays at transport layer; no smart strategy engine
+
+## 6) Heartbeat boundary
+
+Heartbeat is an explicit provider-driven periodic send mechanism for managed TCP roles.
+
+Heartbeat is **not**:
+
+- protocol interpretation
+- health/liveness proof
+- timeout detector
+- implicit reconnect trigger
+
+The library owns scheduling/plumbing; user provider logic owns payload meaning.
+
+## 7) Factory-first construction
+
+Preferred creation path is `AsyncioNetworkFactory`.
+
+Factory responsibilities:
+
+- consistent construction
+- explicit validation
+- stable user-facing setup path
+- explicit conformance to the `aionetx.api.NetworkFactory` contract
+
+Factory must not become implicit orchestration that hides semantics.
+
+## 8) Unified canonical identifier model
+
+Identifiers are part of the observable contract.
+
+Requirements:
+
+- deterministic derivation
+- stable structure
+- human-readable enough for logs/tests/diagnostics
+- consistent model across transport roles
+
+Identifiers support event correlation, lifecycle observability, and semantic testing.
+
+## 9) Testing trust model
+
+Testing is semantic evidence, not only coverage accounting.
+
+Priority areas:
+
+- lifecycle correctness
+- event ordering guarantees
+- cancellation/shutdown safety
+- reconnect behavior
+- backpressure behavior
+
+Coverage is necessary but insufficient without behavioral confidence.
+
+## 10) UDP sender asymmetry (intentional)
+
+`UdpSenderProtocol` remains lifecycle-light by design:
+
+- no managed lifecycle stream
+- no connection metadata stream
+- focused capability: datagram send + idempotent stop
+
+Built-in heartbeat for UDP sender is intentionally out of current scope to avoid turning it into a managed runtime role.
+
+## 11) Compatibility and change policy
+
+Compatibility-breaking redesign is allowed only when it materially improves
+long-term API quality.
+
+That flexibility is not permission for arbitrary churn.
+
+Required discipline:
+
+- clear rationale
+- semantically beneficial outcome
+- explicit migration guidance when user adaptation is required across
+  supported upgrade paths
+- record durable compatibility notes in `docs/breaking_changes/` when user
+  adaptation is required
+
+## 12) Current limitations and explicit non-goals
+
+- No built-in framing/parsing helpers in transport core
+- No protocol adapters/codecs in this repository
+- No hidden recovery automation beyond explicit settings
+- No application-level policy engine (retry/routing/business orchestration)
+
+These are deliberate to preserve transport boundary clarity and predictable behavior.
+
+See [platform notes](./platform_notes.md) for Windows socket option semantics.
+
+## 13) Decision index (consolidated from removed ADR set)
+
+This architecture doc now holds the active knowledge that was previously split across ADR 001-013:
+
+1. per-connection sequential event dispatch
+2. explicit reconnect strategy
+3. bounded/configurable backpressure
+4. four-state lifecycle authority and transition guards
+5. factory-first setup model
+6. strict transport-only boundary
+7. provider-driven heartbeat semantics
+8. single event integration contract
+9. quality-first compatibility and change policy
+10. canonical identifier model
+11. semantic testing trust model
+12. lifecycle authority consolidation over historical variants
+13. preserved UDP sender asymmetry (no built-in heartbeat)
+
+
+## 14) API boundary and import-path guidance
+
+Public boundary expectations:
+
+- `aionetx` package-root curated exports are the default/common onboarding surface.
+- `aionetx.api` curated exports are stable advanced contracts for explicit typing/composition.
+- `aionetx.api._*` and `aionetx.implementations.*` are internal by default.
+
+This preserves a small beginner path while keeping explicit advanced contracts available.
+
+Curation invariant for `aionetx.api`: every type reachable from a public
+signature (method parameter, return type, dataclass field, or exception
+raised by a documented operation) is itself part of `aionetx.api`'s curated
+exports. Reaching into non-underscore submodules by name is a public-API
+gap, not an abstraction. Capability-mixin protocols whose members are
+already exposed through the concrete role-specific protocols
+(`ManagedTransportProtocol`, `ByteSenderProtocol`), the `BytesLike` alias,
+and advanced helper types remain intentionally out of the package-root list.
+
+Settings validation model: public settings dataclasses fail fast at
+construction time via `__post_init__()`. The explicit `.validate()` method
+remains part of the contract as an idempotent re-check helper, but invalid
+settings objects are not expected to circulate in normal use.
+
+## 15) Dispatch/runtime phase clarifications
+
+For `BACKGROUND` dispatch mode, runtime behavior is intentionally phase-aware:
+
+- before dispatcher worker startup: emission may fall back to inline delivery
+- steady-state: dispatcher worker delivers queued events
+- during dispatcher shutdown: newly emitted events may be dropped to guarantee deterministic stop completion
+
+This shutdown-phase drop behavior is a deliberate deterministic-shutdown tradeoff and not a hidden overload policy.
+Runtime diagnostics should make this distinction explicit by separating:
+
+- overload drops (`DROP_OLDEST`/`DROP_NEWEST`)
+- shutdown-phase drops after stop begins
+- queue occupancy snapshots (current + peak)
+
+For handler-failure-driven shutdown, the dispatcher uses an explicit
+`DispatcherStopPolicy` contract. Under
+`handler_failure_policy=STOP_COMPONENT`, it emits
+`HandlerFailurePolicyStopEvent` before invoking the configured stop callback.
+
+In concrete asyncio TCP transports, this diagnostic snapshot is exposed via
+`dispatcher_runtime_stats` on the client/server objects.
+
+## 16) Verification posture interpretation
+
+Verification signals are interpreted in tiers:
+
+- required CI/release gates are primary trust evidence for runtime semantics and packaging
+- non-blocking lanes are secondary/environmental signals
+- semantic behavioral confidence (lifecycle/ordering/cancellation/reconnect) is prioritized over raw coverage alone
+
+The architecture goal is trustworthy runtime semantics, not process-heavy governance signaling.
+

--- a/docs/breaking_changes/README.md
+++ b/docs/breaking_changes/README.md
@@ -1,0 +1,21 @@
+# Breaking Changes Log
+
+This directory records compatibility notes for user-visible changes that affect
+supported upgrade paths between published versions.
+
+Add an entry whenever a later version intentionally changes curated public
+behavior or documented compatibility expectations in a way that requires user
+adaptation.
+
+Use one Markdown file per change, named:
+
+`YYYY-MM-DD_<short_slug>.md`
+
+Recommended structure:
+
+1. **Summary**
+2. **Before**
+3. **After**
+4. **Why**
+5. **Migration**
+6. **Scope**

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,137 @@
+# Logging
+
+aionetx uses the standard library's `logging` module. It does **not**
+configure any handlers itself; the integrating application is expected to
+configure output. All aionetx loggers live under the package namespace
+`aionetx.*` so a single configuration entry can target the library.
+
+---
+
+## Logger hierarchy
+
+All module loggers derive from `__name__`, so names match the import path.
+
+| Logger (prefix `aionetx.implementations.asyncio_impl.`) | Component               |
+|---------------------------------------------------------|-------------------------|
+| `asyncio_tcp_client`                                    | TCP client              |
+| `asyncio_tcp_server`                                    | TCP server              |
+| `asyncio_tcp_connection`                                | TCP connection wrapper  |
+| `asyncio_heartbeat_sender`                              | Heartbeat emission      |
+| `asyncio_udp_receiver`                                  | UDP receiver            |
+| `asyncio_udp_sender`                                    | UDP sender              |
+| `asyncio_multicast_receiver`                            | Multicast receiver      |
+| `event_dispatcher`                                      | Event delivery          |
+| `_tcp_server_helpers`                                   | Internal TCP server     |
+| `_tcp_client_connect`                                   | Internal TCP connect    |
+| `_tcp_connection_helpers`                               | Internal TCP connection |
+| `_asyncio_datagram_receiver_base`                       | Shared datagram base    |
+
+Setting the level on `aionetx` propagates to all of them.
+
+---
+
+## Structured context
+
+Many runtime components attach a `logging.LoggerAdapter` with context merged
+into records via `extra`. The exact keys vary by component. Common keys
+include:
+
+```python
+{"component": "<component-name>", "connection_id": "<canonical-id>", "host": "...", "port": 1234}
+```
+
+Canonical resource-id / connection-id formats (from
+`aionetx.implementations.asyncio_impl.identifier_utils`):
+
+| Component           | canonical id format                            |
+|---------------------|------------------------------------------------|
+| TCP client          | `tcp/client/<host>/<port>`                     |
+| TCP server          | `tcp/server/<host>/<port>`                     |
+| TCP server conn.    | `tcp/server/<peer_host>/<peer_port>/connection/<seq>` |
+| TCP client conn.    | `tcp/client/<host>/<port>/connection`          |
+| UDP receiver        | `udp/receiver/<host>/<port>`                   |
+| UDP sender          | `udp/sender/<local_host>/<local_port>`         |
+| Multicast receiver  | `udp/multicast/<group_ip>/<port>`              |
+
+To surface these keys in the output, a formatter must reference them
+explicitly (e.g. `%(connection_id)s`) or a handler must read them from the
+`LogRecord` via the standard `extra` mechanism.
+
+---
+
+## Recommended levels
+
+| Environment | `aionetx` level | Notes                                    |
+|-------------|-----------------|------------------------------------------|
+| Production  | `WARNING`       | Surfaces fallback warnings, handler-failure warnings, teardown warnings, and dropped-event warnings without per-packet noise. |
+| Staging     | `WARNING` or `DEBUG` | Use `WARNING` for production-like signal; temporarily use `DEBUG` when validating lifecycle/connect sequencing. |
+| Debug       | `DEBUG`         | Adds per-reconnect step, per-event-dispatch detail. Noisy — do not ship. |
+
+---
+
+## Warnings you should alert on
+
+These are the `WARNING`-level events aionetx emits that typically indicate
+user-visible degradation or misconfiguration:
+
+- **UDP `sendto()` / `recvfrom()` fallback polling.** Emitted once per
+  sender/receiver when the running event loop does not expose
+  `sock_sendto()` / `sock_recvfrom()` (typical on Windows
+  `ProactorEventLoop`). Implies per-operation latency up to ~20 ms. See
+  [`platform_notes.md`](platform_notes.md).
+- **TCP client supervision/connect failure.** Emitted when a connect or
+  reconnect cycle fails before policy handling decides whether to retry or
+  stop.
+- **Handler-failure or backpressure warnings.** Emitted when handler-failure
+  policy cannot request a component stop, when shutdown drops background
+  events, or when a configured backpressure policy drops events.
+- **Best-effort teardown warnings.** Emitted when close/shutdown cleanup,
+  multicast membership cleanup, read-task shutdown, writer shutdown, or server
+  connection teardown reports a recoverable failure.
+- **TCP server admission/broadcast warnings.** Emitted when max connection
+  limits reject an accepted connection or when a broadcast send to one
+  connection fails.
+
+An operational alert on `aionetx.*` `WARNING` records is a reasonable
+default.
+
+---
+
+## Minimal configuration
+
+```python
+import logging.config
+
+logging.config.dictConfig({
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "aionetx": {
+            "format": (
+                "%(asctime)s %(levelname)s %(name)s %(message)s"
+            ),
+        },
+    },
+    "handlers": {
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "formatter": "aionetx",
+        },
+    },
+    "loggers": {
+        "aionetx": {
+            "level": "WARNING",
+            "handlers": ["stderr"],
+            "propagate": False,
+        },
+    },
+})
+```
+
+Use a standard formatter as the default copy-paste configuration.
+
+Structured extras such as `component`, `connection_id`, `host`, `port`, and
+`role` are attached on many aionetx records via `LoggerAdapter`, but not every
+record carries the same keys. If you want to render those extras, use a custom
+formatter or filter that supplies defaults for missing fields instead of
+referencing them unconditionally in the format string.

--- a/docs/platform_notes.md
+++ b/docs/platform_notes.md
@@ -1,0 +1,114 @@
+# Platform Notes
+
+This document records platform-specific behaviour that differs from the
+cross-platform defaults assumed elsewhere in aionetx.
+
+---
+
+## TCP/UDP bind reuse and exclusivity
+
+### Linux / macOS
+
+Ordinary TCP/UDP listeners use the platform default bind behavior. Multicast
+receivers opt into address reuse because joining the same multicast group/port
+from multiple sockets is a normal multicast use case.
+
+### Windows
+
+On Windows, `SO_REUSEADDR` has stronger semantics: it allows **any** process
+(including a malicious one) to bind to the same port, even if another process
+is already listening. This is a known security concern documented in the
+[Windows socket documentation](https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse).
+
+The safe Windows alternative is `SO_EXCLUSIVEADDRUSE`, which prevents port
+hijacking while still allowing `TIME_WAIT` reuse.
+
+**Current state:** aionetx uses safer platform-conditional bind setup through
+`configure_listener_bind_socket(...)`:
+
+- ordinary Windows listeners prefer `SO_EXCLUSIVEADDRUSE` when the option is
+  available
+- multicast receivers pass `allow_address_reuse=True` and use `SO_REUSEADDR`
+  because multicast membership needs reuse semantics
+- multicast receivers additionally attempt `SO_REUSEPORT` where the platform
+  exposes it, suppressing unsupported-kernel failures
+
+**Affected components:**
+
+| File | Class |
+|------|-------|
+| `src/aionetx/implementations/asyncio_impl/asyncio_multicast_receiver.py` | `AsyncioMulticastReceiver` |
+| `src/aionetx/implementations/asyncio_impl/asyncio_udp_receiver.py` | `AsyncioUdpReceiver` |
+| `src/aionetx/implementations/asyncio_impl/runtime_utils.py` | `configure_listener_bind_socket` |
+
+---
+
+## Async UDP I/O on Windows (ProactorEventLoop)
+
+aionetx's UDP receive and send paths prefer the event loop's
+`sock_recvfrom()` / `sock_sendto()` awaitables, which deliver non-blocking
+socket I/O integrated with the selector. These APIs are available on
+`asyncio.SelectorEventLoop` (the default on Linux and macOS). On Windows,
+Python 3.8+ defaults to `asyncio.ProactorEventLoop`, which does **not**
+expose `sock_recvfrom()` / `sock_sendto()`.
+
+### Fallback behaviour
+
+When the running loop does not expose these awaitables, aionetx falls back
+to calling `socket.recvfrom()` / `socket.sendto()` directly on the
+non-blocking socket and awaits `asyncio.sleep()` on each `BlockingIOError`
+with exponential backoff.
+
+Backoff envelope (from
+`_WOULD_BLOCK_INITIAL_DELAY_SECONDS` / `_WOULD_BLOCK_MAX_DELAY_SECONDS`
+in `_asyncio_datagram_receiver_base.py` and `asyncio_udp_sender.py`):
+
+| Parameter        | Value       |
+|------------------|-------------|
+| Initial delay    | **0.5 ms**  |
+| Maximum delay    | **20 ms**   |
+| Growth           | Exponential (×2 per retry, capped at max) |
+
+On a busy socket the first retry is cheap; on an idle socket the cap means
+worst-case wake-up latency per operation approaches 20 ms — substantially
+higher than the sub-millisecond behaviour of a selector-integrated loop.
+
+### How to detect fallback is active
+
+Both components emit a single `WARNING` log line on first use of the
+fallback per instance (rate-limited to once per 5 minutes per
+`connection_id` at the module level):
+
+- Receiver:
+  `"<name> is using recvfrom() fallback polling because the event loop does not expose sock_recvfrom()."`
+- Sender:
+  `"AsyncioUdpSender is using sendto() fallback polling because the event loop does not expose sock_sendto()."`
+
+Set the `aionetx.implementations.asyncio_impl` logger (or the project root
+logger) to at least `WARNING` to see these messages. See
+[`logging.md`](logging.md).
+
+### Mitigation
+
+If your application can tolerate the Selector loop's trade-offs (no overlapped
+file I/O, reduced subprocess support on Windows), set the Selector policy
+**before** creating your event loop:
+
+```python
+import asyncio
+import sys
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+```
+
+With the Selector policy, `sock_recvfrom()` / `sock_sendto()` are available
+and aionetx will not use the polling fallback.
+
+### Implications for timing-sensitive use cases
+
+For low-latency test rigs in timing-sensitive or regulated environments (for
+example hardware-in-the-loop setups, CAN/LIN bridging, or protocol
+simulators), profile on the exact platform and event-loop policy you will
+deploy. See [`timing_and_latency.md`](timing_and_latency.md) for the overall
+timing envelope aionetx targets and explicitly does not guarantee.

--- a/docs/reproducible_build.md
+++ b/docs/reproducible_build.md
@@ -1,0 +1,61 @@
+# Reproducible Build Verification
+
+`aionetx` release builds use `SOURCE_DATE_EPOCH` derived from the exact tagged
+commit timestamp. That keeps wheel and sdist timestamps deterministic across
+rebuilds of the same release ref.
+
+## Scope
+
+- Deterministic timestamp control is applied in the release workflow build jobs.
+- The reference value is `git log -1 --format=%ct <ref>`.
+- Reproducibility means the same source tree and build inputs produce identical artifacts.
+
+## Third-party verification recipe
+
+1. Check out the exact release ref.
+
+```bash
+git clone https://github.com/<owner>/aionetx.git
+cd aionetx
+git checkout vX.Y.Z
+```
+
+2. Create a clean environment and install the build frontend.
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip build
+```
+
+3. Export the deterministic timestamp used by the release workflow.
+
+```bash
+export SOURCE_DATE_EPOCH="$(git log -1 --format=%ct HEAD)"
+```
+
+4. Build twice from clean output directories.
+
+```bash
+rm -rf build dist
+python -m build
+mv dist dist-first
+
+rm -rf build dist
+python -m build
+mv dist dist-second
+```
+
+5. Compare artifact hashes.
+
+```bash
+sha256sum dist-first/* dist-second/*
+```
+
+Matching hashes for the wheel and sdist indicate a reproducible rebuild for that ref.
+
+## Notes
+
+- Rebuild the exact tagged commit, not a moving branch tip.
+- Keep tool versions stable while comparing outputs.
+- If a deeper diff is needed, compare wheel contents directly or use `diffoscope`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,92 @@
+# aionetx - Roadmap
+
+This document collects possible future directions. It is not a commitment;
+items may be reprioritized, postponed, or removed.
+
+---
+
+## Near-term transport hardening
+
+### TLS support for TCP (`ssl=` parameter)
+
+`asyncio.open_connection()` and `asyncio.start_server()` already support
+transport-level TLS. The main open work is exposing that cleanly through
+`TcpClientSettings` / `TcpServerSettings` without compromising lifecycle,
+reconnect, or transport-boundary clarity.
+
+Open questions:
+
+- expose `ssl.SSLContext` directly or wrap it in a dedicated settings object
+- certificate reload strategy for long-lived servers
+- typing shape for optional TLS settings
+
+### UDP sender auto-rebind evaluation
+
+`AsyncioUdpSender` is intentionally lifecycle-light today. There is still room
+to evaluate an explicit opt-in recovery/rebind policy for deployments where a
+sender socket may need to be recreated after transport-level errors.
+
+### Ergonomics: `wait_until_stopped()` on `ManagedTransportProtocol`
+
+The library already exposes `wait_until_connected()` and
+`wait_until_running()` helpers for managed TCP roles. A symmetric
+`wait_until_stopped()` helper may improve test ergonomics and shutdown
+coordination without expanding the library beyond transport concerns.
+
+---
+
+## Performance and observability
+
+### Evaluate `asyncio.DatagramProtocol` for UDP receive throughput
+
+The current UDP receiver uses an explicit socket receive loop. It may be worth
+evaluating `loop.create_datagram_endpoint()` / `asyncio.DatagramProtocol` for
+higher datagram throughput and simpler event-loop integration on some
+platforms.
+
+### Publish richer overload metrics
+
+The dispatcher already tracks drop counters and emits rate-limited warnings.
+Additional runtime metrics or a dedicated observability event for backpressure
+may make overload diagnosis easier without relying on log parsing.
+
+### Large-scale connection profiling
+
+The TCP server now exposes explicit admission and timeout controls, but
+high-density workloads still need profiling and stress characterization across
+platforms before stronger scalability claims would be justified.
+
+---
+
+## Explicit scope boundaries
+
+These ideas are intentionally *not* current roadmap goals:
+
+- moving framing or protocol codecs into the core library
+- promoting `TypedEventRouter` into the curated root API without a broader
+  API-boundary change
+- adding protocol-specific helpers (HTTP, MQTT, Modbus, WebSocket,
+  serialization)
+
+Those concerns remain outside the transport-only boundary.
+
+---
+
+## Technical debt and hygiene
+
+- revisit `asyncio_mode = "auto"` versus explicit `@pytest.mark.asyncio`
+  usage in tests
+- clean up overly narrow Hypothesis bounds in settings/property tests
+- reduce environment-sensitive `multicast` marking where a test does not
+  actually require multicast networking
+- periodically reassess supported Python-version bounds as the ecosystem moves
+
+---
+
+## Rejected or deferred ideas
+
+| Idea | Rationale |
+| --- | --- |
+| WebSocket transport | Too far from the raw-byte transport focus; a separate library makes more sense |
+| Thread-safe API (`asyncio.run_coroutine_threadsafe`) | Conflicts with the deliberate single-loop-owner model |
+| Automatic object serialization (JSON, Protobuf, etc.) | Serialization remains the application's responsibility |

--- a/docs/timing_and_latency.md
+++ b/docs/timing_and_latency.md
@@ -1,0 +1,113 @@
+# Timing & Latency
+
+aionetx is a best-effort asyncio transport library. It targets low overhead
+and predictable lifecycle behavior, but it is **not** a real-time system and
+does not provide hard timing guarantees. This document describes the actual
+timing envelope users should expect and, equally important, what is **not**
+guaranteed.
+
+---
+
+## Scope of guarantees
+
+aionetx guarantees:
+
+- **Lifecycle ordering.** State transitions
+  (`STOPPED -> STARTING -> RUNNING -> STOPPING -> STOPPED`) and event ordering
+  invariants hold deterministically. See [`architecture.md`](architecture.md).
+- **Event-loop ownership.** Public methods are checked against the owning
+  event loop; cross-loop misuse fails fast rather than silently corrupting
+  state.
+- **No silent drops of exceptions.** Errors surface as events or explicit
+  exceptions; there are no fire-and-forget exception swallows on the hot path.
+
+aionetx does **not** guarantee:
+
+- upper bounds on per-operation latency
+- deterministic scheduling (jitter-free cadence)
+- safety-rated behavior under the definitions of DO-178C, IEC 61508, or
+  ISO 26262
+
+If your use case requires any of the above, aionetx should be treated as
+instrumentation or a test-bench component, not as a safety-relevant element
+of the system under test.
+
+---
+
+## Observed envelopes
+
+### TCP reconnect backoff
+
+Source: `ReconnectBackoff` in
+`src/aionetx/implementations/asyncio_impl/runtime_utils.py`.
+
+Per attempt the delay is computed as `current_delay`, then advanced to
+`min(current_delay * backoff_factor, max_delay_seconds)`. Jitter is applied
+from `TcpReconnectSettings.jitter`:
+
+| Jitter mode | Returned delay |
+| --- | --- |
+| `NONE` | `current_delay` |
+| `FULL` | uniform `[0, current_delay]` |
+| `EQUAL` | `current_delay / 2 + uniform[0, current_delay / 2]` |
+
+The randomness uses `random.random()` (not cryptographic). Reconnect timing
+therefore has a known *distribution* given the configured settings, but the
+absolute wake-up time additionally depends on event-loop scheduling.
+
+### Heartbeat cadence
+
+Heartbeat cadence is driven by `asyncio.sleep()` between emissions. Under
+normal event-loop conditions jitter is bounded by the loop's scheduler
+resolution (typically sub-millisecond on Linux/macOS selector loops). Under
+load the heartbeat task competes with all other tasks on the same loop, so
+cadence drift grows with overall loop utilization.
+
+Heartbeats are advisory for liveness detection. They are not a time source
+and must not be used as one.
+
+### UDP receive/send
+
+- **Normal path (Selector loop):** A single receive or send completes in a
+  handful of microseconds of event-loop overhead on top of the kernel's
+  socket call. This is the overhead aionetx adds; absolute latency is
+  dominated by the OS network stack and the wire.
+- **Fallback path (Windows ProactorEventLoop):** When `sock_recvfrom()` /
+  `sock_sendto()` are not exposed by the loop, aionetx polls the
+  non-blocking socket and awaits `asyncio.sleep()` on each `BlockingIOError`
+  with exponential backoff (0.5 ms initial, 20 ms cap). Per-operation
+  worst-case wake latency approaches the 20 ms cap on a quiet socket. See
+  [`platform_notes.md`](platform_notes.md).
+
+If latency matters for your use case, measure on the target platform with
+the event-loop policy you will deploy in production. Do not assume numbers
+from Linux selector-loop runs transfer to Windows Proactor-loop runs.
+
+---
+
+## Suitability statement
+
+aionetx is suitable for:
+
+- test harnesses, simulators, HIL/SIL tooling, bench automation, and
+  integration tooling in regulated or certification-adjacent environments
+  where aionetx carries data, logs, and control messages but is not itself
+  the safety-rated or certified component
+- ground-support and lab-support tooling, protocol replay, and CI
+  integration tests
+- timing-sensitive test rigs where best-effort asyncio behavior is acceptable
+  and measured on the target platform
+
+aionetx does not provide certification evidence, qualification artifacts, a
+safety case, or bounded worst-case execution time guarantees.
+
+aionetx is **not** suitable, without additional integration analysis, for:
+
+- airborne software requiring DO-178C certification evidence
+- automotive ECUs certified against ISO 26262 as ASIL-rated components
+- industrial functional-safety systems under IEC 61508 as safety-rated
+  components
+- any context requiring bounded worst-case execution time (WCET)
+
+Users integrating aionetx into larger certified or safety-related systems are
+responsible for their own system-level qualification and compliance evidence.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,60 @@
+# aionetx examples
+
+Five runnable scripts that cover the shapes you are most likely to build on
+top of `aionetx`. Each file is self-contained and exits `0` on success.
+CI runs them as an advisory smoke lane via `scripts/ci/examples_smoke.py`.
+
+## Recommended reading order
+
+1. **[`tcp_echo_server_and_client.py`](tcp_echo_server_and_client.py)** -
+   the smallest possible roundtrip. Introduces `AsyncioNetworkFactory`,
+   `BaseNetworkEventHandler`, `TcpServerSettings` / `TcpClientSettings`,
+   `wait_until_running` / `wait_until_connected`, and how to send bytes
+   over a `ConnectionProtocol`.
+2. **[`udp_round_trip.py`](udp_round_trip.py)** - the same shape for
+   UDP. Shows the asymmetry between `UdpReceiverSettings` (managed
+   lifecycle, emits events) and `UdpSenderSettings` (lifecycle-light,
+   fire-and-forget).
+3. **[`tcp_framing_length_prefix.py`](tcp_framing_length_prefix.py)** -
+   realistic TCP application shape: a fixed-size `CommonMessageHeader`
+   that carries payload length, five typed message variants, a central
+   `MessageDispatcher` that routes complete frames to per-type handlers,
+   and a `FramingHandler` that turns the raw byte stream into complete
+   frames. This is the pattern you would lift into production code.
+4. **[`tcp_reconnect_with_heartbeat.py`](tcp_reconnect_with_heartbeat.py)** -
+   reconnect supervision. A client starts before the server is listening,
+   observes one or more `ReconnectAttemptFailedEvent`s, then the server
+   comes up and the client reconnects. A minimal heartbeat provider is
+   wired up to show the keep-alive hook.
+5. **[`backpressure_policies.py`](backpressure_policies.py)** -
+   side-by-side comparison of `BLOCK`, `DROP_OLDEST`, and `DROP_NEWEST`
+   against an intentionally slow handler. Prints which datagrams each
+   policy actually delivered to the handler.
+
+## Running
+
+Any example can be run directly:
+
+```text
+python examples/tcp_echo_server_and_client.py
+```
+
+To run them all back-to-back with the same guardrails CI uses:
+
+```text
+python scripts/ci/examples_smoke.py
+```
+
+## Scope and caveats
+
+- The examples pick an ephemeral loopback port with a short-lived
+  `socket.bind(("127.0.0.1", 0))` trick. There is a small TOCTOU window
+  between closing that socket and the server binding. It is acceptable
+  for examples; production code should pass a fixed, pre-allocated port.
+- Payloads in `tcp_framing_length_prefix.py` are JSON for readability.
+  Production systems typically swap JSON for a binary schema (protobuf,
+  MessagePack, CBOR, custom struct). The framing + dispatcher shape does
+  not change.
+- Every example terminates on a deterministic condition (counted events
+  or `asyncio.Event`) instead of using a blind "sleep and hope" shutdown,
+  so CI smoke-runs remain fast and stable.

--- a/examples/backpressure_policies.py
+++ b/examples/backpressure_policies.py
@@ -1,0 +1,136 @@
+"""
+Side-by-side demo of the three event backpressure policies.
+
+Run:
+    python examples/backpressure_policies.py
+
+What this shows
+---------------
+aionetx delivers events to your handlers through a bounded queue. When
+handlers are slower than the producer, you have to choose what to do with
+the overflow. `EventBackpressurePolicy` picks the trade-off:
+
+- BLOCK         - producer waits for queue space. Nothing is lost; latency
+                  on the producer rises under sustained overload.
+- DROP_OLDEST   - queue evicts the oldest pending event to make room.
+                  Newest data survives; old data is lost.
+- DROP_NEWEST   - the incoming event is dropped. Oldest data survives;
+                  newest data is lost.
+
+This example uses a UDP receiver per policy (datagram boundaries are
+preserved, so each `send()` produces exactly one `on_bytes_received`
+event) with a tiny event queue and a handler that sleeps per event. The
+producer sends a burst faster than the handler can drain. The printed
+output shows how the three policies diverge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    EventDeliverySettings,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+from aionetx.api import EventBackpressurePolicy
+
+QUEUE_CAPACITY = 2
+
+
+def pick_free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class SlowRecorder(BaseNetworkEventHandler):
+    """Records each event after a small delay, slow enough to force overflow."""
+
+    HANDLER_DELAY_SECONDS = 0.05
+
+    def __init__(self) -> None:
+        self.observed: list[bytes] = []
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        await asyncio.sleep(self.HANDLER_DELAY_SECONDS)
+        self.observed.append(event.data)
+
+
+async def run_policy(policy: EventBackpressurePolicy, burst: list[bytes]) -> list[bytes]:
+    """
+    Start a UDP receiver + sender under `policy`, send `burst`, return what
+    the receiver handler actually observed.
+    """
+    port = pick_free_udp_port()
+    factory = AsyncioNetworkFactory()
+
+    recorder = SlowRecorder()
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(
+                backpressure_policy=policy,
+                max_pending_events=QUEUE_CAPACITY,
+            ),
+        ),
+        event_handler=recorder,
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    await receiver.start()
+
+    # Fire the burst concurrently so overflow is determined by the receiver's
+    # queue policy rather than by an arbitrary "sleep long enough" delay.
+    try:
+        await asyncio.gather(*(sender.send(payload) for payload in burst))
+        while True:
+            stats = receiver.dispatcher_runtime_stats
+            delivered_or_dropped = (
+                len(recorder.observed)
+                + stats.dropped_backpressure_oldest_total
+                + stats.dropped_backpressure_newest_total
+            )
+            if delivered_or_dropped >= len(burst) and stats.queue_depth == 0:
+                break
+            await asyncio.sleep(0)
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+    return list(recorder.observed)
+
+
+async def main() -> int:
+    burst = [f"msg-{i:02d}".encode("ascii") for i in range(10)]
+    print(f"producer burst: {[p.decode() for p in burst]}")
+    print(f"(receiver queue size = {QUEUE_CAPACITY}, handler sleeps 50ms per event)\n")
+
+    for policy in (
+        EventBackpressurePolicy.BLOCK,
+        EventBackpressurePolicy.DROP_OLDEST,
+        EventBackpressurePolicy.DROP_NEWEST,
+    ):
+        observed = await run_policy(policy, burst)
+        decoded = [b.decode() for b in observed]
+        print(f"[{policy.value:>12}] handler observed {len(decoded)}/{len(burst)}: {decoded}")
+
+    print(
+        "\nNotes:"
+        "\n  BLOCK keeps every datagram (producer waits for queue space)."
+        "\n  DROP_OLDEST keeps the tail of the burst (freshest data wins)."
+        "\n  DROP_NEWEST keeps the head of the burst (earliest data wins)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/tcp_echo_server_and_client.py
+++ b/examples/tcp_echo_server_and_client.py
@@ -1,0 +1,107 @@
+"""
+Minimal TCP echo: server echoes bytes back, client verifies the roundtrip.
+
+Run:
+    python examples/tcp_echo_server_and_client.py
+
+This example picks an ephemeral port on 127.0.0.1, starts a server that echoes
+any bytes it receives, runs a client that sends one message, waits for the
+echoed bytes to come back, then stops cleanly. It exits 0 on success so CI can
+smoke-test it as a subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+
+from typing import Callable
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    TcpClientSettings,
+    TcpServerSettings,
+)
+from aionetx.api import ConnectionProtocol, TcpServerProtocol
+
+
+def pick_free_tcp_port() -> int:
+    """
+    Ask the OS for a free TCP port on the loopback interface.
+
+    NOTE: there is a small TOCTOU window between closing this socket and the
+    server binding. For examples that's acceptable; production code should
+    prefer passing a fixed, pre-allocated port.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class EchoServerHandler(BaseNetworkEventHandler):
+    """Echoes every chunk of bytes back over the same connection."""
+
+    def __init__(
+        self,
+        server_connections_provider: Callable[[], tuple[ConnectionProtocol, ...]],
+    ) -> None:
+        self._server_connections_provider = server_connections_provider
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        for connection in self._server_connections_provider():
+            if connection.connection_id == event.resource_id:
+                await connection.send(event.data)
+                return
+
+
+class EchoClientHandler(BaseNetworkEventHandler):
+    """Records the first echoed payload and sets an asyncio.Event."""
+
+    def __init__(self) -> None:
+        self.received = asyncio.Event()
+        self.payload: bytes = b""
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        self.payload = event.data
+        self.received.set()
+
+
+async def main() -> int:
+    port = pick_free_tcp_port()
+    factory = AsyncioNetworkFactory()
+
+    server: TcpServerProtocol
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=EchoServerHandler(lambda: server.connections),
+    )
+    client_handler = EchoClientHandler()
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(host="127.0.0.1", port=port),
+        event_handler=client_handler,
+    )
+
+    await server.start()
+    await server.wait_until_running(timeout_seconds=5.0)
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=5.0)
+
+    message = b"hello, aionetx"
+    await connection.send(message)
+    await asyncio.wait_for(client_handler.received.wait(), timeout=5.0)
+
+    assert client_handler.payload == message, (
+        f"expected echoed {message!r}, got {client_handler.payload!r}"
+    )
+    print(f"echoed payload: {client_handler.payload!r}")
+
+    await client.stop()
+    await server.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/tcp_framing_length_prefix.py
+++ b/examples/tcp_framing_length_prefix.py
@@ -1,0 +1,425 @@
+"""
+Length-prefixed TCP framing with a typed message dispatcher.
+
+Run:
+    python examples/tcp_framing_length_prefix.py
+
+Scope of this example
+---------------------
+aionetx is a raw-byte transport: `on_bytes_received` gives you whatever
+chunk the OS decided to hand over. TCP has no message boundaries, so
+realistic applications add a framing layer on top. This example shows the
+most common one: a fixed-size header that carries the payload length, with
+a central dispatcher that turns complete frames into typed messages.
+
+Wire format
+-----------
+Every frame starts with an 8-byte `CommonMessageHeader`, followed by a
+payload of exactly `payload_length` bytes:
+
+    +----------------+----------------+-------------------------+
+    | type_id (u32)  | payload_length | payload (JSON-encoded)  |
+    |  big endian    |    (u32 be)    |    <payload_length>B    |
+    +----------------+----------------+-------------------------+
+
+`struct.pack(">II", type_id, payload_length)` produces the header. Network
+byte order (big endian) is used because that is the standard on the wire.
+
+Payloads are JSON here to keep the example self-contained. In production,
+you would typically use a binary schema (protobuf, MessagePack, CBOR,
+custom struct layout, ...); the framing+dispatcher pattern is the same.
+
+Shape of the example
+--------------------
+- Five message types with 3-7 fields each (`Heartbeat`,
+  `TelemetryUpdate`, `CommandRequest`, `CommandAck`, `EventNotification`).
+- A central `MessageDispatcher` maps type_id to typed handlers.
+- `FramingHandler` owns a per-connection buffer, pulls out complete
+  frames, and routes them to the dispatcher. This is the piece you would
+  lift into production code: aionetx gives you bytes, the framing handler
+  turns them into messages, the dispatcher turns messages into work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import socket
+import struct
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Awaitable, Callable
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    TcpClientSettings,
+    TcpServerSettings,
+)
+
+# ---------------------------------------------------------------------------
+# Wire framing
+# ---------------------------------------------------------------------------
+
+HEADER_STRUCT = struct.Struct(">II")  # type_id, payload_length (both u32 BE)
+HEADER_SIZE = HEADER_STRUCT.size  # 8 bytes
+MAX_PAYLOAD_BYTES = 1 << 20  # defensive cap: reject 1+ MiB frames
+
+
+@dataclass(frozen=True, slots=True)
+class CommonMessageHeader:
+    """Fixed 8-byte header that precedes every message on the wire."""
+
+    type_id: int
+    payload_length: int
+
+    def pack(self) -> bytes:
+        return HEADER_STRUCT.pack(self.type_id, self.payload_length)
+
+    @staticmethod
+    def unpack(buffer: bytes) -> "CommonMessageHeader":
+        type_id, payload_length = HEADER_STRUCT.unpack(buffer)
+        return CommonMessageHeader(type_id=type_id, payload_length=payload_length)
+
+
+# ---------------------------------------------------------------------------
+# Message catalog
+# ---------------------------------------------------------------------------
+
+
+class MessageType:
+    HEARTBEAT = 1
+    TELEMETRY_UPDATE = 2
+    COMMAND_REQUEST = 3
+    COMMAND_ACK = 4
+    EVENT_NOTIFICATION = 5
+
+
+@dataclass(frozen=True, slots=True)
+class Heartbeat:
+    sequence: int
+    sender_id: str
+    monotonic_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class TelemetryUpdate:
+    sensor_id: str
+    timestamp_ms: int
+    temperature_celsius: float
+    pressure_kpa: float
+    battery_percent: int
+
+
+@dataclass(frozen=True, slots=True)
+class CommandRequest:
+    command_id: str
+    operator: str
+    target: str
+    arguments: list[str]
+    priority: int
+
+
+@dataclass(frozen=True, slots=True)
+class CommandAck:
+    command_id: str
+    accepted: bool
+    reason: str
+    executor: str
+    latency_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class EventNotification:
+    event_id: str
+    severity: str
+    category: str
+    source: str
+    message: str
+    occurred_at_ms: int
+    correlation_id: str
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+# Each message type maps to its dataclass so the framing layer can reconstruct
+# typed objects from the payload. A production codebase would use a proper
+# schema/codec library for this; JSON + dataclasses keeps the example clear.
+MESSAGE_TYPE_TO_CLASS: dict[int, type] = {
+    MessageType.HEARTBEAT: Heartbeat,
+    MessageType.TELEMETRY_UPDATE: TelemetryUpdate,
+    MessageType.COMMAND_REQUEST: CommandRequest,
+    MessageType.COMMAND_ACK: CommandAck,
+    MessageType.EVENT_NOTIFICATION: EventNotification,
+}
+
+
+def encode_message(message: Any) -> bytes:
+    """Encode `message` into header + JSON payload."""
+    type_id = next(tid for tid, cls in MESSAGE_TYPE_TO_CLASS.items() if isinstance(message, cls))
+    payload = json.dumps(asdict(message)).encode("utf-8")
+    header = CommonMessageHeader(type_id=type_id, payload_length=len(payload))
+    return header.pack() + payload
+
+
+def decode_message(type_id: int, payload: bytes) -> Any:
+    """Decode `payload` back into the dataclass registered for `type_id`."""
+    message_class = MESSAGE_TYPE_TO_CLASS[type_id]
+    fields = json.loads(payload.decode("utf-8"))
+    return message_class(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Central dispatcher
+# ---------------------------------------------------------------------------
+
+
+MessageHandler = Callable[[Any], Awaitable[None]]
+
+
+class MessageDispatcher:
+    """
+    Routes typed messages to per-type async handlers.
+
+    This is deliberately small: a dict of `type_id -> handler`. Even so, the
+    shape scales: add a new message type, register its handler, done. Keeping
+    dispatch central means the rest of the codebase never isinstance-chains
+    over message variants.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[int, MessageHandler] = {}
+
+    def register(self, type_id: int, handler: MessageHandler) -> None:
+        self._handlers[type_id] = handler
+
+    async def dispatch(self, type_id: int, message: Any) -> None:
+        handler = self._handlers.get(type_id)
+        if handler is None:
+            print(f"[dispatcher] no handler registered for type_id={type_id}")
+            return
+        await handler(message)
+
+
+# ---------------------------------------------------------------------------
+# Framing handler: bytes -> frames -> dispatcher
+# ---------------------------------------------------------------------------
+
+
+class FramingHandler(BaseNetworkEventHandler):
+    """
+    Converts a raw byte stream into complete frames, one connection at a time.
+
+    Responsibilities:
+    1. Maintain a per-connection `bytearray` buffer (aionetx does not frame
+       anything for you).
+    2. Pull out every complete frame the buffer currently contains.
+    3. Decode each frame into a typed message and hand it to the dispatcher.
+    """
+
+    def __init__(self, dispatcher: MessageDispatcher) -> None:
+        self._dispatcher = dispatcher
+        self._buffers: dict[str, bytearray] = {}
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        buffer = self._buffers.setdefault(event.resource_id, bytearray())
+        buffer.extend(event.data)
+
+        while True:
+            if len(buffer) < HEADER_SIZE:
+                return  # not enough bytes for a header yet
+
+            header = CommonMessageHeader.unpack(bytes(buffer[:HEADER_SIZE]))
+            if header.payload_length > MAX_PAYLOAD_BYTES:
+                # Defensive: a malformed or hostile peer could claim a huge
+                # length. Production code should close the connection and log.
+                print(
+                    f"[framing] rejecting oversize frame "
+                    f"({header.payload_length} > {MAX_PAYLOAD_BYTES})"
+                )
+                buffer.clear()
+                return
+
+            frame_end = HEADER_SIZE + header.payload_length
+            if len(buffer) < frame_end:
+                return  # header parsed, payload still incomplete
+
+            payload = bytes(buffer[HEADER_SIZE:frame_end])
+            del buffer[:frame_end]
+
+            try:
+                message = decode_message(header.type_id, payload)
+            except Exception as exc:  # pragma: no cover - example-only path
+                print(f"[framing] decode failed for type_id={header.type_id}: {exc}")
+                continue
+            await self._dispatcher.dispatch(header.type_id, message)
+
+
+# ---------------------------------------------------------------------------
+# Per-type handlers
+# ---------------------------------------------------------------------------
+
+
+async def handle_heartbeat(message: Heartbeat) -> None:
+    print(f"[heartbeat] seq={message.sequence} sender={message.sender_id!r}")
+    # here dispatch to your liveness/watchdog subsystem
+
+
+async def handle_telemetry(message: TelemetryUpdate) -> None:
+    print(
+        f"[telemetry] sensor={message.sensor_id!r} "
+        f"temp={message.temperature_celsius}C pressure={message.pressure_kpa}kPa"
+    )
+    # here dispatch to your metrics/telemetry pipeline
+
+
+async def handle_command_request(message: CommandRequest) -> None:
+    print(
+        f"[command.request] id={message.command_id!r} "
+        f"operator={message.operator!r} target={message.target!r}"
+    )
+    # here dispatch to your command executor with the typed request
+
+
+async def handle_command_ack(message: CommandAck) -> None:
+    print(
+        f"[command.ack] id={message.command_id!r} accepted={message.accepted} "
+        f"latency_ms={message.latency_ms}"
+    )
+    # here dispatch the ack back to the originating command futures map
+
+
+async def handle_event_notification(message: EventNotification) -> None:
+    print(
+        f"[event] id={message.event_id!r} severity={message.severity!r} "
+        f"source={message.source!r} message={message.message!r}"
+    )
+    # here dispatch to your alerting / event bus
+
+
+# ---------------------------------------------------------------------------
+# Random message factory (one of each type)
+# ---------------------------------------------------------------------------
+
+
+def build_random_message_sequence() -> list[Any]:
+    """Return one randomized instance of every message type, order-shuffled."""
+    rng = random.Random(0xA10E)  # deterministic so smoke output is stable
+    messages: list[Any] = [
+        Heartbeat(
+            sequence=rng.randint(1, 10_000),
+            sender_id=f"node-{rng.randint(1, 32)}",
+            monotonic_ms=rng.randint(0, 10_000_000),
+        ),
+        TelemetryUpdate(
+            sensor_id=f"sensor-{rng.randint(1, 16)}",
+            timestamp_ms=rng.randint(1_700_000_000_000, 1_800_000_000_000),
+            temperature_celsius=round(rng.uniform(-20.0, 120.0), 2),
+            pressure_kpa=round(rng.uniform(80.0, 120.0), 2),
+            battery_percent=rng.randint(0, 100),
+        ),
+        CommandRequest(
+            command_id=f"cmd-{rng.randint(1000, 9999)}",
+            operator=f"op-{rng.randint(1, 8)}",
+            target=f"actuator-{rng.randint(1, 4)}",
+            arguments=[f"arg{i}" for i in range(rng.randint(1, 3))],
+            priority=rng.randint(0, 9),
+        ),
+        CommandAck(
+            command_id=f"cmd-{rng.randint(1000, 9999)}",
+            accepted=bool(rng.getrandbits(1)),
+            reason=rng.choice(["ok", "rejected", "queued"]),
+            executor=f"executor-{rng.randint(1, 4)}",
+            latency_ms=rng.randint(0, 500),
+        ),
+        EventNotification(
+            event_id=f"evt-{rng.randint(10_000, 99_999)}",
+            severity=rng.choice(["info", "warn", "error"]),
+            category=rng.choice(["system", "network", "application"]),
+            source=f"component-{rng.randint(1, 6)}",
+            message="synthetic example event",
+            occurred_at_ms=rng.randint(1_700_000_000_000, 1_800_000_000_000),
+            correlation_id=f"corr-{rng.randint(10_000, 99_999)}",
+        ),
+    ]
+    rng.shuffle(messages)
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def pick_free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def main() -> int:
+    port = pick_free_tcp_port()
+    factory = AsyncioNetworkFactory()
+
+    # Server side: build the dispatcher and framing handler that will turn
+    # the incoming byte stream into typed messages.
+    dispatcher = MessageDispatcher()
+    dispatcher.register(MessageType.HEARTBEAT, handle_heartbeat)
+    dispatcher.register(MessageType.TELEMETRY_UPDATE, handle_telemetry)
+    dispatcher.register(MessageType.COMMAND_REQUEST, handle_command_request)
+    dispatcher.register(MessageType.COMMAND_ACK, handle_command_ack)
+    dispatcher.register(MessageType.EVENT_NOTIFICATION, handle_event_notification)
+
+    messages_to_send = build_random_message_sequence()
+    total_expected = len(messages_to_send)
+    delivered = 0
+    all_delivered = asyncio.Event()
+
+    # Wrap every handler so we can count deliveries and stop once done.
+    async def counting_wrapper(inner: MessageHandler) -> MessageHandler:
+        async def wrapper(message: Any) -> None:
+            nonlocal delivered
+            await inner(message)
+            delivered += 1
+            if delivered >= total_expected:
+                all_delivered.set()
+
+        return wrapper
+
+    for type_id, handler in list(dispatcher._handlers.items()):  # noqa: SLF001
+        dispatcher.register(type_id, await counting_wrapper(handler))
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=FramingHandler(dispatcher),
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(host="127.0.0.1", port=port),
+        event_handler=BaseNetworkEventHandler(),  # client does not consume here
+    )
+
+    await server.start()
+    await server.wait_until_running(timeout_seconds=5.0)
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=5.0)
+
+    # Send all five messages back-to-back. The framing handler on the server
+    # side correctly pulls them apart even when multiple frames arrive in the
+    # same on_bytes_received call.
+    for message in messages_to_send:
+        await connection.send(encode_message(message))
+
+    await asyncio.wait_for(all_delivered.wait(), timeout=5.0)
+    print(f"dispatched {delivered} typed messages")
+
+    await client.stop()
+    await server.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/tcp_reconnect_with_heartbeat.py
+++ b/examples/tcp_reconnect_with_heartbeat.py
@@ -1,0 +1,170 @@
+"""
+TCP client reconnect cycle with observable lifecycle/reconnect events.
+
+Run:
+    python examples/tcp_reconnect_with_heartbeat.py
+
+What this shows
+---------------
+1. A client starts with reconnect enabled while no server is listening. The
+   first few connection attempts fail and the client schedules retries with
+   exponential backoff.
+2. After a short delay the server is started on the same port. The client's
+   next reconnect attempt succeeds.
+3. The example observes the reconnect events (`attempt_started`,
+   `attempt_failed`, `scheduled`) and prints them so you can see the full
+   cycle, then sends one message and exits cleanly.
+
+Heartbeats
+----------
+The client is configured with `TcpHeartbeatSettings(enabled=True, ...)` plus a
+minimal heartbeat provider. Once the connection is up, the client asks the
+provider every interval whether to send a keep-alive byte. This is how you
+would keep idle TCP connections alive or detect zombie peers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    HeartbeatProviderProtocol,
+    TcpHeartbeatSettings,
+    TcpReconnectSettings,
+    TcpClientSettings,
+    TcpServerSettings,
+)
+from aionetx.api import (
+    ConnectionOpenedEvent,
+    HeartbeatRequest,
+    HeartbeatResult,
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+
+def pick_free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class ClientObserver(BaseNetworkEventHandler):
+    """Prints reconnect lifecycle events and signals when the client connects."""
+
+    def __init__(self) -> None:
+        self.connected = asyncio.Event()
+        self.first_failure_seen = asyncio.Event()
+        self.failed_attempts = 0
+
+    async def on_reconnect_attempt_started(self, event: ReconnectAttemptStartedEvent) -> None:
+        print(f"[reconnect] attempt #{event.attempt} starting")
+
+    async def on_reconnect_attempt_failed(self, event: ReconnectAttemptFailedEvent) -> None:
+        self.failed_attempts += 1
+        self.first_failure_seen.set()
+        print(
+            f"[reconnect] attempt #{event.attempt} failed "
+            f"(next delay: {event.next_delay_seconds}s) — {type(event.error).__name__}"
+        )
+
+    async def on_reconnect_scheduled(self, event: ReconnectScheduledEvent) -> None:
+        print(f"[reconnect] scheduled attempt #{event.attempt} in {event.delay_seconds}s")
+
+    async def on_connection_opened(self, event: ConnectionOpenedEvent) -> None:
+        print(f"[connection] opened {event.resource_id}")
+        self.connected.set()
+
+
+class ServerHandler(BaseNetworkEventHandler):
+    """Records the first payload the client sends after reconnecting."""
+
+    def __init__(self) -> None:
+        self.received = asyncio.Event()
+        self.payload: bytes = b""
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        # Ignore heartbeat bytes; only store the real application message.
+        if event.data == b"hb":
+            return
+        self.payload = event.data
+        self.received.set()
+
+
+class ConstantHeartbeatProvider(HeartbeatProviderProtocol):
+    """
+    Sends a 2-byte keep-alive on every tick. Production providers typically
+    gate `should_send` on traffic-idle conditions or wall-clock deadlines.
+    """
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload=b"hb")
+
+
+async def main() -> int:
+    port = pick_free_tcp_port()
+    factory = AsyncioNetworkFactory()
+
+    observer = ClientObserver()
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.2,
+                max_delay_seconds=1.0,
+                backoff_factor=2.0,
+            ),
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.5),
+        ),
+        event_handler=observer,
+        heartbeat_provider=ConstantHeartbeatProvider(),
+    )
+
+    # Start client first. No server is listening yet, so initial attempts fail
+    # and the client schedules retries.
+    await client.start()
+
+    # Wait until at least one attempt has failed before bringing the server
+    # up. That keeps the "reconnect cycle" part of the example deterministic
+    # across platforms (connect refusal latency varies).
+    await asyncio.wait_for(observer.first_failure_seen.wait(), timeout=5.0)
+
+    # Now bring the server up. The next reconnect attempt will succeed.
+    server_handler = ServerHandler()
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=server_handler,
+    )
+    await server.start()
+    await server.wait_until_running(timeout_seconds=5.0)
+    print("[server] up; waiting for client to reconnect")
+
+    connection = await client.wait_until_connected(timeout_seconds=5.0)
+    await asyncio.wait_for(observer.connected.wait(), timeout=5.0)
+
+    # Send one message over the now-established connection.
+    await connection.send(b"ready-after-reconnect")
+    await asyncio.wait_for(server_handler.received.wait(), timeout=5.0)
+
+    assert server_handler.payload == b"ready-after-reconnect", server_handler.payload
+    assert observer.failed_attempts >= 1, "expected at least one failed attempt"
+    print(
+        f"reconnected after {observer.failed_attempts} failed attempt(s); "
+        f"server received {server_handler.payload!r}"
+    )
+
+    await client.stop()
+    await server.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/udp_round_trip.py
+++ b/examples/udp_round_trip.py
@@ -1,0 +1,73 @@
+"""
+UDP datagram round trip: receiver consumes one datagram sent by a sender.
+
+Run:
+    python examples/udp_round_trip.py
+
+This example binds a UDP receiver to an ephemeral loopback port, creates a
+sender that targets that port, sends a single datagram, waits until the
+receiver has observed it, then shuts everything down. Exits 0 on success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+
+
+def pick_free_udp_port() -> int:
+    """Ask the OS for a free UDP port on the loopback interface."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class RecordingHandler(BaseNetworkEventHandler):
+    def __init__(self) -> None:
+        self.received = asyncio.Event()
+        self.payload: bytes = b""
+        self.remote: tuple[str | None, int | None] = (None, None)
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        self.payload = event.data
+        self.remote = (event.remote_host, event.remote_port)
+        self.received.set()
+
+
+async def main() -> int:
+    port = pick_free_udp_port()
+    factory = AsyncioNetworkFactory()
+
+    handler = RecordingHandler()
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=handler,
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    await receiver.start()
+    try:
+        await sender.send(b"datagram-payload")
+        await asyncio.wait_for(handler.received.wait(), timeout=5.0)
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.payload == b"datagram-payload", handler.payload
+    print(f"received {handler.payload!r} from {handler.remote}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aionetx"
+version = "0.1.0"
+description = "Reusable raw-byte network layer for TCP, UDP sender/receiver, and multicast"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    {name = "Marcus Korinth"},
+]
+dependencies = []
+license-files = ["LICENSE"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Networking",
+    "Typing :: Typed",
+]
+keywords = ["asyncio", "networking", "tcp", "udp", "multicast"]
+
+[project.urls]
+Repository = "https://github.com/MarcusKorinth/aionetx"
+Documentation = "https://github.com/MarcusKorinth/aionetx#readme"
+Issues = "https://github.com/MarcusKorinth/aionetx/issues"
+Changelog = "https://github.com/MarcusKorinth/aionetx/blob/main/CHANGELOG.md"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
+    "pytest-timeout>=2.3",
+    "coverage>=7.0",
+    "ruff>=0.5",
+    "mypy>=1.10",
+    "tomli>=2.0; python_version < '3.11'",
+]
+dev-hypothesis = [
+    "aionetx[dev]",
+    "hypothesis>=6.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+aionetx = ["py.typed"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = [
+    "--strict-markers",
+]
+markers = [
+    "behavior_critical: runtime-semantic checks for lifecycle, ordering, concurrency, cancellation, or failure behavior",
+    "integration_confidence: end-to-end transport scenarios validating user-observable integration behavior",
+    "asyncio: marks tests that require pytest-asyncio",
+    "integration: marks integration tests",
+    "integration_smoke: marks required intermediate-version integration smoke tests",
+    "integration_semantic: marks required intermediate-version semantic integration shard tests",
+    "multicast: marks environment-sensitive multicast tests",
+    "slow: marks timing-sensitive or long-running tests",
+    "reliability_smoke: marks deterministic reliability-sensitive smoke tests that are required in CI",
+    "hypothesis: marks property-based tests that require the hypothesis package (opt-in, not a required CI gate)",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+packages = ["aionetx"]
+mypy_path = "src"
+explicit_package_bases = true

--- a/scripts/ci/assert_integration_semantic_shard.py
+++ b/scripts/ci/assert_integration_semantic_shard.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator
+
+
+EXPECTED_SHARD_TESTS: dict[str, str] = {
+    "tests/integration/test_client_reconnect.py": "test_tcp_client_reconnects_after_server_appears",
+    "tests/integration/test_heartbeat_integration.py": "test_heartbeat_restarts_after_reconnect",
+    "tests/integration/test_on_event_payload_contract.py": "test_on_event_bytes_received_event_contains_payload_bytes",
+}
+
+
+def _has_integration_semantic_marker(function_node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    for decorator in function_node.decorator_list:
+        if not isinstance(decorator, ast.Attribute):
+            continue
+        if decorator.attr != "integration_semantic":
+            continue
+        mark_attribute = decorator.value
+        if not isinstance(mark_attribute, ast.Attribute):
+            continue
+        if mark_attribute.attr != "mark":
+            continue
+        pytest_name = mark_attribute.value
+        if isinstance(pytest_name, ast.Name) and pytest_name.id == "pytest":
+            return True
+    return False
+
+
+def _load_marked_tests(path: Path) -> set[str]:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    marked: set[str] = set()
+    for test_id, node in _iter_collectable_function_nodes(module):
+        if _has_integration_semantic_marker(node):
+            marked.add(test_id)
+    return marked
+
+
+def _iter_collectable_function_nodes(
+    module: ast.Module,
+) -> Iterator[tuple[str, ast.AsyncFunctionDef | ast.FunctionDef]]:
+    stack: list[tuple[ast.Module | ast.ClassDef, tuple[str, ...]]] = [(module, ())]
+    while stack:
+        node, class_path = stack.pop()
+        for child in node.body:
+            if isinstance(child, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                if class_path:
+                    yield ("::".join((*class_path, child.name)), child)
+                else:
+                    yield (child.name, child)
+            elif isinstance(child, ast.ClassDef):
+                stack.append((child, (*class_path, child.name)))
+
+
+def main() -> None:
+    expected_total = len(EXPECTED_SHARD_TESTS)
+    observed_total = 0
+
+    for file_path_str, expected_test_name in EXPECTED_SHARD_TESTS.items():
+        file_path = Path(file_path_str)
+        marked_tests = _load_marked_tests(file_path)
+        if expected_test_name not in marked_tests:
+            raise AssertionError(
+                f"required integration_semantic shard test missing marker: {file_path_str}::{expected_test_name}"
+            )
+        observed_total += 1
+
+    all_marked_tests: list[str] = []
+    for integration_test_file in sorted(Path("tests/integration").glob("test_*.py")):
+        marked = _load_marked_tests(integration_test_file)
+        all_marked_tests.extend(
+            f"{integration_test_file}::{test_name}" for test_name in sorted(marked)
+        )
+
+    if len(all_marked_tests) != expected_total:
+        raise AssertionError(
+            "integration_semantic shard drift detected: "
+            f"expected exactly {expected_total} marked tests, found {len(all_marked_tests)}: {all_marked_tests}"
+        )
+
+    print(
+        "integration_semantic shard contract verified: "
+        f"{observed_total} required tests marked; total marked tests={len(all_marked_tests)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/check_release_codeql_gate.py
+++ b/scripts/ci/check_release_codeql_gate.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Required environment variable is missing: {name}")
+    return value
+
+
+def _parse_next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for segment in link_header.split(","):
+        candidate = segment.strip()
+        if 'rel="next"' not in candidate:
+            continue
+        start = candidate.find("<")
+        end = candidate.find(">", start + 1)
+        if start != -1 and end != -1:
+            return candidate[start + 1 : end]
+    return None
+
+
+def _iter_open_alerts(*, repository: str, ref: str, token: str) -> list[dict[str, object]]:
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    url = (
+        f"https://api.github.com/repos/{repository}/code-scanning/alerts"
+        f"?state=open&ref={encoded_ref}&per_page=100"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "aionetx-release-codeql-gate",
+    }
+
+    alerts: list[dict[str, object]] = []
+    while url:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, list):
+                raise RuntimeError("Unexpected code scanning alerts response shape.")
+            alerts.extend(item for item in payload if isinstance(item, dict))
+            url = _parse_next_link(response.headers.get("Link"))
+    return alerts
+
+
+def _severity_rank(severity: str) -> int:
+    return {"critical": 3, "high": 2, "medium": 1, "low": 0}.get(severity, -1)
+
+
+def main() -> int:
+    repository = _require_env("GITHUB_REPOSITORY")
+    ref = _require_env("GITHUB_REF")
+    token = _require_env("GITHUB_TOKEN")
+
+    open_alerts = _iter_open_alerts(repository=repository, ref=ref, token=token)
+    blocking_alerts = []
+    for alert in open_alerts:
+        rule = alert.get("rule")
+        severity = ""
+        if isinstance(rule, dict):
+            severity_value = rule.get("security_severity_level")
+            if isinstance(severity_value, str):
+                severity = severity_value.lower()
+        if _severity_rank(severity) >= _severity_rank("high"):
+            blocking_alerts.append(alert)
+
+    print(f"CodeQL release gate inspected {len(open_alerts)} open alert(s) for {ref}.")
+    if not blocking_alerts:
+        print("No open high/critical CodeQL alerts block this release ref.")
+        return 0
+
+    print(
+        f"Found {len(blocking_alerts)} blocking CodeQL alert(s) with severity high/critical:",
+        file=sys.stderr,
+    )
+    for alert in blocking_alerts:
+        number = alert.get("number", "?")
+        html_url = str(alert.get("html_url", ""))
+        rule = alert.get("rule")
+        rule_id = "<unknown>"
+        severity = "<unknown>"
+        if isinstance(rule, dict):
+            rule_id = str(rule.get("id", "<unknown>"))
+            severity = str(rule.get("security_severity_level", "<unknown>"))
+        print(
+            f"- alert #{number}: rule={rule_id} severity={severity} {html_url}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_sha_pins.py
+++ b/scripts/ci/check_sha_pins.py
@@ -1,0 +1,149 @@
+"""
+Validate that every SHA-pinned action in .github/workflows/*.yml matches its tag comment.
+
+For each line of the form:
+    uses: owner/repo@<40-char-sha>  # vX.Y.Z
+
+the script calls the GitHub API to resolve the tag to a commit SHA and compares it
+against the pinned SHA.
+
+Exit codes:
+    0 — all pins match (or GH_TOKEN is not set, in which case checks are skipped)
+    1 — one or more pins do not match the expected tag SHA
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Regex to capture:  owner/repo@<sha>  # vX.Y.Z
+_PIN_RE = re.compile(
+    r"uses:\s+(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
+    r"@(?P<sha>[0-9a-f]{40})\s+#\s+(?P<tag>v\S+)"
+)
+
+
+def _gh_api(path: str, token: str) -> dict:  # type: ignore[type-arg]
+    """Call `gh api <path>` and return parsed JSON."""
+    result = subprocess.run(
+        ["gh", "api", path],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GH_TOKEN": token},
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh api {path!r} failed (exit {result.returncode}):\n{result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)  # type: ignore[no-any-return]
+
+
+def _resolve_tag_commit_sha(owner: str, repo: str, tag: str, token: str) -> str | None:
+    """Return the commit SHA that *tag* points to, or None if the tag is not found."""
+    path = f"/repos/{owner}/{repo}/git/refs/tags/{tag}"
+    try:
+        ref_data = _gh_api(path, token)
+    except RuntimeError as exc:
+        # 404 → tag not found; surface the error but keep going
+        if "404" in str(exc) or "Not Found" in str(exc):
+            return None
+        raise
+
+    obj = ref_data.get("object", {})
+    obj_type: str = obj.get("type", "")
+    obj_sha: str = obj.get("sha", "")
+
+    if obj_type == "commit":
+        # Lightweight tag: the ref object IS the commit
+        return obj_sha
+
+    if obj_type == "tag":
+        # Annotated tag: dereference the tag object to get the commit SHA
+        tag_obj = _gh_api(f"/repos/{owner}/{repo}/git/tags/{obj_sha}", token)
+        tagged = tag_obj.get("object", {})
+        tagged_type: str = tagged.get("type", "")
+        tagged_sha: str = tagged.get("sha", "")
+        if tagged_type == "commit":
+            return tagged_sha
+        # Edge case: tag points to another tag (rare); follow one more level
+        tag_obj2 = _gh_api(f"/repos/{owner}/{repo}/git/tags/{tagged_sha}", token)
+        inner: str = tag_obj2.get("object", {}).get("sha", "")
+        return inner
+
+    return obj_sha
+
+
+def main() -> int:
+    token = os.environ.get("GH_TOKEN", "")
+    if not token:
+        print(
+            "GH_TOKEN is not set — skipping SHA pin validation "
+            "(set GH_TOKEN to enable checks in local runs).",
+            file=sys.stderr,
+        )
+        return 0
+
+    repo_root = Path(__file__).parent.parent.parent
+    workflow_dir = repo_root / ".github" / "workflows"
+    workflow_files = sorted(workflow_dir.glob("*.yml"))
+
+    if not workflow_files:
+        print(f"No workflow files found under {workflow_dir}", file=sys.stderr)
+        return 0
+
+    failures: list[str] = []
+
+    for wf_file in workflow_files:
+        content = wf_file.read_text(encoding="utf-8")
+        for lineno, line in enumerate(content.splitlines(), start=1):
+            m = _PIN_RE.search(line)
+            if not m:
+                continue
+
+            owner = m.group("owner")
+            repo = m.group("repo")
+            pinned_sha = m.group("sha")
+            tag = m.group("tag")
+
+            print(f"  checking {owner}/{repo}@{pinned_sha[:12]}… ({tag})")
+
+            try:
+                resolved_sha = _resolve_tag_commit_sha(owner, repo, tag, token)
+            except RuntimeError as exc:
+                failures.append(
+                    f"{wf_file.name}:{lineno}: ERROR resolving {owner}/{repo} {tag}: {exc}"
+                )
+                continue
+
+            if resolved_sha is None:
+                failures.append(
+                    f"{wf_file.name}:{lineno}: tag {tag!r} not found for {owner}/{repo}"
+                )
+                continue
+
+            if resolved_sha != pinned_sha:
+                failures.append(
+                    f"{wf_file.name}:{lineno}: SHA mismatch for {owner}/{repo} {tag}\n"
+                    f"    pinned:   {pinned_sha}\n"
+                    f"    resolved: {resolved_sha}"
+                )
+            else:
+                print(f"    OK ({pinned_sha[:12]} == {tag})")
+
+    if failures:
+        print("\nSHA pin validation FAILED:", file=sys.stderr)
+        for msg in failures:
+            print(f"  {msg}", file=sys.stderr)
+        return 1
+
+    print(f"\nAll SHA pins validated successfully across {len(workflow_files)} workflow file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/examples_smoke.py
+++ b/scripts/ci/examples_smoke.py
@@ -1,0 +1,86 @@
+"""
+CI smoke runner for `examples/`.
+
+Runs every example as a subprocess, asserts it exits 0 inside a short
+timeout, and prints a one-line result per example. Intended for a
+non-blocking CI lane that keeps the examples executable without gating
+releases on environment-sensitive networking behavior.
+
+Exit code is the number of failures (0 on success).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
+REPO_ROOT = EXAMPLES_DIR.parent
+SRC_DIR = REPO_ROOT / "src"
+PER_EXAMPLE_TIMEOUT_SECONDS = 30
+
+EXAMPLE_SCRIPTS: tuple[str, ...] = (
+    "tcp_echo_server_and_client.py",
+    "udp_round_trip.py",
+    "tcp_framing_length_prefix.py",
+    "tcp_reconnect_with_heartbeat.py",
+    "backpressure_policies.py",
+)
+
+
+def run_one(script_name: str) -> bool:
+    script_path = EXAMPLES_DIR / script_name
+    if not script_path.is_file():
+        print(f"[FAIL] {script_name}: missing file at {script_path}")
+        return False
+
+    env = dict(os.environ)
+    pythonpath_parts = [str(SRC_DIR)]
+    if env.get("PYTHONPATH"):
+        pythonpath_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
+    print(f"[ RUN] {script_name}")
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(script_path)],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=PER_EXAMPLE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print(f"[FAIL] {script_name}: timeout after {exc.timeout}s")
+        return False
+
+    if completed.returncode != 0:
+        print(f"[FAIL] {script_name}: exit code {completed.returncode}")
+        if completed.stdout:
+            print("----- stdout -----")
+            print(completed.stdout)
+        if completed.stderr:
+            print("----- stderr -----")
+            print(completed.stderr)
+        return False
+
+    print(f"[ OK ] {script_name}")
+    return True
+
+
+def main() -> int:
+    if not EXAMPLES_DIR.is_dir():
+        print(f"examples directory not found at {EXAMPLES_DIR}")
+        return 1
+
+    failures = sum(0 if run_one(name) else 1 for name in EXAMPLE_SCRIPTS)
+    total = len(EXAMPLE_SCRIPTS)
+    print(f"\nexamples smoke: {total - failures}/{total} passed")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/install_single_artifact.py
+++ b/scripts/ci/install_single_artifact.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import subprocess
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install exactly one built artifact matched by a glob pattern.",
+    )
+    parser.add_argument(
+        "pattern", help="Glob pattern for an artifact path (for example: dist/*.whl)."
+    )
+    parser.add_argument(
+        "--force-reinstall",
+        action="store_true",
+        help="Pass --force-reinstall to pip install.",
+    )
+    parser.add_argument(
+        "--no-deps",
+        action="store_true",
+        help="Pass --no-deps to pip install.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    matches = sorted(glob.glob(args.pattern))
+    if len(matches) != 1:
+        raise SystemExit(
+            f"Expected exactly one artifact for pattern {args.pattern!r}, found {len(matches)}: {matches}"
+        )
+
+    pip_command = [sys.executable, "-m", "pip", "install"]
+    if args.force_reinstall:
+        pip_command.append("--force-reinstall")
+    if args.no_deps:
+        pip_command.append("--no-deps")
+    pip_command.append(matches[0])
+
+    subprocess.check_call(pip_command)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/installed_artifact_semantic_minisuite.py
+++ b/scripts/ci/installed_artifact_semantic_minisuite.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from collections import defaultdict
+from collections.abc import Callable
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BytesReceivedEvent,
+    TcpHeartbeatSettings,
+    TcpReconnectSettings,
+    TcpClientSettings,
+    TcpServerSettings,
+)
+from aionetx.api import (
+    ComponentLifecycleChangedEvent,
+    ComponentLifecycleState,
+    ConnectionOpenedEvent,
+    HeartbeatRequest,
+    HeartbeatResult,
+    NetworkEvent,
+    ReconnectAttemptFailedEvent,
+)
+
+
+class SemanticEventHandler:
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self.events: list[NetworkEvent] = []
+        self.received_payloads: list[bytes] = []
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        async with self._condition:
+            self.events.append(event)
+            if isinstance(event, BytesReceivedEvent):
+                self.received_payloads.append(event.data)
+            self._condition.notify_all()
+
+
+class _StaticHeartbeatProvider:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        del request
+        return HeartbeatResult(should_send=True, payload=self._payload)
+
+
+async def _wait_for_condition(
+    handler: SemanticEventHandler,
+    predicate: Callable[[], bool],
+    *,
+    timeout: float,
+    description: str,
+) -> None:
+    try:
+        async with handler._condition:
+            await asyncio.wait_for(handler._condition.wait_for(predicate), timeout=timeout)
+    except TimeoutError as error:
+        raise AssertionError(
+            f"installed artifact semantic mini-suite missing expected condition: {description}"
+        ) from error
+
+
+def _get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _lifecycle_sequences(handler: SemanticEventHandler) -> dict[str, list[ComponentLifecycleState]]:
+    by_resource: dict[str, list[ComponentLifecycleState]] = defaultdict(list)
+    for event in handler.events:
+        if isinstance(event, ComponentLifecycleChangedEvent):
+            by_resource[event.resource_id].append(event.current)
+    return dict(by_resource)
+
+
+def _has_ordered_subsequence(
+    sequence: list[ComponentLifecycleState], expected: list[ComponentLifecycleState]
+) -> bool:
+    index = 0
+    for state in sequence:
+        if state == expected[index]:
+            index += 1
+            if index == len(expected):
+                return True
+    return False
+
+
+async def _assert_lifecycle_and_order_semantics(factory: AsyncioNetworkFactory) -> None:
+    handler = SemanticEventHandler()
+    port = _get_unused_tcp_port()
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=handler,
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=handler,
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        payloads = [b"mini-suite-order-1", b"mini-suite-order-2", b"mini-suite-order-3"]
+        for payload in payloads:
+            await connection.send(payload)
+            await _wait_for_condition(
+                handler,
+                lambda payload=payload: payload in handler.received_payloads,
+                timeout=3.0,
+                description=f"ordered byte receive for {payload!r}",
+            )
+
+        received_subset = [p for p in handler.received_payloads if p in payloads]
+        assert received_subset[: len(payloads)] == payloads, (
+            "expected in-order sequential bytes delivery for single connection, "
+            f"got {received_subset[: len(payloads)]!r}"
+        )
+    finally:
+        await client.stop()
+        await server.stop()
+
+    expected_lifecycle = [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    lifecycle_by_resource = _lifecycle_sequences(handler)
+    assert any(
+        _has_ordered_subsequence(states, expected_lifecycle)
+        for states in lifecycle_by_resource.values()
+    ), (
+        "expected at least one managed transport lifecycle STARTING→RUNNING→STOPPING→STOPPED sequence"
+    )
+
+
+async def _assert_reconnect_failure_and_recovery(factory: AsyncioNetworkFactory) -> None:
+    handler = SemanticEventHandler()
+    port = _get_unused_tcp_port()
+
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.1,
+                backoff_factor=1.0,
+            ),
+        ),
+        event_handler=handler,
+    )
+
+    await client.start()
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=handler,
+    )
+    try:
+        await _wait_for_condition(
+            handler,
+            lambda: any(isinstance(event, ReconnectAttemptFailedEvent) for event in handler.events),
+            timeout=3.0,
+            description="reconnect failure before server starts",
+        )
+
+        await server.start()
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        payload = b"mini-suite-reconnect-recovered"
+        await connection.send(payload)
+
+        await _wait_for_condition(
+            handler,
+            lambda: payload in handler.received_payloads,
+            timeout=3.0,
+            description="reconnect recovery with successful send",
+        )
+
+        assert any(isinstance(event, ConnectionOpenedEvent) for event in handler.events), (
+            "expected a connection-opened event after reconnect recovery"
+        )
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+async def _assert_heartbeat_semantics(factory: AsyncioNetworkFactory) -> None:
+    handler = SemanticEventHandler()
+    port = _get_unused_tcp_port()
+    heartbeat_payload = b"mini-suite-heartbeat"
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.05),
+        ),
+        heartbeat_provider=_StaticHeartbeatProvider(heartbeat_payload),
+        event_handler=handler,
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=handler,
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await _wait_for_condition(
+            handler,
+            lambda: heartbeat_payload in handler.received_payloads,
+            timeout=3.0,
+            description="heartbeat payload emission",
+        )
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+async def main() -> None:
+    factory = AsyncioNetworkFactory()
+    await _assert_lifecycle_and_order_semantics(factory)
+    await _assert_reconnect_failure_and_recovery(factory)
+    await _assert_heartbeat_semantics(factory)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ci/installed_artifact_smoke.py
+++ b/scripts/ci/installed_artifact_smoke.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from collections.abc import Callable
+from importlib.metadata import version as package_version
+
+import aionetx
+from aionetx import (
+    AsyncioNetworkFactory,
+    BytesReceivedEvent,
+    TcpReconnectSettings,
+    TcpClientSettings,
+    TcpServerSettings,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+from aionetx.api import NetworkEvent, ReconnectAttemptFailedEvent
+
+# Verify __version__ is present, non-empty, and matches expected pyproject.toml version.
+assert hasattr(aionetx, "__version__"), "aionetx.__version__ is missing from installed package"
+assert isinstance(aionetx.__version__, str) and aionetx.__version__, (
+    f"aionetx.__version__ must be a non-empty string; got {aionetx.__version__!r}"
+)
+assert aionetx.__version__ == package_version("aionetx"), (
+    "aionetx.__version__ must match installed package metadata; "
+    f"got {aionetx.__version__!r} vs {package_version('aionetx')!r}"
+)
+
+
+class SmokeEventHandler:
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self.events: list[NetworkEvent] = []
+        self.received_payloads: list[bytes] = []
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        async with self._condition:
+            self.events.append(event)
+            if isinstance(event, BytesReceivedEvent):
+                self.received_payloads.append(event.data)
+            self._condition.notify_all()
+
+
+async def _wait_for_event(
+    handler: SmokeEventHandler,
+    predicate: Callable[[], bool],
+    *,
+    timeout: float,
+    description: str,
+) -> None:
+    try:
+        async with handler._condition:
+            await asyncio.wait_for(handler._condition.wait_for(predicate), timeout=timeout)
+    except TimeoutError as error:
+        raise AssertionError(
+            f"installed artifact smoke did not observe expected event: {description}"
+        ) from error
+
+
+def _get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _get_unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _run_tcp_roundtrip_smoke(
+    factory: AsyncioNetworkFactory, handler: SmokeEventHandler
+) -> None:
+    port = _get_unused_tcp_port()
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=handler,
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=handler,
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        payload = b"installed-artifact-smoke-tcp"
+        await connection.send(payload)
+        await _wait_for_event(
+            handler,
+            lambda: payload in handler.received_payloads,
+            timeout=3.0,
+            description="TCP payload loopback",
+        )
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+async def _run_udp_roundtrip_smoke(
+    factory: AsyncioNetworkFactory, handler: SmokeEventHandler
+) -> None:
+    port = _get_unused_udp_port()
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=handler,
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    await receiver.start()
+    try:
+        payload = b"installed-artifact-smoke-udp"
+        await sender.send(payload)
+        await _wait_for_event(
+            handler,
+            lambda: payload in handler.received_payloads,
+            timeout=3.0,
+            description="UDP payload receive",
+        )
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+
+async def _run_reconnect_smoke(factory: AsyncioNetworkFactory, handler: SmokeEventHandler) -> None:
+    port = _get_unused_tcp_port()
+    reconnecting_client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.1,
+                backoff_factor=1.0,
+            ),
+        ),
+        event_handler=handler,
+    )
+
+    await reconnecting_client.start()
+    try:
+        await _wait_for_event(
+            handler,
+            lambda: any(isinstance(event, ReconnectAttemptFailedEvent) for event in handler.events),
+            timeout=3.0,
+            description="reconnect failure event",
+        )
+    finally:
+        await reconnecting_client.stop()
+
+
+async def main() -> None:
+    handler = SmokeEventHandler()
+    factory = AsyncioNetworkFactory()
+
+    await _run_tcp_roundtrip_smoke(factory, handler)
+    await _run_udp_roundtrip_smoke(factory, handler)
+    await _run_reconnect_smoke(factory, handler)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ci/installed_artifact_smoke.py
+++ b/scripts/ci/installed_artifact_smoke.py
@@ -6,16 +6,15 @@ from collections.abc import Callable
 from importlib.metadata import version as package_version
 
 import aionetx
-from aionetx import (
-    AsyncioNetworkFactory,
-    BytesReceivedEvent,
-    TcpReconnectSettings,
-    TcpClientSettings,
-    TcpServerSettings,
-    UdpReceiverSettings,
-    UdpSenderSettings,
-)
 from aionetx.api import NetworkEvent, ReconnectAttemptFailedEvent
+
+AsyncioNetworkFactory = aionetx.AsyncioNetworkFactory
+BytesReceivedEvent = aionetx.BytesReceivedEvent
+TcpClientSettings = aionetx.TcpClientSettings
+TcpReconnectSettings = aionetx.TcpReconnectSettings
+TcpServerSettings = aionetx.TcpServerSettings
+UdpReceiverSettings = aionetx.UdpReceiverSettings
+UdpSenderSettings = aionetx.UdpSenderSettings
 
 # Verify __version__ is present, non-empty, and matches expected pyproject.toml version.
 assert hasattr(aionetx, "__version__"), "aionetx.__version__ is missing from installed package"

--- a/scripts/ci/validate_release_provenance.py
+++ b/scripts/ci/validate_release_provenance.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
+
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[a-zA-Z0-9.\-+]+)?$")
+
+
+def read_pyproject_version(pyproject_path: pathlib.Path = pathlib.Path("pyproject.toml")) -> str:
+    if tomllib is None:
+        raise RuntimeError(
+            "validate_release_provenance.py requires the stdlib tomllib module or the "
+            "'tomli' backport to parse pyproject.toml. Use Python 3.11+ or install "
+            "'tomli' when running on Python 3.10."
+        )
+    with pyproject_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    try:
+        version = data["project"]["version"]
+    except KeyError:
+        raise AssertionError("Could not read [project].version from pyproject.toml.") from None
+    if not isinstance(version, str):
+        raise AssertionError(f"[project].version in pyproject.toml is not a string: {version!r}")
+    return version
+
+
+def validate_tag_release(tag_name: str, pyproject_version: str) -> None:
+    expected_tag = f"v{pyproject_version}"
+    if tag_name != expected_tag:
+        raise AssertionError(
+            f"Tag/version mismatch: tag is {tag_name!r}, pyproject version is "
+            f"{pyproject_version!r} (expected tag {expected_tag!r})"
+        )
+
+
+def validate_manual_testpypi_release(
+    *,
+    event_name: str,
+    publish_target: str,
+    declared_release_version: str,
+    pyproject_version: str,
+) -> None:
+    if event_name != "workflow_dispatch" or publish_target != "testpypi":
+        raise AssertionError(
+            "Manual TestPyPI provenance check can only run for "
+            "workflow_dispatch with publish_target=testpypi."
+        )
+    if not declared_release_version:
+        raise AssertionError(
+            "Manual TestPyPI publish requires RELEASE_VERSION input (expected pyproject version)."
+        )
+    if not SEMVER_RE.match(declared_release_version):
+        raise AssertionError(
+            f"Invalid RELEASE_VERSION format {declared_release_version!r}; expected semver-like format."
+        )
+    if declared_release_version != pyproject_version:
+        raise AssertionError(
+            f"Release provenance mismatch: RELEASE_VERSION is {declared_release_version!r}, "
+            f"but pyproject version is {pyproject_version!r}."
+        )
+
+
+def main() -> None:
+    pyproject_version = read_pyproject_version()
+    tag_name = os.getenv("TAG_NAME", "")
+    event_name = os.getenv("EVENT_NAME", "")
+    publish_target = os.getenv("PUBLISH_TARGET", "")
+    declared_release_version = os.getenv("RELEASE_VERSION", "")
+
+    if event_name == "workflow_dispatch" and publish_target == "testpypi":
+        validate_manual_testpypi_release(
+            event_name=event_name,
+            publish_target=publish_target,
+            declared_release_version=declared_release_version,
+            pyproject_version=pyproject_version,
+        )
+        print(
+            "Manual TestPyPI provenance verified: "
+            f"RELEASE_VERSION={declared_release_version} matches pyproject version {pyproject_version}."
+        )
+        return
+
+    if tag_name:
+        validate_tag_release(tag_name=tag_name, pyproject_version=pyproject_version)
+        print(f"Tag/version match verified: {tag_name}")
+        return
+
+    raise AssertionError(
+        "Unsupported provenance check context. Expected either a tag-triggered release "
+        "or workflow_dispatch with publish_target=testpypi."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aionetx/__init__.py
+++ b/src/aionetx/__init__.py
@@ -1,0 +1,65 @@
+"""
+aionetx — asyncio-first transport library for TCP and UDP networking.
+
+This package exposes a curated, stable public API via :data:`PUBLIC_API`.
+The recommended entry point for application code is
+:class:`AsyncioNetworkFactory`, which produces managed TCP/UDP transports
+driven by dataclass-based settings (``TcpClientSettings``, ``TcpServerSettings``,
+``UdpReceiverSettings``, ``UdpSenderSettings``, ``MulticastReceiverSettings``).
+
+Advanced event-handler composition helpers live alongside the factory
+(``BaseNetworkEventHandler``, ``NetworkEvent``, ``BytesReceivedEvent``).
+Transport-protocol interfaces, concrete event subclasses, and additional
+errors are available from :mod:`aionetx.api` for users who need the full
+curated surface. Anything under :mod:`aionetx.implementations` is internal.
+"""
+
+from importlib.metadata import version as _metadata_version
+
+try:
+    __version__: str = _metadata_version("aionetx")
+except Exception:  # pragma: no cover — package not installed in editable mode rarely
+    __version__ = "0.0.0.dev0"
+
+from aionetx.api import (
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    ComponentLifecycleState,
+    EventDeliverySettings,
+    HeartbeatConfigurationError,
+    HeartbeatProviderProtocol,
+    MulticastReceiverSettings,
+    NetworkEvent,
+    TcpHeartbeatSettings,
+    TcpReconnectSettings,
+    TcpClientSettings,
+    TcpServerSettings,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+from aionetx.factories import AsyncioNetworkFactory
+
+# Public API governance:
+# - `__all__` is the canonical curated export list for this module.
+# - `PUBLIC_API` is derived from `__all__` for downstream introspection/testing.
+# - `aionetx.implementations.*` remains internal/advanced and may change.
+__all__ = (
+    "__version__",
+    "AsyncioNetworkFactory",
+    "BaseNetworkEventHandler",
+    "BytesReceivedEvent",
+    "ComponentLifecycleState",
+    "EventDeliverySettings",
+    "HeartbeatConfigurationError",
+    "HeartbeatProviderProtocol",
+    "TcpHeartbeatSettings",
+    "MulticastReceiverSettings",
+    "NetworkEvent",
+    "TcpReconnectSettings",
+    "TcpClientSettings",
+    "TcpServerSettings",
+    "UdpReceiverSettings",
+    "UdpSenderSettings",
+)
+
+PUBLIC_API = tuple(__all__)

--- a/src/aionetx/api/__init__.py
+++ b/src/aionetx/api/__init__.py
@@ -1,0 +1,129 @@
+"""
+Curated advanced API surface for ``aionetx``.
+
+This package groups public event types, lifecycle models, protocols, settings,
+and selected exceptions for users who want more control than the package-root
+imports provide.
+"""
+
+from aionetx.api.events import (
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    ComponentLifecycleChangedEvent,
+    ConnectionClosedEvent,
+    ConnectionOpenedEvent,
+    ConnectionRejectedEvent,
+    HandlerFailurePolicyStopEvent,
+    NetworkErrorEvent,
+    NetworkEvent,
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+from aionetx.api.lifecycle import (
+    ComponentLifecycleState,
+    ConnectionMetadata,
+    ConnectionRole,
+    ConnectionState,
+)
+from aionetx.api.errors import (
+    ConnectionClosedError,
+    HeartbeatConfigurationError,
+    InvalidNetworkConfigurationError,
+    NetworkConfigurationError,
+    NetworkLayerError,
+    NetworkRuntimeError,
+)
+from aionetx.api.heartbeat import HeartbeatRequest, HeartbeatResult, TcpHeartbeatSettings
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.policies import (
+    ErrorPolicy,
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+    ReconnectJitter,
+)
+from aionetx.api.protocols import (
+    ConnectionProtocol,
+    HeartbeatProviderProtocol,
+    MulticastReceiverProtocol,
+    NetworkFactory,
+    TcpClientProtocol,
+    TcpServerProtocol,
+    UdpReceiverProtocol,
+    UdpSenderProtocol,
+)
+from aionetx.api.settings import (
+    MulticastReceiverSettings,
+    TcpClientSettings,
+    TcpReconnectSettings,
+    TcpServerSettings,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+from aionetx.api.udp import (
+    UdpInvalidTargetError,
+    UdpSenderStoppedError,
+)
+from aionetx.api.typed_event_router import TypedEventRouter
+
+# Public API governance:
+# - ``__all__`` is the canonical curated export list for this module.
+# - ``PUBLIC_API`` mirrors that list for tests and introspection helpers.
+# - Underscore-prefixed modules remain internal unless explicitly promoted here.
+# - Any type reachable from a public signature should be importable from this
+#   curated API surface so callers do not need to reach into internal modules.
+__all__ = (
+    "BaseNetworkEventHandler",
+    "BytesReceivedEvent",
+    "ComponentLifecycleChangedEvent",
+    "ComponentLifecycleState",
+    "ConnectionClosedError",
+    "ConnectionClosedEvent",
+    "ConnectionMetadata",
+    "ConnectionOpenedEvent",
+    "ConnectionRejectedEvent",
+    "ConnectionProtocol",
+    "ConnectionRole",
+    "ConnectionState",
+    "ErrorPolicy",
+    "EventBackpressurePolicy",
+    "EventDeliverySettings",
+    "EventDispatchMode",
+    "EventHandlerFailurePolicy",
+    "HandlerFailurePolicyStopEvent",
+    "HeartbeatConfigurationError",
+    "HeartbeatProviderProtocol",
+    "HeartbeatRequest",
+    "HeartbeatResult",
+    "TcpHeartbeatSettings",
+    "InvalidNetworkConfigurationError",
+    "MulticastReceiverProtocol",
+    "MulticastReceiverSettings",
+    "NetworkConfigurationError",
+    "NetworkFactory",
+    "NetworkErrorEvent",
+    "NetworkEvent",
+    "NetworkEventHandlerProtocol",
+    "NetworkLayerError",
+    "NetworkRuntimeError",
+    "ReconnectAttemptFailedEvent",
+    "ReconnectAttemptStartedEvent",
+    "ReconnectJitter",
+    "ReconnectScheduledEvent",
+    "TcpReconnectSettings",
+    "TcpClientProtocol",
+    "TcpClientSettings",
+    "TcpServerProtocol",
+    "TcpServerSettings",
+    "TypedEventRouter",
+    "UdpInvalidTargetError",
+    "UdpReceiverProtocol",
+    "UdpReceiverSettings",
+    "UdpSenderProtocol",
+    "UdpSenderSettings",
+    "UdpSenderStoppedError",
+)
+
+PUBLIC_API = tuple(__all__)

--- a/src/aionetx/api/_event_registry.py
+++ b/src/aionetx/api/_event_registry.py
@@ -168,3 +168,15 @@ def validate_network_event_registry_conformance(
 
 
 validate_network_event_registry_conformance(NetworkEvent, NETWORK_EVENT_REGISTRY)
+
+__all__ = (
+    "EventHandlerMethod",
+    "EventRegistryEntry",
+    "EventType",
+    "NETWORK_EVENT_HANDLER_METHODS",
+    "NETWORK_EVENT_RECORDING_BUCKETS",
+    "NETWORK_EVENT_REGISTRY",
+    "NETWORK_EVENT_TYPES",
+    "NetworkEvent",
+    "validate_network_event_registry_conformance",
+)

--- a/src/aionetx/api/_event_registry.py
+++ b/src/aionetx/api/_event_registry.py
@@ -1,0 +1,170 @@
+"""
+Internal taxonomy registry for all emitted network event types.
+
+The registry in this module is the single source of truth for the open
+``NetworkEvent`` union, typed hook names, and recording bucket names used by
+testing helpers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias, get_args
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_events import (
+    ConnectionClosedEvent,
+    ConnectionOpenedEvent,
+    ConnectionRejectedEvent,
+)
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+NetworkEvent: TypeAlias = (
+    ConnectionOpenedEvent
+    | ConnectionRejectedEvent
+    | ConnectionClosedEvent
+    | BytesReceivedEvent
+    | NetworkErrorEvent
+    | HandlerFailurePolicyStopEvent
+    | ComponentLifecycleChangedEvent
+    | ReconnectAttemptStartedEvent
+    | ReconnectAttemptFailedEvent
+    | ReconnectScheduledEvent
+)
+EventType: TypeAlias = type[NetworkEvent]
+EventHandlerMethod: TypeAlias = Callable[[Any], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class EventRegistryEntry:
+    """Canonical taxonomy entry for one network event type."""
+
+    event_type: EventType
+    handler_method_name: str
+    recording_bucket_name: str
+
+
+NETWORK_EVENT_REGISTRY: tuple[EventRegistryEntry, ...] = (
+    EventRegistryEntry(
+        event_type=ConnectionOpenedEvent,
+        handler_method_name="on_connection_opened",
+        recording_bucket_name="opened_events",
+    ),
+    EventRegistryEntry(
+        event_type=ConnectionRejectedEvent,
+        handler_method_name="on_connection_rejected",
+        recording_bucket_name="rejected_events",
+    ),
+    EventRegistryEntry(
+        event_type=ConnectionClosedEvent,
+        handler_method_name="on_connection_closed",
+        recording_bucket_name="closed_events",
+    ),
+    EventRegistryEntry(
+        event_type=BytesReceivedEvent,
+        handler_method_name="on_bytes_received",
+        recording_bucket_name="received_events",
+    ),
+    EventRegistryEntry(
+        event_type=NetworkErrorEvent,
+        handler_method_name="on_error",
+        recording_bucket_name="error_events",
+    ),
+    EventRegistryEntry(
+        event_type=HandlerFailurePolicyStopEvent,
+        handler_method_name="on_handler_failure_policy_stop",
+        recording_bucket_name="handler_failure_policy_stop_events",
+    ),
+    EventRegistryEntry(
+        event_type=ComponentLifecycleChangedEvent,
+        handler_method_name="on_component_lifecycle_changed",
+        recording_bucket_name="lifecycle_events",
+    ),
+    EventRegistryEntry(
+        event_type=ReconnectAttemptStartedEvent,
+        handler_method_name="on_reconnect_attempt_started",
+        recording_bucket_name="reconnect_attempt_started_events",
+    ),
+    EventRegistryEntry(
+        event_type=ReconnectAttemptFailedEvent,
+        handler_method_name="on_reconnect_attempt_failed",
+        recording_bucket_name="reconnect_attempt_failed_events",
+    ),
+    EventRegistryEntry(
+        event_type=ReconnectScheduledEvent,
+        handler_method_name="on_reconnect_scheduled",
+        recording_bucket_name="reconnect_scheduled_events",
+    ),
+)
+
+# Keep ``NETWORK_EVENT_REGISTRY`` as the taxonomy source of truth. Conformance
+# checks below ensure that the open ``NetworkEvent`` union, typed event hooks,
+# and testing collectors stay aligned with the same event set.
+
+NETWORK_EVENT_TYPES: tuple[EventType, ...] = tuple(
+    entry.event_type for entry in NETWORK_EVENT_REGISTRY
+)
+NETWORK_EVENT_HANDLER_METHODS: dict[EventType, str] = {
+    entry.event_type: entry.handler_method_name for entry in NETWORK_EVENT_REGISTRY
+}
+NETWORK_EVENT_RECORDING_BUCKETS: dict[EventType, str] = {
+    entry.event_type: entry.recording_bucket_name for entry in NETWORK_EVENT_REGISTRY
+}
+
+
+def validate_network_event_registry_conformance(
+    network_event_union: object,
+    registry: tuple[EventRegistryEntry, ...],
+) -> None:
+    """
+    Validate that the event union and taxonomy registry describe the same types.
+
+    Args:
+        network_event_union: Union object representing the public event taxonomy.
+        registry: Registry entries that define hook names and recording buckets.
+
+    Raises:
+        RuntimeError: If the union and registry have drifted apart.
+    """
+    union_event_types = tuple(get_args(network_event_union))
+    registry_event_types = tuple(entry.event_type for entry in registry)
+
+    missing_from_registry = [
+        event_type.__name__
+        for event_type in union_event_types
+        if event_type not in registry_event_types
+    ]
+    extra_in_registry = [
+        event_type.__name__
+        for event_type in registry_event_types
+        if event_type not in union_event_types
+    ]
+
+    if not missing_from_registry and not extra_in_registry:
+        return
+
+    message_parts: list[str] = [
+        "Network event registry drift detected.",
+        "Update `NetworkEvent` and `NETWORK_EVENT_REGISTRY` together.",
+    ]
+    if missing_from_registry:
+        message_parts.append(
+            f"Missing registry entries for: {', '.join(sorted(missing_from_registry))}."
+        )
+    if extra_in_registry:
+        message_parts.append(
+            f"Registry contains events missing from the union: {', '.join(sorted(extra_in_registry))}."
+        )
+
+    raise RuntimeError(" ".join(message_parts))
+
+
+validate_network_event_registry_conformance(NetworkEvent, NETWORK_EVENT_REGISTRY)

--- a/src/aionetx/api/_validation.py
+++ b/src/aionetx/api/_validation.py
@@ -1,0 +1,104 @@
+"""Internal validation helpers for public settings dataclasses."""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from numbers import Real
+from typing import TypeVar
+
+from aionetx.api.errors import InvalidNetworkConfigurationError
+
+_TEnum = TypeVar("_TEnum", bound=Enum)
+_ErrorType = type[Exception]
+
+
+def require_bool(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> bool:
+    if type(value) is not bool:
+        raise error_type(f"{field_name} must be a bool.")
+    return value
+
+
+def require_non_empty_str(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise error_type(f"{field_name} must not be empty or whitespace-only.")
+    return value
+
+
+def require_optional_non_empty_str(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> str | None:
+    if value is None:
+        return None
+    return require_non_empty_str(field_name=field_name, value=value, error_type=error_type)
+
+
+def require_int_range(
+    *,
+    field_name: str,
+    value: object,
+    min_value: int,
+    max_value: int,
+    error_type: _ErrorType = InvalidNetworkConfigurationError,
+) -> int:
+    if type(value) is not int or not (min_value <= value <= max_value):
+        raise error_type(f"{field_name} must be between {min_value} and {max_value}.")
+    return value
+
+
+def require_positive_int(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> int:
+    if type(value) is not int or value <= 0:
+        raise error_type(f"{field_name} must be > 0.")
+    return value
+
+
+def require_positive_finite_number(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise error_type(f"{field_name} must be a finite number > 0.")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise error_type(f"{field_name} must be a finite number > 0.")
+    return number
+
+
+def require_optional_positive_finite_number(
+    *, field_name: str, value: object, error_type: _ErrorType = InvalidNetworkConfigurationError
+) -> float | None:
+    if value is None:
+        return None
+    return require_positive_finite_number(field_name=field_name, value=value, error_type=error_type)
+
+
+def require_finite_number_at_least(
+    *,
+    field_name: str,
+    value: object,
+    minimum: float,
+    error_type: _ErrorType = InvalidNetworkConfigurationError,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise error_type(f"{field_name} must be a finite number >= {minimum}.")
+    number = float(value)
+    if not math.isfinite(number) or number < minimum:
+        raise error_type(f"{field_name} must be a finite number >= {minimum}.")
+    return number
+
+
+def require_enum_member(
+    *,
+    field_name: str,
+    value: object,
+    enum_type: type[_TEnum],
+    error_type: _ErrorType = InvalidNetworkConfigurationError,
+) -> _TEnum:
+    if not isinstance(value, enum_type):
+        raise error_type(f"{field_name} must be a {enum_type.__name__} value.")
+    return value

--- a/src/aionetx/api/base_network_event_handler.py
+++ b/src/aionetx/api/base_network_event_handler.py
@@ -1,0 +1,113 @@
+"""
+Typed hook dispatch helpers for unified network event handling.
+
+This module exposes :class:`BaseNetworkEventHandler`, a convenience base class
+that keeps the single ``on_event(event)`` callback contract while letting
+applications override per-event async hooks instead of writing their own
+``isinstance`` dispatch ladder.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_events import (
+    ConnectionClosedEvent,
+    ConnectionOpenedEvent,
+    ConnectionRejectedEvent,
+)
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api._event_registry import EventHandlerMethod, NETWORK_EVENT_HANDLER_METHODS
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+
+class BaseNetworkEventHandler(NetworkEventHandlerProtocol):
+    """
+    Convenience base class with typed no-op hooks.
+
+    `NetworkEventHandlerProtocol` stays unified as `on_event(event)`.
+    This class keeps that contract but provides optional typed hooks so users can
+    implement readable per-event handlers without writing isinstance chains.
+    """
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        """
+        Route one network event to the matching typed hook.
+
+        Args:
+            event: Event instance emitted by a transport or component.
+        """
+        for event_type, handler_name in NETWORK_EVENT_HANDLER_METHODS.items():
+            if isinstance(event, event_type):
+                handler = cast(EventHandlerMethod, getattr(self, handler_name))
+                await handler(event)
+                break
+        return None
+
+    async def on_connection_opened(self, event: ConnectionOpenedEvent) -> None:
+        """Handle ``ConnectionOpenedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_connection_closed(self, event: ConnectionClosedEvent) -> None:
+        """Handle ``ConnectionClosedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_connection_rejected(self, event: ConnectionRejectedEvent) -> None:
+        """Handle ``ConnectionRejectedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        """Handle ``BytesReceivedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_error(self, event: NetworkErrorEvent) -> None:
+        """Handle ``NetworkErrorEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_handler_failure_policy_stop(self, event: HandlerFailurePolicyStopEvent) -> None:
+        """Handle ``HandlerFailurePolicyStopEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_component_lifecycle_changed(
+        self,
+        event: ComponentLifecycleChangedEvent,
+    ) -> None:
+        """Handle ``ComponentLifecycleChangedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_reconnect_attempt_started(
+        self,
+        event: ReconnectAttemptStartedEvent,
+    ) -> None:
+        """Handle ``ReconnectAttemptStartedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_reconnect_attempt_failed(
+        self,
+        event: ReconnectAttemptFailedEvent,
+    ) -> None:
+        """Handle ``ReconnectAttemptFailedEvent`` with a default no-op implementation."""
+        del event
+        return None
+
+    async def on_reconnect_scheduled(self, event: ReconnectScheduledEvent) -> None:
+        """Handle ``ReconnectScheduledEvent`` with a default no-op implementation."""
+        del event
+        return None

--- a/src/aionetx/api/byte_sender_protocol.py
+++ b/src/aionetx/api/byte_sender_protocol.py
@@ -32,4 +32,4 @@ class ByteSenderProtocol(Protocol):
         by the local transport path; it does not guarantee remote delivery.
         Role-specific protocols document their concrete exceptions.
         """
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/byte_sender_protocol.py
+++ b/src/aionetx/api/byte_sender_protocol.py
@@ -1,0 +1,35 @@
+"""
+Shared capability protocol for bytes-like send operations.
+
+This module defines the narrowest send contract used across stream and
+datagram transports. Role-specific protocols layer lifecycle, addressing, and
+connection semantics on top of this capability.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aionetx.api.bytes_like import BytesLike
+
+
+class ByteSenderProtocol(Protocol):
+    """
+    Capability protocol for components that can send raw bytes-like payloads.
+
+    This capability means only: "can send bytes-like payloads". It does not
+    imply shared addressing semantics (connected stream vs datagram target),
+    shared lifecycle model, or shared connection supervision behavior.
+    Use role-specific protocols when you need transport-specific guarantees.
+    """
+
+    async def send(self, data: BytesLike) -> None:
+        """
+        Send raw bytes-like payload.
+
+        Implementations may differ in lifecycle, addressing, and transport
+        failure semantics. A successful return means the payload was accepted
+        by the local transport path; it does not guarantee remote delivery.
+        Role-specific protocols document their concrete exceptions.
+        """
+        ...

--- a/src/aionetx/api/bytes_like.py
+++ b/src/aionetx/api/bytes_like.py
@@ -1,0 +1,12 @@
+"""
+Shared bytes-like payload alias used across transport APIs.
+
+``BytesLike`` intentionally matches the payload types accepted by Python's
+socket and stream APIs: ``bytes``, ``bytearray``, and ``memoryview``.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+BytesLike: TypeAlias = bytes | bytearray | memoryview

--- a/src/aionetx/api/bytes_like.py
+++ b/src/aionetx/api/bytes_like.py
@@ -10,3 +10,5 @@ from __future__ import annotations
 from typing import TypeAlias
 
 BytesLike: TypeAlias = bytes | bytearray | memoryview
+
+__all__ = ("BytesLike",)

--- a/src/aionetx/api/bytes_received_event.py
+++ b/src/aionetx/api/bytes_received_event.py
@@ -1,0 +1,30 @@
+"""
+Event type for raw transport payload delivery.
+
+The dataclass in this module is emitted by stream, UDP, and multicast receivers
+whenever bytes are read from the underlying transport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BytesReceivedEvent:
+    """
+    Event emitted when raw bytes are read from a transport.
+
+    Attributes:
+        resource_id: Identifier of the transport/source stream.
+        data: Raw transport payload bytes with no framing/parsing.
+        remote_host: Optional remote sender host metadata (typically present for
+            UDP/multicast datagrams, may be None for stream transports).
+        remote_port: Optional remote sender port metadata (typically present for
+            UDP/multicast datagrams, may be None for stream transports).
+    """
+
+    resource_id: str
+    data: bytes
+    remote_host: str | None = None
+    remote_port: int | None = None

--- a/src/aionetx/api/component_lifecycle_changed_event.py
+++ b/src/aionetx/api/component_lifecycle_changed_event.py
@@ -1,0 +1,30 @@
+"""
+Event type describing managed component lifecycle transitions.
+
+Managed transports emit this dataclass whenever their component lifecycle state
+changes, for example during startup, steady-state operation, or shutdown.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentLifecycleChangedEvent:
+    """
+    Event emitted when a managed component lifecycle state changes.
+
+    Attributes:
+        resource_id: Identifier of the component whose lifecycle changed.
+        previous: Lifecycle state before the transition.
+        current: Lifecycle state after the transition.
+        reason: Optional implementation-supplied explanation for the transition.
+    """
+
+    resource_id: str
+    previous: ComponentLifecycleState
+    current: ComponentLifecycleState
+    reason: str | None = None

--- a/src/aionetx/api/component_lifecycle_state.py
+++ b/src/aionetx/api/component_lifecycle_state.py
@@ -1,0 +1,19 @@
+"""
+Lifecycle-state enum for managed network components.
+
+These states apply to top-level managed transports such as TCP clients,
+servers, and datagram receivers.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ComponentLifecycleState(str, Enum):
+    """Lifecycle state for top-level network components."""
+
+    STOPPED = "stopped"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"

--- a/src/aionetx/api/connection_events.py
+++ b/src/aionetx/api/connection_events.py
@@ -1,0 +1,71 @@
+"""
+Connection lifecycle event dataclasses.
+
+These events describe when a logical connection becomes available and when it
+reaches its terminal closed state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionState
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionOpenedEvent:
+    """
+    Event emitted when a connection becomes available for data transfer.
+
+    Attributes:
+        resource_id (str): Identifier of the opened connection.
+        metadata (ConnectionMetadata): Metadata snapshot captured at open time.
+    """
+
+    resource_id: str
+    metadata: ConnectionMetadata
+
+    def __post_init__(self) -> None:
+        if self.resource_id != self.metadata.connection_id:
+            raise ValueError("resource_id must match metadata.connection_id.")
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionClosedEvent:
+    """
+    Event emitted exactly once when a connection transitions to closed.
+
+    Attributes:
+        resource_id (str): Identifier of the connection that was closed.
+        previous_state (ConnectionState): Lifecycle state immediately before closure.
+        metadata (ConnectionMetadata | None): Transport metadata snapshot when
+            available from the implementation. This is populated for normal TCP
+            connection closes and for datagram receivers after a successful
+            start/open sequence. It may be ``None`` when close occurs before
+            metadata could be established.
+    """
+
+    resource_id: str
+    previous_state: ConnectionState
+    metadata: ConnectionMetadata | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionRejectedEvent:
+    """
+    Event emitted when a TCP server rejects an incoming connection attempt.
+
+    Attributes:
+        resource_id: Identifier of the rejecting server component.
+        connection_id: Stable identifier assigned to the rejected attempt.
+        reason: Machine-readable rejection reason.
+        remote_host: Best-effort remote peer host when available.
+        remote_port: Best-effort remote peer port when available.
+    """
+
+    resource_id: str
+    connection_id: str
+    reason: str
+    remote_host: str | None = None
+    remote_port: int | None = None

--- a/src/aionetx/api/connection_lifecycle.py
+++ b/src/aionetx/api/connection_lifecycle.py
@@ -1,0 +1,29 @@
+"""
+Enums describing connection roles and connection-level lifecycle states.
+
+These enums are shared by TCP connections and datagram receiver abstractions
+when they report logical connection identity and state.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ConnectionRole(str, Enum):
+    """Logical role assigned to a connection for lifecycle/event reporting."""
+
+    CLIENT = "client"
+    SERVER = "server"
+    MULTICAST_RECEIVER = "multicast_receiver"
+    UDP_RECEIVER = "udp_receiver"
+
+
+class ConnectionState(str, Enum):
+    """Lifecycle state used by connection implementations."""
+
+    CREATED = "created"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    CLOSING = "closing"
+    CLOSED = "closed"

--- a/src/aionetx/api/connection_metadata.py
+++ b/src/aionetx/api/connection_metadata.py
@@ -1,0 +1,34 @@
+"""
+Connection metadata model shared by emitted lifecycle events.
+
+The dataclass in this module carries stable connection identity plus optional
+local and remote addressing details when implementations can provide them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.connection_lifecycle import ConnectionRole
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionMetadata:
+    """
+    Transport-level metadata describing one logical connection.
+
+    Attributes:
+        connection_id (str): Stable ID used in all events for this connection.
+        role (ConnectionRole): Role of this endpoint (client/server/multicast receiver).
+        local_host (str | None): Local interface address when available.
+        local_port (int | None): Local interface port when available.
+        remote_host (str | None): Peer address when available.
+        remote_port (int | None): Peer port when available.
+    """
+
+    connection_id: str
+    role: ConnectionRole
+    local_host: str | None = None
+    local_port: int | None = None
+    remote_host: str | None = None
+    remote_port: int | None = None

--- a/src/aionetx/api/connection_protocol.py
+++ b/src/aionetx/api/connection_protocol.py
@@ -1,0 +1,75 @@
+"""
+Shared public protocol for logical network connections.
+
+This module defines the stable surface that concrete TCP connection
+implementations expose to callers and to higher-level transport abstractions.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aionetx.api.byte_sender_protocol import ByteSenderProtocol
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+
+
+class ConnectionProtocol(ByteSenderProtocol, Protocol):
+    """
+    Role-specific connection contract built on shared send capability.
+
+    A connection models one logical TCP session owned by a managed client or
+    server. Identifiers and metadata are part of the observable contract and
+    are used to correlate send/receive/lifecycle events.
+    """
+
+    @property
+    def connection_id(self) -> str:
+        """Return a stable identifier used for correlation in emitted events."""
+        ...
+
+    @property
+    def role(self) -> ConnectionRole:
+        """Return the logical role of the connection endpoint."""
+        ...
+
+    @property
+    def state(self) -> ConnectionState:
+        """Return the current lifecycle state."""
+        ...
+
+    @property
+    def is_connected(self) -> bool:
+        """Return ``True`` when ``send`` is expected to succeed."""
+        ...
+
+    @property
+    def metadata(self) -> ConnectionMetadata:
+        """Return immutable transport metadata for this connection."""
+        ...
+
+    async def send(self, data: BytesLike) -> None:
+        """
+        Send raw bytes-like payload over the transport.
+
+        Args:
+            data: Bytes-like payload to write to the peer.
+
+        Raises:
+            ConnectionClosedError: When the connection is already known to be closed.
+            TypeError: If ``data`` is not bytes-like.
+            OSError: When the underlying transport accepts the write but later
+                reports a socket or stream failure while flushing.
+        """
+        ...
+
+    async def close(self) -> None:
+        """
+        Close the connection.
+
+        Implementations should be safe to call repeatedly. After close, future
+        ``send()`` calls must fail rather than silently succeeding.
+        """
+        ...

--- a/src/aionetx/api/connection_protocol.py
+++ b/src/aionetx/api/connection_protocol.py
@@ -28,27 +28,27 @@ class ConnectionProtocol(ByteSenderProtocol, Protocol):
     @property
     def connection_id(self) -> str:
         """Return a stable identifier used for correlation in emitted events."""
-        ...
+        raise NotImplementedError
 
     @property
     def role(self) -> ConnectionRole:
         """Return the logical role of the connection endpoint."""
-        ...
+        raise NotImplementedError
 
     @property
     def state(self) -> ConnectionState:
         """Return the current lifecycle state."""
-        ...
+        raise NotImplementedError
 
     @property
     def is_connected(self) -> bool:
         """Return ``True`` when ``send`` is expected to succeed."""
-        ...
+        raise NotImplementedError
 
     @property
     def metadata(self) -> ConnectionMetadata:
         """Return immutable transport metadata for this connection."""
-        ...
+        raise NotImplementedError
 
     async def send(self, data: BytesLike) -> None:
         """
@@ -63,7 +63,7 @@ class ConnectionProtocol(ByteSenderProtocol, Protocol):
             OSError: When the underlying transport accepts the write but later
                 reports a socket or stream failure while flushing.
         """
-        ...
+        raise NotImplementedError
 
     async def close(self) -> None:
         """
@@ -72,4 +72,4 @@ class ConnectionProtocol(ByteSenderProtocol, Protocol):
         Implementations should be safe to call repeatedly. After close, future
         ``send()`` calls must fail rather than silently succeeding.
         """
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/error_policy.py
+++ b/src/aionetx/api/error_policy.py
@@ -1,0 +1,18 @@
+"""
+Runtime error-policy enum for supervised TCP clients.
+
+These policies tell client supervision whether failures should stop
+immediately, be retried, or be surfaced only through emitted events.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ErrorPolicy(str, Enum):
+    """How client supervision handles runtime connection errors."""
+
+    RETRY = "retry"
+    FAIL_FAST = "fail_fast"
+    IGNORE = "ignore"

--- a/src/aionetx/api/errors.py
+++ b/src/aionetx/api/errors.py
@@ -1,0 +1,32 @@
+"""
+Public exception hierarchy for configuration and runtime failures.
+
+User code can import these exceptions to validate configuration failures and to
+catch transport operations that fail after construction succeeds.
+"""
+
+from __future__ import annotations
+
+
+class NetworkLayerError(Exception):
+    """Base exception for the network layer."""
+
+
+class NetworkConfigurationError(NetworkLayerError):
+    """Base exception for invalid public configuration or validation failures."""
+
+
+class NetworkRuntimeError(NetworkLayerError):
+    """Base exception for runtime transport failures after configuration succeeds."""
+
+
+class InvalidNetworkConfigurationError(NetworkConfigurationError):
+    """Raised when invalid network settings are supplied."""
+
+
+class HeartbeatConfigurationError(NetworkConfigurationError):
+    """Raised when heartbeat is enabled but configured incorrectly."""
+
+
+class ConnectionClosedError(NetworkRuntimeError):
+    """Raised when an operation requires an open connection."""

--- a/src/aionetx/api/event_delivery_settings.py
+++ b/src/aionetx/api/event_delivery_settings.py
@@ -1,0 +1,90 @@
+"""
+Configuration types controlling event dispatch behavior.
+
+The enums and dataclass in this module define dispatch mode, queue behavior,
+and handler-failure policy for emitted transport events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from aionetx.api._validation import require_enum_member, require_positive_int
+
+
+class EventDispatchMode(str, Enum):
+    """Execution strategy used to deliver emitted events to the handler."""
+
+    INLINE = "inline"
+    BACKGROUND = "background"
+
+
+class EventBackpressurePolicy(str, Enum):
+    """Policy used when the background dispatcher queue reaches capacity."""
+
+    BLOCK = "block"
+    DROP_OLDEST = "drop_oldest"
+    DROP_NEWEST = "drop_newest"
+
+
+class EventHandlerFailurePolicy(str, Enum):
+    """Policy describing what the dispatcher does when the handler raises."""
+
+    LOG_ONLY = "log_only"
+    EMIT_ERROR_EVENT = "emit_error_event"
+    STOP_COMPONENT = "stop_component"
+    RAISE_IN_INLINE_MODE = "raise_in_inline_mode"
+
+
+@dataclass(frozen=True, slots=True)
+class EventDeliverySettings:
+    """
+    Event delivery configuration for managed components.
+
+    Attributes:
+        dispatch_mode: Whether events are delivered inline in the caller task
+            or via a background worker task.
+        backpressure_policy: Queue behavior once pending-event capacity is
+            reached in background mode.
+        max_pending_events: Maximum number of queued background events before
+            backpressure handling applies.
+        handler_failure_policy: Response when the application event handler
+            raises while processing an event.
+    """
+
+    dispatch_mode: EventDispatchMode = EventDispatchMode.BACKGROUND
+    backpressure_policy: EventBackpressurePolicy = EventBackpressurePolicy.BLOCK
+    max_pending_events: int = 1024
+    handler_failure_policy: EventHandlerFailurePolicy = EventHandlerFailurePolicy.LOG_ONLY
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate event delivery settings.
+
+        Raises:
+            InvalidNetworkConfigurationError: If queue bounds or enum values
+                are invalid.
+        """
+        require_positive_int(
+            field_name="EventDeliverySettings.max_pending_events",
+            value=self.max_pending_events,
+        )
+        require_enum_member(
+            field_name="EventDeliverySettings.dispatch_mode",
+            value=self.dispatch_mode,
+            enum_type=EventDispatchMode,
+        )
+        require_enum_member(
+            field_name="EventDeliverySettings.backpressure_policy",
+            value=self.backpressure_policy,
+            enum_type=EventBackpressurePolicy,
+        )
+        require_enum_member(
+            field_name="EventDeliverySettings.handler_failure_policy",
+            value=self.handler_failure_policy,
+            enum_type=EventHandlerFailurePolicy,
+        )

--- a/src/aionetx/api/events.py
+++ b/src/aionetx/api/events.py
@@ -1,0 +1,41 @@
+"""
+Curated event re-export module for the public API.
+
+This module groups the event dataclasses and handler helper that advanced users
+may want to import from one place without reaching into the fine-grained event
+modules directly.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.base_network_event_handler import BaseNetworkEventHandler
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_events import (
+    ConnectionClosedEvent,
+    ConnectionOpenedEvent,
+    ConnectionRejectedEvent,
+)
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+__all__ = (
+    "BaseNetworkEventHandler",
+    "BytesReceivedEvent",
+    "ComponentLifecycleChangedEvent",
+    "ConnectionClosedEvent",
+    "ConnectionOpenedEvent",
+    "ConnectionRejectedEvent",
+    "HandlerFailurePolicyStopEvent",
+    "NetworkErrorEvent",
+    "NetworkEvent",
+    "ReconnectAttemptFailedEvent",
+    "ReconnectAttemptStartedEvent",
+    "ReconnectScheduledEvent",
+)

--- a/src/aionetx/api/handler_failure_policy_stop_event.py
+++ b/src/aionetx/api/handler_failure_policy_stop_event.py
@@ -1,0 +1,34 @@
+"""
+Event type emitted when a handler failure requests component shutdown.
+
+This event lets applications observe why a dispatcher chose the
+``STOP_COMPONENT`` failure path and which triggering event caused it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.event_delivery_settings import EventDispatchMode, EventHandlerFailurePolicy
+
+
+@dataclass(slots=True, frozen=True)
+class HandlerFailurePolicyStopEvent:
+    """
+    Event emitted when handler failure policy requests component shutdown.
+
+    Attributes:
+        resource_id: Identifier of the component whose dispatcher raised the
+            stop request.
+        triggering_event_name: Name of the event type that caused the handler
+            failure.
+        error: Original exception raised by the event handler.
+        policy: Handler-failure policy that selected component shutdown.
+        dispatch_mode: Dispatcher mode in effect when the failure happened.
+    """
+
+    resource_id: str
+    triggering_event_name: str
+    error: Exception
+    policy: EventHandlerFailurePolicy
+    dispatch_mode: EventDispatchMode

--- a/src/aionetx/api/heartbeat.py
+++ b/src/aionetx/api/heartbeat.py
@@ -1,0 +1,70 @@
+"""
+Heartbeat request, response, and configuration models.
+
+These dataclasses define the public handshake between transports that schedule
+heartbeats and user-supplied heartbeat providers that decide what to send.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api._validation import require_bool, require_positive_finite_number
+
+
+@dataclass(frozen=True, slots=True)
+class HeartbeatRequest:
+    """
+    Input provided to ``HeartbeatProviderProtocol`` for each heartbeat tick.
+
+    Attributes:
+        connection_id (str): Identifier of the currently connected transport.
+    """
+
+    connection_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class HeartbeatResult:
+    """
+    Heartbeat provider output consumed by the sender loop.
+
+    Attributes:
+        should_send (bool): When ``True``, ``payload`` is sent over the connection.
+        payload (BytesLike): Raw heartbeat payload to send when ``should_send`` is true.
+    """
+
+    should_send: bool
+    payload: BytesLike = b""
+
+
+@dataclass(frozen=True, slots=True)
+class TcpHeartbeatSettings:
+    """
+    TCP heartbeat scheduling configuration.
+
+    Attributes:
+        enabled: Whether heartbeat scheduling is active for the transport.
+        interval_seconds: Seconds between heartbeat polls while enabled.
+    """
+
+    enabled: bool = False
+    interval_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate heartbeat configuration.
+
+        Raises:
+            InvalidNetworkConfigurationError: If ``enabled`` is not a bool or
+                ``interval_seconds`` is not a positive finite number.
+        """
+        require_bool(field_name="TcpHeartbeatSettings.enabled", value=self.enabled)
+        require_positive_finite_number(
+            field_name="TcpHeartbeatSettings.interval_seconds",
+            value=self.interval_seconds,
+        )

--- a/src/aionetx/api/heartbeat_provider_protocol.py
+++ b/src/aionetx/api/heartbeat_provider_protocol.py
@@ -1,0 +1,28 @@
+"""
+Protocol for user-defined heartbeat payload generation.
+
+Implementations receive a lightweight request describing the active connection
+and return a decision about whether bytes should be sent for that tick.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aionetx.api.heartbeat import HeartbeatRequest, HeartbeatResult
+
+
+class HeartbeatProviderProtocol(Protocol):
+    """Contract for creating heartbeat payloads on demand."""
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        """
+        Build the next heartbeat decision for a connection.
+
+        Args:
+            request: Context identifying which connection is requesting a heartbeat.
+
+        Returns:
+            A ``HeartbeatResult`` indicating whether bytes should be sent and which payload.
+        """
+        ...

--- a/src/aionetx/api/heartbeat_provider_protocol.py
+++ b/src/aionetx/api/heartbeat_provider_protocol.py
@@ -25,4 +25,4 @@ class HeartbeatProviderProtocol(Protocol):
         Returns:
             A ``HeartbeatResult`` indicating whether bytes should be sent and which payload.
         """
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/lifecycle.py
+++ b/src/aionetx/api/lifecycle.py
@@ -1,0 +1,19 @@
+"""
+Curated lifecycle-model re-exports for the public API.
+
+This module groups component and connection lifecycle types so advanced users
+can import the shared state model from one stable place.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_lifecycle import ConnectionRole, ConnectionState
+from aionetx.api.connection_metadata import ConnectionMetadata
+
+__all__ = (
+    "ComponentLifecycleState",
+    "ConnectionMetadata",
+    "ConnectionRole",
+    "ConnectionState",
+)

--- a/src/aionetx/api/managed_transport_protocol.py
+++ b/src/aionetx/api/managed_transport_protocol.py
@@ -1,0 +1,72 @@
+"""
+Shared lifecycle protocol for managed transport components.
+
+This protocol captures the common start/stop/context-manager behavior that TCP
+clients, TCP servers, and datagram receivers all expose.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Protocol, TypeVar
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+
+_TManagedTransport = TypeVar("_TManagedTransport", bound="ManagedTransportProtocol")
+
+
+class ManagedTransportProtocol(Protocol):
+    """
+    Capability protocol for components with explicit lifecycle management.
+
+    All managed transports use the same transition model:
+    ``STOPPED -> STARTING -> RUNNING -> STOPPING -> STOPPED``.
+    Failed startup may transition ``STARTING -> STOPPED``.
+
+    Guarantees only shared lifecycle participation via:
+    - ``start()``
+    - ``stop()``
+    - ``lifecycle_state``
+    - async context manager (``async with``)
+
+    It intentionally does *not* guarantee connection shape, reconnect behavior,
+    background-task strategy, or client/server-specific features.
+    """
+
+    @property
+    def lifecycle_state(self) -> ComponentLifecycleState:
+        """Return current component lifecycle state."""
+        ...
+
+    async def start(self) -> None:
+        """
+        Start the component lifecycle.
+
+        Calling ``start()`` when the component is already starting or running
+        must be a no-op. Successful return means the managed runtime owns its
+        background resources and lifecycle publication has begun.
+        """
+        ...
+
+    async def stop(self) -> None:
+        """
+        Stop the component lifecycle.
+
+        Implementations must be safe to call repeatedly. Once ``stop()``
+        returns, owned background tasks and transport resources must no longer
+        continue running on behalf of the component.
+        """
+        ...
+
+    async def __aenter__(self: _TManagedTransport) -> _TManagedTransport:
+        """Start the component and return ``self`` for use as a context variable."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Stop the component unconditionally, regardless of any exception."""
+        ...

--- a/src/aionetx/api/managed_transport_protocol.py
+++ b/src/aionetx/api/managed_transport_protocol.py
@@ -36,7 +36,7 @@ class ManagedTransportProtocol(Protocol):
     @property
     def lifecycle_state(self) -> ComponentLifecycleState:
         """Return current component lifecycle state."""
-        ...
+        raise NotImplementedError
 
     async def start(self) -> None:
         """
@@ -46,7 +46,7 @@ class ManagedTransportProtocol(Protocol):
         must be a no-op. Successful return means the managed runtime owns its
         background resources and lifecycle publication has begun.
         """
-        ...
+        raise NotImplementedError
 
     async def stop(self) -> None:
         """
@@ -56,11 +56,11 @@ class ManagedTransportProtocol(Protocol):
         returns, owned background tasks and transport resources must no longer
         continue running on behalf of the component.
         """
-        ...
+        raise NotImplementedError
 
     async def __aenter__(self: _TManagedTransport) -> _TManagedTransport:
         """Start the component and return ``self`` for use as a context variable."""
-        ...
+        raise NotImplementedError
 
     async def __aexit__(
         self,
@@ -69,4 +69,4 @@ class ManagedTransportProtocol(Protocol):
         exc_tb: TracebackType | None,
     ) -> None:
         """Stop the component unconditionally, regardless of any exception."""
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/multicast_receiver_protocol.py
+++ b/src/aionetx/api/multicast_receiver_protocol.py
@@ -1,0 +1,16 @@
+"""
+Public protocol for managed UDP multicast receivers.
+
+The protocol adds no new methods beyond ``ManagedTransportProtocol``; its
+purpose is to give multicast receivers an explicit role-specific API type.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+
+
+class MulticastReceiverProtocol(ManagedTransportProtocol, Protocol):
+    """Multicast receiver contract built on managed lifecycle capability."""

--- a/src/aionetx/api/multicast_receiver_settings.py
+++ b/src/aionetx/api/multicast_receiver_settings.py
@@ -1,0 +1,88 @@
+"""
+Configuration model for UDP multicast receivers.
+
+The dataclass in this module describes group membership, bind/interface
+addresses, receive-buffer size, and event-delivery behavior for multicast
+receivers.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass, field
+
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.errors import InvalidNetworkConfigurationError
+from aionetx.api._validation import (
+    require_int_range,
+    require_non_empty_str,
+    require_positive_int,
+)
+
+
+def _validate_ipv4_address(*, field_name: str, value: str) -> ipaddress.IPv4Address:
+    """Return a parsed IPv4 address or raise the public configuration error."""
+    try:
+        return ipaddress.IPv4Address(value)
+    except ValueError as error:
+        raise InvalidNetworkConfigurationError(
+            f"MulticastReceiverSettings.{field_name} must be a valid IPv4 address."
+        ) from error
+
+
+@dataclass(frozen=True, slots=True)
+class MulticastReceiverSettings:
+    """
+    Configuration for receiving UDP multicast datagrams.
+
+    Attributes:
+        group_ip: Multicast group address to join.
+        port: UDP port used for bind and group membership.
+        bind_ip: Local bind address for the socket.
+        interface_ip: Interface address used for multicast membership.
+        receive_buffer_size: Maximum bytes read from the socket per receive.
+        event_delivery: Event dispatch configuration for emitted receive and
+            lifecycle events.
+    """
+
+    group_ip: str
+    port: int
+    bind_ip: str = "0.0.0.0"
+    interface_ip: str = "0.0.0.0"
+    receive_buffer_size: int = 65535
+    event_delivery: EventDeliverySettings = field(default_factory=EventDeliverySettings)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate multicast socket settings.
+
+        Raises:
+            InvalidNetworkConfigurationError: If any required value is missing
+                or outside valid UDP/socket bounds.
+        """
+        require_non_empty_str(field_name="MulticastReceiverSettings.group_ip", value=self.group_ip)
+        require_int_range(
+            field_name="MulticastReceiverSettings.port",
+            value=self.port,
+            min_value=1,
+            max_value=65535,
+        )
+        require_non_empty_str(field_name="MulticastReceiverSettings.bind_ip", value=self.bind_ip)
+        require_non_empty_str(
+            field_name="MulticastReceiverSettings.interface_ip", value=self.interface_ip
+        )
+        group_address = _validate_ipv4_address(field_name="group_ip", value=self.group_ip)
+        if not group_address.is_multicast:
+            raise InvalidNetworkConfigurationError(
+                "MulticastReceiverSettings.group_ip must be an IPv4 multicast address."
+            )
+        _validate_ipv4_address(field_name="bind_ip", value=self.bind_ip)
+        _validate_ipv4_address(field_name="interface_ip", value=self.interface_ip)
+        require_positive_int(
+            field_name="MulticastReceiverSettings.receive_buffer_size",
+            value=self.receive_buffer_size,
+        )
+        self.event_delivery.validate()

--- a/src/aionetx/api/network_error_event.py
+++ b/src/aionetx/api/network_error_event.py
@@ -1,0 +1,24 @@
+"""
+Event type used to surface caught transport-side exceptions.
+
+Implementations emit this event when they catch an exception and choose to
+report it through the event stream instead of raising it to the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkErrorEvent:
+    """
+    Event emitted when transport-side logic catches an exception.
+
+    Attributes:
+        resource_id (str): Identifier of the component that detected the error.
+        error (Exception): Original exception instance.
+    """
+
+    resource_id: str
+    error: Exception

--- a/src/aionetx/api/network_event.py
+++ b/src/aionetx/api/network_event.py
@@ -49,3 +49,5 @@ from typing import TypeAlias
 from aionetx.api._event_registry import NetworkEvent as _NetworkEvent
 
 NetworkEvent: TypeAlias = _NetworkEvent
+
+__all__ = ("NetworkEvent",)

--- a/src/aionetx/api/network_event.py
+++ b/src/aionetx/api/network_event.py
@@ -1,0 +1,51 @@
+"""
+Type-level union of every event dataclass delivered to ``on_event``.
+
+Open-union policy
+-----------------
+``NetworkEvent`` is an *open* union. New event dataclasses may be added in
+minor releases as the library's observability surface grows. In practice
+that means:
+
+- Existing event dataclasses, their field names, and their field types are
+  stable: fields are never renamed, retyped, or removed without a
+  deprecation cycle and a CHANGELOG entry.
+- New event types may appear in any minor release; additions are always
+  called out under **Added** in the CHANGELOG.
+- Removing an event type from the union is treated as a breaking change
+  and reserved for major releases (or, during the pre-1.0 phase, for
+  minor bumps with an explicit **Removed** CHANGELOG entry).
+
+Consequences for handler code
+-----------------------------
+User code that branches on event type must keep a catch-all fallback so a
+future union extension does not silently break:
+
+.. code-block:: python
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            ...
+        elif isinstance(event, ConnectionClosedEvent):
+            ...
+        else:
+            # Unknown event type from a newer aionetx release: ignore,
+            # log, or forward — but do not assert exhaustiveness.
+            pass
+
+``match``/``case`` users should always include a ``case _:`` arm.
+``typing.assert_never`` is intentionally **not** safe against this union
+because it assumes a closed taxonomy.
+
+``BaseNetworkEventHandler`` handles this correctly out-of-the-box: its
+typed hooks are optional overrides, and unknown event types fall back to
+its default no-op ``on_event`` dispatch.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from aionetx.api._event_registry import NetworkEvent as _NetworkEvent
+
+NetworkEvent: TypeAlias = _NetworkEvent

--- a/src/aionetx/api/network_event_handler_protocol.py
+++ b/src/aionetx/api/network_event_handler_protocol.py
@@ -1,0 +1,20 @@
+"""
+Public callback protocol for the emitted network event stream.
+
+Every managed component delivers lifecycle, data, and error reporting through a
+single async ``on_event(event)`` method defined here.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aionetx.api.network_event import NetworkEvent
+
+
+class NetworkEventHandlerProtocol(Protocol):
+    """Application callback interface for network lifecycle and transport events."""
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        """Handle one emitted transport event."""
+        ...

--- a/src/aionetx/api/network_event_handler_protocol.py
+++ b/src/aionetx/api/network_event_handler_protocol.py
@@ -17,4 +17,4 @@ class NetworkEventHandlerProtocol(Protocol):
 
     async def on_event(self, event: NetworkEvent) -> None:
         """Handle one emitted transport event."""
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/network_factory.py
+++ b/src/aionetx/api/network_factory.py
@@ -1,0 +1,130 @@
+"""
+Public factory protocol for constructing supported transport roles.
+
+Applications can depend on this protocol when they want to abstract over the
+concrete backend that creates TCP, UDP, and multicast transports.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.multicast_receiver_protocol import MulticastReceiverProtocol
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.tcp_client import TcpClientProtocol, TcpClientSettings
+from aionetx.api.tcp_server import TcpServerProtocol, TcpServerSettings
+from aionetx.api.udp import (
+    UdpReceiverProtocol,
+    UdpReceiverSettings,
+    UdpSenderProtocol,
+    UdpSenderSettings,
+)
+
+
+@runtime_checkable
+class NetworkFactory(Protocol):
+    """
+    Explicit transport-construction contract for supported backends.
+
+    The factory boundary is intentionally transport-only: it constructs TCP,
+    UDP, and multicast transport roles, but it does not add framing, parsing,
+    or application-level protocol behavior.
+    """
+
+    def create_tcp_client(
+        self,
+        settings: TcpClientSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+    ) -> TcpClientProtocol:
+        """
+        Create a managed TCP client transport.
+
+        Args:
+            settings: TCP client configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+            heartbeat_provider: Optional heartbeat provider used when client
+                heartbeat scheduling is enabled.
+
+        Returns:
+            A transport implementing ``TcpClientProtocol``.
+
+        Raises:
+            HeartbeatConfigurationError: If heartbeat is enabled but the
+                provider is missing or does not satisfy the async provider
+                contract.
+        """
+        ...
+
+    def create_tcp_server(
+        self,
+        settings: TcpServerSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+    ) -> TcpServerProtocol:
+        """
+        Create a managed TCP server transport.
+
+        Args:
+            settings: TCP server listener configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+            heartbeat_provider: Optional heartbeat provider used when
+                server-side heartbeat scheduling is enabled.
+
+        Returns:
+            A transport implementing ``TcpServerProtocol``.
+
+        Raises:
+            HeartbeatConfigurationError: If heartbeat is enabled but the
+                provider is missing or does not satisfy the async provider
+                contract.
+        """
+        ...
+
+    def create_multicast_receiver(
+        self,
+        settings: MulticastReceiverSettings,
+        event_handler: NetworkEventHandlerProtocol,
+    ) -> MulticastReceiverProtocol:
+        """
+        Create a managed UDP multicast receiver.
+
+        Args:
+            settings: Multicast receiver configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+
+        Returns:
+            A transport implementing ``MulticastReceiverProtocol``.
+        """
+        ...
+
+    def create_udp_receiver(
+        self,
+        settings: UdpReceiverSettings,
+        event_handler: NetworkEventHandlerProtocol,
+    ) -> UdpReceiverProtocol:
+        """
+        Create a managed UDP receiver.
+
+        Args:
+            settings: UDP receiver configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+
+        Returns:
+            A transport implementing ``UdpReceiverProtocol``.
+        """
+        ...
+
+    def create_udp_sender(self, settings: UdpSenderSettings) -> UdpSenderProtocol:
+        """
+        Create a UDP sender.
+
+        Args:
+            settings: UDP sender configuration.
+
+        Returns:
+            A transport implementing ``UdpSenderProtocol``.
+        """
+        ...

--- a/src/aionetx/api/network_factory.py
+++ b/src/aionetx/api/network_factory.py
@@ -56,7 +56,7 @@ class NetworkFactory(Protocol):
                 provider is missing or does not satisfy the async provider
                 contract.
         """
-        ...
+        raise NotImplementedError
 
     def create_tcp_server(
         self,
@@ -81,7 +81,7 @@ class NetworkFactory(Protocol):
                 provider is missing or does not satisfy the async provider
                 contract.
         """
-        ...
+        raise NotImplementedError
 
     def create_multicast_receiver(
         self,
@@ -98,7 +98,7 @@ class NetworkFactory(Protocol):
         Returns:
             A transport implementing ``MulticastReceiverProtocol``.
         """
-        ...
+        raise NotImplementedError
 
     def create_udp_receiver(
         self,
@@ -115,7 +115,7 @@ class NetworkFactory(Protocol):
         Returns:
             A transport implementing ``UdpReceiverProtocol``.
         """
-        ...
+        raise NotImplementedError
 
     def create_udp_sender(self, settings: UdpSenderSettings) -> UdpSenderProtocol:
         """
@@ -127,4 +127,4 @@ class NetworkFactory(Protocol):
         Returns:
             A transport implementing ``UdpSenderProtocol``.
         """
-        ...
+        raise NotImplementedError

--- a/src/aionetx/api/policies.py
+++ b/src/aionetx/api/policies.py
@@ -1,0 +1,26 @@
+"""
+Curated policy re-exports for the public API.
+
+This module groups error, reconnect, and event-delivery policy types so they
+can be imported from one stable location.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.reconnect_jitter import ReconnectJitter
+
+__all__ = (
+    "ErrorPolicy",
+    "EventBackpressurePolicy",
+    "EventDeliverySettings",
+    "EventDispatchMode",
+    "EventHandlerFailurePolicy",
+    "ReconnectJitter",
+)

--- a/src/aionetx/api/protocols.py
+++ b/src/aionetx/api/protocols.py
@@ -1,0 +1,33 @@
+"""
+Curated protocol re-exports for the public API.
+
+This module groups shared capability and role-specific protocol types so users
+can import the protocol layer from one stable location.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.byte_sender_protocol import ByteSenderProtocol
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+from aionetx.api.multicast_receiver_protocol import MulticastReceiverProtocol
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.network_factory import NetworkFactory
+from aionetx.api.tcp_client import TcpClientProtocol
+from aionetx.api.tcp_server import TcpServerProtocol
+from aionetx.api.udp import UdpReceiverProtocol, UdpSenderProtocol
+
+__all__ = (
+    "ByteSenderProtocol",
+    "ConnectionProtocol",
+    "HeartbeatProviderProtocol",
+    "ManagedTransportProtocol",
+    "MulticastReceiverProtocol",
+    "NetworkEventHandlerProtocol",
+    "NetworkFactory",
+    "TcpClientProtocol",
+    "TcpServerProtocol",
+    "UdpReceiverProtocol",
+    "UdpSenderProtocol",
+)

--- a/src/aionetx/api/reconnect_events.py
+++ b/src/aionetx/api/reconnect_events.py
@@ -1,0 +1,59 @@
+"""
+Reconnect-related event dataclasses emitted by supervised TCP clients.
+
+These events describe when a reconnect attempt starts, fails, and when the
+next reconnect delay has been scheduled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ReconnectAttemptStartedEvent:
+    """
+    Event emitted when the client starts a connection or reconnection attempt.
+
+    Attributes:
+        resource_id: Canonical TCP client component identifier.
+        attempt: One-based attempt counter for the current connection cycle.
+    """
+
+    resource_id: str
+    attempt: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReconnectAttemptFailedEvent:
+    """
+    Event emitted when a connection or reconnection attempt fails.
+
+    Attributes:
+        resource_id: Canonical TCP client component identifier.
+        attempt: Attempt counter that failed.
+        error: Original exception raised by the failed attempt.
+        next_delay_seconds: Delay before the next attempt when reconnect is
+            still scheduled, otherwise ``None``.
+    """
+
+    resource_id: str
+    attempt: int
+    error: Exception
+    next_delay_seconds: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReconnectScheduledEvent:
+    """
+    Event emitted when the next reconnect delay has been scheduled.
+
+    Attributes:
+        resource_id: Canonical TCP client component identifier.
+        attempt: One-based number of the upcoming attempt.
+        delay_seconds: Delay before the next reconnect attempt is started.
+    """
+
+    resource_id: str
+    attempt: int
+    delay_seconds: float

--- a/src/aionetx/api/reconnect_jitter.py
+++ b/src/aionetx/api/reconnect_jitter.py
@@ -1,0 +1,17 @@
+"""
+Jitter strategies for reconnect backoff calculation.
+
+These enum values control how reconnect delays are randomized between attempts.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ReconnectJitter(str, Enum):
+    """Jitter strategy used for reconnect delay randomization."""
+
+    NONE = "none"
+    FULL = "full"
+    EQUAL = "equal"

--- a/src/aionetx/api/settings.py
+++ b/src/aionetx/api/settings.py
@@ -1,0 +1,25 @@
+"""
+Curated settings re-exports for the public API.
+
+This module groups the public dataclass-based transport settings so callers can
+import configuration types from one stable location.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings, UdpSenderSettings
+
+__all__ = (
+    "TcpHeartbeatSettings",
+    "MulticastReceiverSettings",
+    "TcpClientSettings",
+    "TcpReconnectSettings",
+    "TcpServerSettings",
+    "UdpReceiverSettings",
+    "UdpSenderSettings",
+)

--- a/src/aionetx/api/tcp_client.py
+++ b/src/aionetx/api/tcp_client.py
@@ -115,7 +115,7 @@ class TcpClientProtocol(ManagedTransportProtocol, Protocol):
     @property
     def connection(self) -> ConnectionProtocol | None:
         """Return active connection if connected, otherwise ``None``."""
-        ...
+        raise NotImplementedError
 
     async def wait_until_connected(
         self,
@@ -141,7 +141,7 @@ class TcpClientProtocol(ManagedTransportProtocol, Protocol):
             The currently active connection object. The returned connection is
             still subject to later disconnect/close events.
         """
-        ...
+        raise NotImplementedError
 
 
 __all__ = (

--- a/src/aionetx/api/tcp_client.py
+++ b/src/aionetx/api/tcp_client.py
@@ -1,0 +1,150 @@
+"""
+Public TCP client settings and protocol definitions.
+
+This module exposes the dataclass users configure and the managed protocol
+implemented by concrete TCP client transports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.errors import InvalidNetworkConfigurationError
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api._validation import (
+    require_enum_member,
+    require_int_range,
+    require_non_empty_str,
+    require_optional_positive_finite_number,
+    require_positive_int,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TcpClientSettings:
+    """
+    Configuration for a TCP client connection.
+
+    Attributes:
+        host: Target host to connect to (non-empty, non-whitespace).
+        port: Target TCP port in the range ``1..65535``.
+        reconnect: Reconnect scheduling policy. When ``enabled=True`` the
+            client retries connection attempts using the configured backoff.
+            Defaults to a disabled policy (no automatic reconnect).
+        heartbeat: TCP keep-alive scheduling policy. When ``enabled=True`` the
+            configured ``HeartbeatProviderProtocol`` is asked every interval
+            whether to send a heartbeat payload. Defaults to disabled.
+        error_policy: Optional strategy for runtime send/receive failures.
+            ``ErrorPolicy.RETRY`` requires ``reconnect.enabled=True``.
+            ``None`` (default) lets the transport surface errors via events
+            without an implicit retry policy.
+        receive_buffer_size: Max bytes read per underlying receive call.
+            Must be ``> 0``. Defaults to 4096.
+        connect_timeout_seconds: Optional per-attempt connect timeout. Must
+            be ``> 0`` when set. ``None`` (default) waits for the OS-level
+            connect to resolve.
+        event_delivery: Dispatch mode, buffering, and handler-failure policy
+            controls for events emitted by this client.
+    """
+
+    host: str
+    port: int
+    reconnect: TcpReconnectSettings = field(default_factory=TcpReconnectSettings)
+    heartbeat: TcpHeartbeatSettings = field(default_factory=TcpHeartbeatSettings)
+    error_policy: ErrorPolicy | None = None
+    receive_buffer_size: int = 4096
+    connect_timeout_seconds: float | None = None
+    event_delivery: EventDeliverySettings = field(default_factory=EventDeliverySettings)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate TCP client configuration.
+
+        Raises:
+            InvalidNetworkConfigurationError: If host, port, reconnect, timeout,
+                heartbeat, or event-delivery settings are invalid.
+        """
+        require_non_empty_str(field_name="TcpClientSettings.host", value=self.host)
+        require_int_range(
+            field_name="TcpClientSettings.port",
+            value=self.port,
+            min_value=1,
+            max_value=65535,
+        )
+        require_positive_int(
+            field_name="TcpClientSettings.receive_buffer_size",
+            value=self.receive_buffer_size,
+        )
+        require_optional_positive_finite_number(
+            field_name="TcpClientSettings.connect_timeout_seconds",
+            value=self.connect_timeout_seconds,
+        )
+        if self.error_policy is not None:
+            require_enum_member(
+                field_name="TcpClientSettings.error_policy",
+                value=self.error_policy,
+                enum_type=ErrorPolicy,
+            )
+        if self.error_policy == ErrorPolicy.RETRY and not self.reconnect.enabled:
+            raise InvalidNetworkConfigurationError(
+                "TcpClientSettings.error_policy='retry' requires reconnect.enabled=True."
+            )
+        self.reconnect.validate()
+        self.heartbeat.validate()
+        self.event_delivery.validate()
+
+
+class TcpClientProtocol(ManagedTransportProtocol, Protocol):
+    """
+    TCP client contract built on managed lifecycle capability.
+
+    A client exposes at most one active connection at a time. Reconnect, when
+    enabled, is still observable through lifecycle/error events rather than
+    hidden behind a permanently "connected" abstraction.
+    """
+
+    @property
+    def connection(self) -> ConnectionProtocol | None:
+        """Return active connection if connected, otherwise ``None``."""
+        ...
+
+    async def wait_until_connected(
+        self,
+        timeout_seconds: float | None = None,
+        poll_interval_seconds: float = 0.1,
+    ) -> ConnectionProtocol:
+        """
+        Wait until an active connected connection is available.
+
+        Args:
+            timeout_seconds: Optional max wait time; waits forever when ``None``.
+            poll_interval_seconds: Positive interval used to re-check failure
+                conditions while waiting.
+
+        Raises:
+            ConnectionError: If the client has been started and then stopped
+                before a connection becomes available, or when connection
+                establishment fails without further reconnect attempts.
+            asyncio.TimeoutError: When ``timeout_seconds`` is provided and the
+                timeout expires first.
+
+        Returns:
+            The currently active connection object. The returned connection is
+            still subject to later disconnect/close events.
+        """
+        ...
+
+
+__all__ = (
+    "TcpClientProtocol",
+    "TcpClientSettings",
+)

--- a/src/aionetx/api/tcp_reconnect_settings.py
+++ b/src/aionetx/api/tcp_reconnect_settings.py
@@ -1,0 +1,74 @@
+"""
+Reconnect policy configuration for managed TCP clients.
+
+The dataclass in this module defines whether reconnect is enabled and how
+backoff timing behaves across repeated connection attempts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aionetx.api.errors import InvalidNetworkConfigurationError
+from aionetx.api.reconnect_jitter import ReconnectJitter
+from aionetx.api._validation import (
+    require_bool,
+    require_enum_member,
+    require_finite_number_at_least,
+    require_positive_finite_number,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TcpReconnectSettings:
+    """
+    Reconnect policy for TCP clients.
+
+    Attributes:
+        enabled: Whether reconnect scheduling is active after disconnects or
+            handled failures.
+        initial_delay_seconds: Delay before the first reconnect attempt.
+        max_delay_seconds: Maximum backoff delay after repeated failures.
+        backoff_factor: Multiplicative growth factor for delay progression.
+        jitter: Randomization strategy applied to each reconnect delay.
+    """
+
+    enabled: bool = False
+    initial_delay_seconds: float = 1.0
+    max_delay_seconds: float = 30.0
+    backoff_factor: float = 2.0
+    jitter: ReconnectJitter = ReconnectJitter.NONE
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate reconnect backoff bounds.
+
+        Raises:
+            InvalidNetworkConfigurationError: If reconnect timing values are invalid.
+        """
+        require_bool(field_name="TcpReconnectSettings.enabled", value=self.enabled)
+        initial_delay_seconds = require_positive_finite_number(
+            field_name="TcpReconnectSettings.initial_delay_seconds",
+            value=self.initial_delay_seconds,
+        )
+        max_delay_seconds = require_positive_finite_number(
+            field_name="TcpReconnectSettings.max_delay_seconds",
+            value=self.max_delay_seconds,
+        )
+        if max_delay_seconds < initial_delay_seconds:
+            raise InvalidNetworkConfigurationError(
+                "TcpReconnectSettings.max_delay_seconds must be >= initial_delay_seconds."
+            )
+        require_finite_number_at_least(
+            field_name="TcpReconnectSettings.backoff_factor",
+            value=self.backoff_factor,
+            minimum=1.0,
+        )
+        require_enum_member(
+            field_name="TcpReconnectSettings.jitter",
+            value=self.jitter,
+            enum_type=ReconnectJitter,
+        )

--- a/src/aionetx/api/tcp_server.py
+++ b/src/aionetx/api/tcp_server.py
@@ -122,7 +122,7 @@ class TcpServerProtocol(ManagedTransportProtocol, Protocol):
 
         Rejected or already-closed connections are never part of this tuple.
         """
-        ...
+        raise NotImplementedError
 
     async def wait_until_running(
         self,
@@ -138,7 +138,7 @@ class TcpServerProtocol(ManagedTransportProtocol, Protocol):
             asyncio.TimeoutError: When ``timeout_seconds`` is provided and
                 timeout expires.
         """
-        ...
+        raise NotImplementedError
 
     async def broadcast(self, data: BytesLike) -> None:
         """
@@ -149,7 +149,7 @@ class TcpServerProtocol(ManagedTransportProtocol, Protocol):
         observable through events and may still cause this call to raise after
         best-effort delivery/cleanup.
         """
-        ...
+        raise NotImplementedError
 
 
 __all__ = (

--- a/src/aionetx/api/tcp_server.py
+++ b/src/aionetx/api/tcp_server.py
@@ -1,0 +1,158 @@
+"""
+Public TCP server settings and protocol definitions.
+
+This module exposes the dataclass users configure and the managed protocol
+implemented by concrete TCP server transports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+from aionetx.api._validation import (
+    require_int_range,
+    require_non_empty_str,
+    require_optional_positive_finite_number,
+    require_positive_int,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TcpServerSettings:
+    """
+    Configuration for a TCP server listener.
+
+    Attributes:
+        host: Bind address (non-empty, non-whitespace). Use ``"0.0.0.0"`` or
+            ``"::"`` to listen on all interfaces.
+        port: Listen port in the range ``1..65535``.
+        max_connections: Maximum simultaneously tracked live client connections.
+            Must be ``> 0`` and is intentionally explicit because the library is
+            transport-level and should not silently accept unbounded server fan-in.
+        connection_idle_timeout_seconds: Optional per-connection receive idle timeout.
+            ``None`` disables idle-timeout enforcement.
+        broadcast_concurrency_limit: Maximum number of concurrent per-connection
+            broadcast sends. Must be ``> 0``.
+        broadcast_send_timeout_seconds: Optional timeout applied to each individual
+            per-connection broadcast send. ``None`` disables the timeout.
+        heartbeat: Server-side TCP keep-alive scheduling policy. When
+            ``enabled=True`` the configured ``HeartbeatProviderProtocol`` is
+            asked every interval whether to send a heartbeat payload to each
+            connected client. Defaults to disabled.
+        receive_buffer_size: Max bytes read per underlying receive call for
+            each accepted connection. Must be ``> 0``. Defaults to 4096.
+        backlog: Maximum queued pending connections passed to ``listen(2)``.
+            Must be ``> 0``. Defaults to 100.
+        event_delivery: Dispatch mode, buffering, and handler-failure policy
+            controls for events emitted by this server.
+    """
+
+    host: str
+    port: int
+    max_connections: int
+    connection_idle_timeout_seconds: float | None = None
+    broadcast_concurrency_limit: int = 64
+    broadcast_send_timeout_seconds: float | None = None
+    heartbeat: TcpHeartbeatSettings = field(default_factory=TcpHeartbeatSettings)
+    receive_buffer_size: int = 4096
+    backlog: int = 100
+    event_delivery: EventDeliverySettings = field(default_factory=EventDeliverySettings)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate TCP server listener settings.
+
+        Raises:
+            InvalidNetworkConfigurationError: If host/port/backlog/buffer inputs
+                are invalid.
+        """
+        require_non_empty_str(field_name="TcpServerSettings.host", value=self.host)
+        require_int_range(
+            field_name="TcpServerSettings.port",
+            value=self.port,
+            min_value=1,
+            max_value=65535,
+        )
+        require_positive_int(
+            field_name="TcpServerSettings.max_connections", value=self.max_connections
+        )
+        require_optional_positive_finite_number(
+            field_name="TcpServerSettings.connection_idle_timeout_seconds",
+            value=self.connection_idle_timeout_seconds,
+        )
+        require_positive_int(
+            field_name="TcpServerSettings.broadcast_concurrency_limit",
+            value=self.broadcast_concurrency_limit,
+        )
+        require_optional_positive_finite_number(
+            field_name="TcpServerSettings.broadcast_send_timeout_seconds",
+            value=self.broadcast_send_timeout_seconds,
+        )
+        require_positive_int(
+            field_name="TcpServerSettings.receive_buffer_size",
+            value=self.receive_buffer_size,
+        )
+        require_positive_int(field_name="TcpServerSettings.backlog", value=self.backlog)
+        self.heartbeat.validate()
+        self.event_delivery.validate()
+
+
+class TcpServerProtocol(ManagedTransportProtocol, Protocol):
+    """
+    TCP server contract built on managed lifecycle capability.
+
+    The server owns listener lifecycle plus a tracked set of accepted
+    connections. Connection admission, timeout, and broadcast behavior are
+    explicit settings concerns rather than hidden implementation details.
+    """
+
+    @property
+    def connections(self) -> tuple[ConnectionProtocol, ...]:
+        """
+        Return a snapshot of currently tracked client connections.
+
+        Rejected or already-closed connections are never part of this tuple.
+        """
+        ...
+
+    async def wait_until_running(
+        self,
+        timeout_seconds: float | None = None,
+        poll_interval_seconds: float = 0.1,
+    ) -> None:
+        """
+        Wait until server lifecycle reaches RUNNING.
+
+        Raises:
+            ConnectionError: If the server is started and then returns to
+                STOPPED before reaching RUNNING.
+            asyncio.TimeoutError: When ``timeout_seconds`` is provided and
+                timeout expires.
+        """
+        ...
+
+    async def broadcast(self, data: BytesLike) -> None:
+        """
+        Send raw bytes-like payload to the current connection snapshot.
+
+        Implementations may fan out concurrently, but a slow client must not
+        serialize all peers behind it. Per-connection failures remain
+        observable through events and may still cause this call to raise after
+        best-effort delivery/cleanup.
+        """
+        ...
+
+
+__all__ = (
+    "TcpServerProtocol",
+    "TcpServerSettings",
+)

--- a/src/aionetx/api/typed_event_router.py
+++ b/src/aionetx/api/typed_event_router.py
@@ -1,0 +1,87 @@
+"""
+Composable typed router for ``NetworkEvent`` handlers.
+
+This module offers a composition-first alternative to subclassing
+``BaseNetworkEventHandler`` when callers want one unified ``on_event`` entry
+point backed by per-event handlers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from aionetx.api.network_event import NetworkEvent
+
+TEvent = TypeVar("TEvent", bound=NetworkEvent)
+EventHandler = Callable[[NetworkEvent], Awaitable[None]]
+
+
+class TypedEventRouter:
+    """
+    Composable typed event router for unified `on_event` handlers.
+
+    Use this when you prefer composition over subclassing `BaseNetworkEventHandler`.
+
+    Dispatch is intentionally single-handler (no fan-out):
+    1) closest event type in MRO wins,
+    2) ties are resolved by earliest registration order.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: list[tuple[type[object], EventHandler]] = []
+
+    def register(
+        self, event_type: type[TEvent], handler: Callable[[TEvent], Awaitable[None]]
+    ) -> None:
+        """
+        Register one async handler for an event type.
+
+        Args:
+            event_type: Concrete event class that should be matched.
+            handler: Async callback invoked when the best-match dispatch
+                algorithm selects ``event_type`` for an incoming event.
+        """
+
+        async def _wrapped(event: NetworkEvent) -> None:
+            await handler(event)  # type: ignore[arg-type]
+
+        self._handlers.append((event_type, _wrapped))
+
+    async def dispatch(self, event: NetworkEvent) -> bool:
+        """
+        Dispatch to one best-matching handler.
+
+        Returns ``True`` when a handler is selected and awaited, otherwise
+        returns ``False``.
+        """
+        event_mro = type(event).mro()
+        selected_handler: EventHandler | None = None
+        best_distance: int | None = None
+        best_registration_index: int | None = None
+
+        for registration_index, (event_type, handler) in enumerate(self._handlers):
+            if not isinstance(event, event_type):
+                continue
+            try:
+                distance = event_mro.index(event_type)
+            except ValueError:
+                distance = len(event_mro)
+
+            if (
+                best_distance is None
+                or distance < best_distance
+                or (
+                    distance == best_distance
+                    and best_registration_index is not None
+                    and registration_index < best_registration_index
+                )
+            ):
+                best_distance = distance
+                best_registration_index = registration_index
+                selected_handler = handler
+
+        if selected_handler is not None:
+            await selected_handler(event)
+            return True
+        return False

--- a/src/aionetx/api/udp.py
+++ b/src/aionetx/api/udp.py
@@ -56,7 +56,7 @@ class UdpSenderProtocol(ByteSenderProtocol, Protocol):
             UdpSenderStoppedError: If the sender has already been stopped.
             OSError: If the underlying UDP socket reports a send failure.
         """
-        ...
+        raise NotImplementedError
 
     async def stop(self) -> None:
         """
@@ -66,11 +66,11 @@ class UdpSenderProtocol(ByteSenderProtocol, Protocol):
         transition. Implementations must be idempotent. After stop, send()
         must raise.
         """
-        ...
+        raise NotImplementedError
 
     async def __aenter__(self) -> UdpSenderProtocol:
         """Return ``self``; UDP sender is lazy and needs no explicit start."""
-        ...
+        raise NotImplementedError
 
     async def __aexit__(
         self,
@@ -79,7 +79,7 @@ class UdpSenderProtocol(ByteSenderProtocol, Protocol):
         exc_tb: TracebackType | None,
     ) -> None:
         """Close the sender's socket unconditionally."""
-        ...
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aionetx/api/udp.py
+++ b/src/aionetx/api/udp.py
@@ -1,0 +1,187 @@
+"""
+Public UDP sender and receiver settings, protocols, and exceptions.
+
+This module defines the lifecycle-light UDP sender surface together with the
+managed UDP receiver protocol and their configuration dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Protocol
+
+from aionetx.api.byte_sender_protocol import ByteSenderProtocol
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+from aionetx.api.errors import NetworkConfigurationError, NetworkRuntimeError
+from aionetx.api._validation import (
+    require_bool,
+    require_int_range,
+    require_non_empty_str,
+    require_optional_non_empty_str,
+    require_positive_int,
+)
+
+
+class UdpSenderProtocol(ByteSenderProtocol, Protocol):
+    """
+    UDP sender contract built on shared byte-sender capability.
+
+    This role is intentionally stateless/fire-and-forget at API level:
+    no lifecycle state/events and no ``ManagedTransportProtocol``.
+    Addressing semantics intentionally differ from connected senders:
+    ``host``/``port`` can override target selection per send call.
+    """
+
+    async def send(
+        self,
+        data: BytesLike,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> None:
+        """
+        Send raw bytes-like datagram data to a target host and port.
+
+        Args:
+            data: Datagram payload to send.
+            host: Optional per-call target host override.
+            port: Optional per-call target port override.
+
+        Raises:
+            TypeError: If ``data`` is not bytes-like.
+            UdpInvalidTargetError: If the resolved target host/port is missing
+                or invalid.
+            UdpSenderStoppedError: If the sender has already been stopped.
+            OSError: If the underlying UDP socket reports a send failure.
+        """
+        ...
+
+    async def stop(self) -> None:
+        """
+        Close sender socket resources.
+
+        This is resource finalization, not a managed component lifecycle
+        transition. Implementations must be idempotent. After stop, send()
+        must raise.
+        """
+        ...
+
+    async def __aenter__(self) -> UdpSenderProtocol:
+        """Return ``self``; UDP sender is lazy and needs no explicit start."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Close the sender's socket unconditionally."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class UdpSenderSettings:
+    """
+    Configuration for sending generic UDP datagrams.
+
+    Target resolution precedence at send-time is:
+    1) explicit ``send(..., host=..., port=...)`` arguments
+    2) ``default_host`` / ``default_port`` from these settings
+
+    Partial explicit targets are supported. For example ``send(host="x")``
+    uses ``port=default_port`` and vice versa.
+    """
+
+    default_host: str | None = None
+    default_port: int | None = None
+    local_host: str = "0.0.0.0"
+    local_port: int = 0
+    enable_broadcast: bool = False
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate UDP sender configuration.
+
+        Raises:
+            InvalidNetworkConfigurationError: If bind or default target values
+                are empty or outside valid UDP bounds. Missing default target
+                values are allowed when every send call provides a target.
+        """
+        require_optional_non_empty_str(
+            field_name="UdpSenderSettings.default_host", value=self.default_host
+        )
+        if self.default_port is not None:
+            require_int_range(
+                field_name="UdpSenderSettings.default_port",
+                value=self.default_port,
+                min_value=1,
+                max_value=65535,
+            )
+        require_non_empty_str(field_name="UdpSenderSettings.local_host", value=self.local_host)
+        require_int_range(
+            field_name="UdpSenderSettings.local_port",
+            value=self.local_port,
+            min_value=0,
+            max_value=65535,
+        )
+        require_bool(
+            field_name="UdpSenderSettings.enable_broadcast",
+            value=self.enable_broadcast,
+        )
+
+
+class UdpSenderStoppedError(NetworkRuntimeError):
+    """Raised when send() is attempted after a UDP sender has been stopped."""
+
+
+class UdpInvalidTargetError(NetworkConfigurationError):
+    """Raised when a UDP send target is missing or invalid."""
+
+
+class UdpReceiverProtocol(ManagedTransportProtocol, Protocol):
+    """UDP datagram receiver contract built on managed lifecycle capability."""
+
+
+@dataclass(frozen=True, slots=True)
+class UdpReceiverSettings:
+    """Configuration for receiving generic UDP datagrams."""
+
+    host: str
+    port: int
+    receive_buffer_size: int = 65535
+    enable_broadcast: bool = False
+    event_delivery: EventDeliverySettings = field(default_factory=EventDeliverySettings)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """
+        Validate UDP receiver configuration.
+
+        Raises:
+            InvalidNetworkConfigurationError: If bind or receive-buffer values
+                are missing or outside valid UDP bounds.
+        """
+        require_non_empty_str(field_name="UdpReceiverSettings.host", value=self.host)
+        require_int_range(
+            field_name="UdpReceiverSettings.port",
+            value=self.port,
+            min_value=1,
+            max_value=65535,
+        )
+        require_positive_int(
+            field_name="UdpReceiverSettings.receive_buffer_size",
+            value=self.receive_buffer_size,
+        )
+        require_bool(
+            field_name="UdpReceiverSettings.enable_broadcast",
+            value=self.enable_broadcast,
+        )
+        self.event_delivery.validate()

--- a/src/aionetx/factories/__init__.py
+++ b/src/aionetx/factories/__init__.py
@@ -1,0 +1,10 @@
+"""
+Factory entry points for concrete backend implementations.
+
+The public package root re-exports :class:`AsyncioNetworkFactory`, but this
+subpackage keeps the actual factory implementation in one focused place.
+"""
+
+from aionetx.factories.asyncio_network_factory import AsyncioNetworkFactory
+
+__all__ = ["AsyncioNetworkFactory"]

--- a/src/aionetx/factories/asyncio_network_factory.py
+++ b/src/aionetx/factories/asyncio_network_factory.py
@@ -1,0 +1,141 @@
+"""
+Asyncio-backed factory implementation for all supported transport roles.
+
+This module contains the concrete ``NetworkFactory`` implementation that
+constructs TCP, UDP, and multicast transports for the asyncio backend.
+"""
+
+from __future__ import annotations
+
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.multicast_receiver_protocol import MulticastReceiverProtocol
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.network_factory import NetworkFactory
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.tcp_client import TcpClientProtocol, TcpClientSettings
+from aionetx.api.tcp_server import TcpServerProtocol, TcpServerSettings
+from aionetx.api.udp import (
+    UdpReceiverProtocol,
+    UdpReceiverSettings,
+    UdpSenderProtocol,
+    UdpSenderSettings,
+)
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import AsyncioMulticastReceiver
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+from aionetx.implementations.asyncio_impl.runtime_utils import validate_heartbeat_provider
+
+
+class AsyncioNetworkFactory(NetworkFactory):
+    """
+    Factory that creates asyncio-based network layer components.
+
+    Construction symmetry:
+    - Managed transports (TCP client/server + datagram receivers) accept an
+      event handler because they emit runtime events.
+    - UDP sender is intentionally lifecycle-light and stateless from an event
+      stream perspective; it therefore requires only sender settings.
+    - The concrete asyncio implementation satisfies the explicit
+      ``aionetx.api.NetworkFactory`` contract.
+    """
+
+    def create_tcp_client(
+        self,
+        settings: TcpClientSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+    ) -> TcpClientProtocol:
+        """
+        Create an asyncio TCP client transport.
+
+        Args:
+            settings: TCP client configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+            heartbeat_provider: Optional heartbeat provider used when client
+                heartbeat scheduling is enabled.
+
+        Returns:
+            A transport implementing ``TcpClientProtocol``.
+        """
+        validate_heartbeat_provider(
+            heartbeat_settings=settings.heartbeat,
+            heartbeat_provider=heartbeat_provider,
+        )
+        return AsyncioTcpClient(
+            settings=settings,
+            event_handler=event_handler,
+            heartbeat_provider=heartbeat_provider,
+        )
+
+    def create_tcp_server(
+        self,
+        settings: TcpServerSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+    ) -> TcpServerProtocol:
+        """
+        Create an asyncio TCP server transport.
+
+        Args:
+            settings: TCP server configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+            heartbeat_provider: Optional heartbeat provider used when server
+                heartbeat scheduling is enabled.
+
+        Returns:
+            A transport implementing ``TcpServerProtocol``.
+        """
+        validate_heartbeat_provider(
+            heartbeat_settings=settings.heartbeat,
+            heartbeat_provider=heartbeat_provider,
+        )
+        return AsyncioTcpServer(
+            settings=settings,
+            event_handler=event_handler,
+            heartbeat_provider=heartbeat_provider,
+        )
+
+    def create_multicast_receiver(
+        self,
+        settings: MulticastReceiverSettings,
+        event_handler: NetworkEventHandlerProtocol,
+    ) -> MulticastReceiverProtocol:
+        """
+        Create an asyncio multicast receiver.
+
+        Args:
+            settings: Multicast receiver configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+
+        Returns:
+            A transport implementing ``MulticastReceiverProtocol``.
+        """
+        return AsyncioMulticastReceiver(settings=settings, event_handler=event_handler)
+
+    def create_udp_receiver(
+        self,
+        settings: UdpReceiverSettings,
+        event_handler: NetworkEventHandlerProtocol,
+    ) -> UdpReceiverProtocol:
+        """
+        Create an asyncio UDP receiver.
+
+        Args:
+            settings: UDP receiver configuration.
+            event_handler: Async event handler for lifecycle, data, and error events.
+
+        Returns:
+            A transport implementing ``UdpReceiverProtocol``.
+        """
+        return AsyncioUdpReceiver(settings=settings, event_handler=event_handler)
+
+    def create_udp_sender(self, settings: UdpSenderSettings) -> UdpSenderProtocol:
+        """
+        Create a UDP sender.
+
+        UDP sender intentionally does not implement managed lifecycle/event
+        contracts: it is a lightweight bytes sender with lazy socket creation.
+        """
+        return AsyncioUdpSender(settings=settings)

--- a/src/aionetx/implementations/__init__.py
+++ b/src/aionetx/implementations/__init__.py
@@ -1,0 +1,18 @@
+"""
+Internal implementation namespace.
+
+This module intentionally does not re-export concrete runtime classes.
+Stable imports are curated at package root (``aionetx``) and
+``aionetx.api``. Importing from ``aionetx.implementations`` is
+supported only for tests and advanced internal integrations and may change
+between releases.
+"""
+
+__all__: list[str] = []
+
+
+def __getattr__(name: str) -> object:
+    raise AttributeError(
+        f"module 'aionetx.implementations' has no attribute {name!r}. "
+        "This module is internal; import from 'aionetx' instead."
+    )

--- a/src/aionetx/implementations/asyncio_impl/__init__.py
+++ b/src/aionetx/implementations/asyncio_impl/__init__.py
@@ -1,0 +1,16 @@
+"""
+Asyncio implementation namespace (internal and unstable).
+
+Concrete runtime modules/classes in this package are implementation details.
+Prefer construction via ``aionetx.AsyncioNetworkFactory`` and protocol
+imports from ``aionetx`` / ``aionetx.api``.
+"""
+
+__all__: list[str] = []
+
+
+def __getattr__(name: str) -> object:
+    raise AttributeError(
+        f"aionetx.implementations.asyncio_impl.{name} is internal and unstable; "
+        "construct transports via AsyncioNetworkFactory instead."
+    )

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -145,9 +145,8 @@ class _AsyncioDatagramReceiverBase:
         """
         await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
 
-    def _cleanup_socket(self, sock: socket.socket) -> None:
+    def _cleanup_socket(self, _sock: socket.socket) -> None:
         """Subclass extension point for socket-specific cleanup before close."""
-        del sock
 
     @property
     def _running(self) -> bool:
@@ -266,23 +265,23 @@ class _AsyncioDatagramReceiverBase:
         first_error: BaseException | None = None
         try:
             await self._publish_stopping_transition(snapshot)
-        except BaseException as error:
+        except (Exception, asyncio.CancelledError) as error:
             first_error = error
         try:
             await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
-        except BaseException as error:
+        except (Exception, asyncio.CancelledError) as error:
             if first_error is None:
                 first_error = error
         if first_error is None:
             try:
                 await self._publish_closed_event_if_needed(snapshot)
-            except BaseException as error:
+            except (Exception, asyncio.CancelledError) as error:
                 first_error = error
         await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
         if snapshot.stop_dispatcher:
             try:
                 await self._event_dispatcher.stop()
-            except BaseException as error:
+            except (Exception, asyncio.CancelledError) as error:
                 if first_error is None:
                     first_error = error
         if first_error is not None:
@@ -353,7 +352,7 @@ class _AsyncioDatagramReceiverBase:
             if snapshot.task is not asyncio.current_task():
                 snapshot.task.cancel()
                 try:
-                    await snapshot.task
+                    _ = await cast("asyncio.Task[object]", snapshot.task)
                 except asyncio.CancelledError as error:
                     current_task = asyncio.current_task()
                     cancelling = getattr(current_task, "cancelling", None)
@@ -440,7 +439,7 @@ class _AsyncioDatagramReceiverBase:
             starting_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
         try:
             await self._emit_lifecycle_event(starting_event)
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             await self._rollback_failed_starting_publication()
             raise
         return True
@@ -465,8 +464,8 @@ class _AsyncioDatagramReceiverBase:
             await self._event_dispatcher.emit(
                 ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
             )
-        except BaseException:
-            with contextlib.suppress(BaseException):
+        except (Exception, asyncio.CancelledError):
+            with contextlib.suppress(Exception, asyncio.CancelledError):
                 await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
             raise
         async with self._state_lock:
@@ -505,5 +504,5 @@ class _AsyncioDatagramReceiverBase:
                 self._connection_metadata = None
                 self._connection_state = ConnectionState.CREATED
                 self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._event_dispatcher.stop()

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -1,0 +1,509 @@
+"""
+Shared asyncio datagram receiver lifecycle and teardown helpers.
+
+This module centralizes the startup, receive-loop, and ordered stop behavior
+used by UDP and multicast receivers so both transports publish the same
+lifecycle and connection events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+from collections.abc import Callable
+from dataclasses import dataclass
+from logging import Logger, LoggerAdapter
+from typing import cast
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.implementations.asyncio_impl.event_dispatcher import (
+    AsyncioEventDispatcher,
+    DispatcherRuntimeStats,
+)
+from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
+from aionetx.implementations.asyncio_impl.lifecycle_internal import (
+    LifecycleTransitionPublisher,
+    emit_lifecycle_event,
+)
+from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+from aionetx.implementations.asyncio_impl.runtime_utils import assert_running_on_owner_loop
+
+SocketCleanup = Callable[[socket.socket], None]
+_recv_fallback_warning_limiter = WarningRateLimiter(interval_seconds=300.0)
+
+
+@dataclass(slots=True)
+class _DatagramRuntimeState:
+    """Mutable runtime fields shared by datagram receiver implementations."""
+
+    running: bool = False
+    sock: socket.socket | None = None
+    task: asyncio.Task[None] | None = None
+    lifecycle_state: ComponentLifecycleState = ComponentLifecycleState.STOPPED
+    connection_state: ConnectionState = ConnectionState.CREATED
+    metadata: ConnectionMetadata | None = None
+    recv_fallback_warning_emitted: bool = False
+
+
+@dataclass(slots=True)
+class _DatagramStopSnapshot:
+    """
+    Detached stop plan consumed after leaving the state lock.
+
+    Attributes:
+        stop_dispatcher: Whether dispatcher shutdown must run after stop-path events.
+        should_transition_to_stopped: Whether STOPPED should be published after teardown.
+        should_emit_closed_event: Whether the stop path should publish ``ConnectionClosedEvent``.
+        previous_connection_state: Connection state to report in the close event.
+        task: Receive task detached from runtime state.
+        sock: Socket detached from runtime state.
+        stopping_event: Precomputed STOPPING lifecycle event, if any.
+    """
+
+    stop_dispatcher: bool = False
+    should_transition_to_stopped: bool = False
+    should_emit_closed_event: bool = False
+    previous_connection_state: ConnectionState = ConnectionState.CREATED
+    task: asyncio.Task[None] | None = None
+    sock: socket.socket | None = None
+    stopping_event: ComponentLifecycleChangedEvent | None = None
+
+    @property
+    def is_noop(self) -> bool:
+        """Whether stop planning found the receiver already fully stopped."""
+        return (
+            self.stopping_event is None
+            and not self.should_transition_to_stopped
+            and not self.should_emit_closed_event
+            and self.task is None
+            and self.sock is None
+        )
+
+
+class _AsyncioDatagramReceiverBase:
+    """
+    Shared internals for asyncio datagram receiver implementations.
+
+    The base class keeps startup and shutdown sequencing identical across
+    datagram transports so users observe the same lifecycle transitions,
+    connection events, and error reporting regardless of socket type.
+    """
+
+    _WOULD_BLOCK_INITIAL_DELAY_SECONDS = 0.0005
+    _WOULD_BLOCK_MAX_DELAY_SECONDS = 0.02
+
+    def __init__(
+        self,
+        *,
+        receiver_name: str,
+        connection_id: str,
+        logger: Logger | LoggerAdapter[Logger],
+        event_dispatcher: AsyncioEventDispatcher,
+        lifecycle_role: LifecycleRole,
+    ) -> None:
+        self._receiver_name = receiver_name
+        self._connection_id = connection_id
+        self._logger = logger
+        self._event_dispatcher = event_dispatcher
+
+        self._runtime = _DatagramRuntimeState()
+        self._lifecycle_publisher = LifecycleTransitionPublisher(
+            component_name=connection_id,
+            resource_id=connection_id,
+            role=lifecycle_role,
+            get_state=lambda: self._runtime.lifecycle_state,
+            set_state=lambda state: setattr(self._runtime, "lifecycle_state", state),
+        )
+        self._state_lock = asyncio.Lock()
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+
+    def _assert_owner_loop(self) -> None:
+        """
+        Raise RuntimeError if called outside the owner event loop.
+
+        Also pins ``_owner_loop`` on first call so all subsequent guard checks
+        use the same loop identity drawn from ``runtime_utils.asyncio`` - not
+        from a potentially test-patched module-level asyncio import.
+        """
+        self._owner_loop = assert_running_on_owner_loop(
+            class_name=type(self).__name__, owner_loop=self._owner_loop
+        )
+
+    async def stop(self) -> None:
+        """
+        Stop the receiver, tear down detached resources, and publish final events.
+
+        The public stop path delegates to the ordered internal shutdown helper
+        so subclasses inherit the same teardown semantics.
+        """
+        await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
+
+    def _cleanup_socket(self, sock: socket.socket) -> None:
+        """Subclass extension point for socket-specific cleanup before close."""
+        del sock
+
+    @property
+    def _running(self) -> bool:
+        return self._runtime.running
+
+    @_running.setter
+    def _running(self, value: bool) -> None:
+        self._runtime.running = value
+
+    @property
+    def _socket(self) -> socket.socket | None:
+        return self._runtime.sock
+
+    @_socket.setter
+    def _socket(self, value: socket.socket | None) -> None:
+        self._runtime.sock = value
+
+    @property
+    def _task(self) -> asyncio.Task[None] | None:
+        return self._runtime.task
+
+    @_task.setter
+    def _task(self, value: asyncio.Task[None] | None) -> None:
+        self._runtime.task = value
+
+    @property
+    def _lifecycle_state(self) -> ComponentLifecycleState:
+        return self._runtime.lifecycle_state
+
+    @property
+    def _connection_state(self) -> ConnectionState:
+        return self._runtime.connection_state
+
+    @_connection_state.setter
+    def _connection_state(self, value: ConnectionState) -> None:
+        self._runtime.connection_state = value
+
+    @property
+    def _connection_metadata(self) -> ConnectionMetadata | None:
+        return self._runtime.metadata
+
+    @_connection_metadata.setter
+    def _connection_metadata(self, value: ConnectionMetadata | None) -> None:
+        self._runtime.metadata = value
+
+    def _apply_lifecycle_state(
+        self, next_state: ComponentLifecycleState
+    ) -> ComponentLifecycleChangedEvent | None:
+        return self._lifecycle_publisher.apply(next_state)
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Dispatcher operational snapshot for runtime diagnostics."""
+        return self._event_dispatcher.runtime_stats
+
+    async def _emit_lifecycle_event(self, event: ComponentLifecycleChangedEvent | None) -> None:
+        await emit_lifecycle_event(dispatcher=self._event_dispatcher, event=event)
+
+    async def _set_lifecycle_state(self, next_state: ComponentLifecycleState) -> None:
+        event = self._apply_lifecycle_state(next_state)
+        await self._emit_lifecycle_event(event)
+
+    async def _receive_datagrams(self, receive_buffer_size: int) -> None:
+        """Read datagrams until stop, emitting payload and error events as needed."""
+        if self._socket is None:
+            return
+        loop = asyncio.get_running_loop()
+        try:
+            while self._running:
+                data, sender = await self._recv_nonblocking(loop, self._socket, receive_buffer_size)
+                remote_host = (
+                    str(sender[0]) if isinstance(sender, tuple) and len(sender) >= 2 else None
+                )
+                remote_port = (
+                    int(sender[1]) if isinstance(sender, tuple) and len(sender) >= 2 else None
+                )
+                await self._event_dispatcher.emit(
+                    BytesReceivedEvent(
+                        resource_id=self._connection_id,
+                        data=data,
+                        remote_host=remote_host,
+                        remote_port=remote_port,
+                    )
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            self._logger.warning("%s receive loop error: %s", self._receiver_name, error)
+            await self._event_dispatcher.emit(
+                NetworkErrorEvent(resource_id=self._connection_id, error=error)
+            )
+        finally:
+            if self._running:
+                # The task is already on the owner loop, so it shuts down
+                # internally instead of re-entering the public guard that exists
+                # to catch cross-loop user calls.
+                await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
+
+    async def _stop_datagram_receiver(self, socket_cleanup: SocketCleanup | None = None) -> None:
+        """
+        Stop the receiver in ordered phases.
+
+        The method first snapshots state under lock, then performs slow teardown
+        and event publication outside the lock so concurrent callers see a
+        stable stop plan without blocking on socket cleanup.
+
+        Flow overview:
+            lock      : plan snapshot, detach task/socket, compute STOPPING
+            unlock    : emit STOPPING
+            unlock    : cancel task and close socket
+            unlock    : emit ConnectionClosedEvent when this is not startup rollback
+            lock      : compute STOPPED
+            unlock    : emit STOPPED and stop dispatcher
+        """
+        snapshot = await self._plan_stop_snapshot()
+        first_error: BaseException | None = None
+        try:
+            await self._publish_stopping_transition(snapshot)
+        except BaseException as error:
+            first_error = error
+        try:
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except BaseException as error:
+            if first_error is None:
+                first_error = error
+        if first_error is None:
+            try:
+                await self._publish_closed_event_if_needed(snapshot)
+            except BaseException as error:
+                first_error = error
+        await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
+        if snapshot.stop_dispatcher:
+            try:
+                await self._event_dispatcher.stop()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+    async def _plan_stop_snapshot(self) -> _DatagramStopSnapshot:
+        """Detach stop-time resources under lock and return the resulting stop snapshot."""
+        snapshot = _DatagramStopSnapshot()
+        async with self._state_lock:
+            snapshot.previous_connection_state = self._connection_state
+            pre_transition_lifecycle_state = self._lifecycle_state
+            if self._is_fully_stopped_locked():
+                snapshot.stop_dispatcher = True
+                return snapshot
+
+            if self._lifecycle_state != ComponentLifecycleState.STOPPED:
+                snapshot.stopping_event = self._apply_lifecycle_state(
+                    ComponentLifecycleState.STOPPING
+                )
+                snapshot.should_transition_to_stopped = True
+
+            self._running = False
+            snapshot.task = self._task
+            self._task = None
+            snapshot.sock = self._socket
+            self._socket = None
+            self._connection_state = ConnectionState.CLOSED
+            if pre_transition_lifecycle_state != ComponentLifecycleState.STARTING:
+                snapshot.should_emit_closed_event = True
+            snapshot.stop_dispatcher = True
+        return snapshot
+
+    async def _publish_stopping_transition(self, snapshot: _DatagramStopSnapshot) -> None:
+        """Emit the precomputed STOPPING event, if this stop path created one."""
+        if snapshot.is_noop:
+            return
+        await self._emit_lifecycle_event(snapshot.stopping_event)
+
+    async def _publish_closed_event_if_needed(self, snapshot: _DatagramStopSnapshot) -> None:
+        """Emit the connection-closed event unless stop is rolling back startup."""
+        if not snapshot.should_emit_closed_event:
+            return
+        await self._event_dispatcher.emit(
+            ConnectionClosedEvent(
+                resource_id=self._connection_id,
+                previous_state=snapshot.previous_connection_state,
+                metadata=self._connection_metadata,
+            )
+        )
+
+    def _is_fully_stopped_locked(self) -> bool:
+        """Return whether runtime state already represents a fully stopped receiver."""
+        return (
+            not self._running
+            and self._socket is None
+            and self._lifecycle_state == ComponentLifecycleState.STOPPED
+        )
+
+    async def _teardown_stop_resources(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        socket_cleanup: SocketCleanup | None,
+    ) -> None:
+        """Cancel the detached receive task and close the detached socket, if present."""
+        task_error: BaseException | None = None
+        if snapshot.task is not None:
+            if snapshot.task is not asyncio.current_task():
+                snapshot.task.cancel()
+                try:
+                    await snapshot.task
+                except asyncio.CancelledError as error:
+                    current_task = asyncio.current_task()
+                    cancelling = getattr(current_task, "cancelling", None)
+                    if current_task is not None and callable(cancelling) and cancelling():
+                        task_error = error
+
+        if snapshot.sock is not None:
+            if socket_cleanup is not None:
+                socket_cleanup(snapshot.sock)
+            snapshot.sock.close()
+        if snapshot.task is not None and snapshot.task is not asyncio.current_task():
+            if task_error is not None:
+                raise task_error
+
+    async def _publish_stopped_transition_if_needed(
+        self, snapshot: _DatagramStopSnapshot, *, emit_event: bool = True
+    ) -> None:
+        """Compute and emit the final STOPPED lifecycle event when required."""
+        if not snapshot.should_transition_to_stopped:
+            return
+        async with self._state_lock:
+            stopped_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+        if emit_event:
+            await self._emit_lifecycle_event(stopped_event)
+
+    async def _recv_nonblocking(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        sock: socket.socket,
+        receive_buffer_size: int,
+    ) -> tuple[bytes, object]:
+        """
+        Receive one datagram using the event loop helper or a polling fallback.
+
+        Returns:
+            tuple[bytes, object]: Payload bytes and the raw sender object returned by the socket.
+        """
+        runtime_sock_recvfrom = getattr(loop, "sock_recvfrom", None)
+        if callable(runtime_sock_recvfrom):
+            return cast(
+                tuple[bytes, object], await runtime_sock_recvfrom(sock, receive_buffer_size)
+            )
+
+        if not self._runtime.recv_fallback_warning_emitted:
+            limiter_key = f"{self._connection_id}:recvfrom-fallback"
+            if _recv_fallback_warning_limiter.should_log(limiter_key):
+                self._logger.warning(
+                    "%s is using recvfrom() fallback polling because the event loop "
+                    "does not expose sock_recvfrom().",
+                    self._receiver_name,
+                )
+            self._runtime.recv_fallback_warning_emitted = True
+
+        backoff_delay_seconds = self._WOULD_BLOCK_INITIAL_DELAY_SECONDS
+        while True:
+            try:
+                return sock.recvfrom(receive_buffer_size)
+            except (BlockingIOError, InterruptedError):
+                await asyncio.sleep(backoff_delay_seconds)
+                backoff_delay_seconds = min(
+                    self._WOULD_BLOCK_MAX_DELAY_SECONDS, backoff_delay_seconds * 2
+                )
+
+    async def _begin_startup(self) -> bool:
+        """
+        Begin receiver startup and publish STARTING when startup should proceed.
+
+        Returns:
+            bool: ``True`` when the caller should continue with socket setup.
+        """
+        starting_event: ComponentLifecycleChangedEvent | None = None
+        async with self._state_lock:
+            if self._lifecycle_state in (
+                ComponentLifecycleState.STARTING,
+                ComponentLifecycleState.RUNNING,
+            ):
+                self._logger.debug(
+                    "%s receiver start called while already running.", self._receiver_name
+                )
+                return False
+            # Keep dispatcher startup and the STARTING transition in one locked
+            # section so stop() cannot observe a half-started receiver.
+            await self._event_dispatcher.start()
+            starting_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
+        try:
+            await self._emit_lifecycle_event(starting_event)
+        except BaseException:
+            await self._rollback_failed_starting_publication()
+            raise
+        return True
+
+    async def _complete_startup(
+        self,
+        *,
+        sock: socket.socket,
+        metadata: ConnectionMetadata,
+        receive_buffer_size: int,
+    ) -> None:
+        """Attach socket state, publish open events, then start the receive task."""
+        running_event: ComponentLifecycleChangedEvent | None = None
+        async with self._state_lock:
+            self._socket = sock
+            self._running = True
+            self._connection_metadata = metadata
+            self._connection_state = ConnectionState.CONNECTED
+            running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
+        try:
+            await self._emit_lifecycle_event(running_event)
+            await self._event_dispatcher.emit(
+                ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
+            )
+        except BaseException:
+            with contextlib.suppress(BaseException):
+                await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
+            raise
+        async with self._state_lock:
+            if (
+                self._socket is not sock
+                or not self._running
+                or self._lifecycle_state != ComponentLifecycleState.RUNNING
+            ):
+                return
+            self._task = asyncio.create_task(
+                self._receive_datagrams(receive_buffer_size), name=f"{self._connection_id}-receiver"
+            )
+
+    async def _fail_startup(self) -> None:
+        """Roll startup back to a clean stopped state and quiesce the dispatcher."""
+        stopped_event: ComponentLifecycleChangedEvent | None = None
+        async with self._state_lock:
+            self._socket = None
+            self._running = False
+            self._task = None
+            self._connection_metadata = None
+            self._connection_state = ConnectionState.CREATED
+            stopped_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+        try:
+            await self._emit_lifecycle_event(stopped_event)
+        finally:
+            await self._event_dispatcher.stop()
+
+    async def _rollback_failed_starting_publication(self) -> None:
+        """Return STARTING publication failure to STOPPED without relying on handlers."""
+        async with self._state_lock:
+            if self._lifecycle_state == ComponentLifecycleState.STARTING:
+                self._socket = None
+                self._running = False
+                self._task = None
+                self._connection_metadata = None
+                self._connection_state = ConnectionState.CREATED
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+        with contextlib.suppress(BaseException):
+            await self._event_dispatcher.stop()

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
@@ -1,0 +1,176 @@
+"""
+TCP client connection and heartbeat helpers.
+
+These free functions keep connection establishment, heartbeat sender ownership,
+and wait logic focused and reusable outside the main client class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.identifier_utils import tcp_client_connection_id
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    WarningRateLimiter,
+    validate_heartbeat_provider,
+)
+
+if TYPE_CHECKING:
+    from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+    from aionetx.api.tcp_client import TcpClientSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+
+_warning_limiter = WarningRateLimiter(interval_seconds=30.0)
+
+
+async def connect_once(
+    *,
+    settings: "TcpClientSettings",
+    connection_opener: Callable[..., Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
+    event_dispatcher: AsyncioEventDispatcher,
+    on_closed_callback: Callable[["AsyncioTcpConnection"], Awaitable[None] | None],
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    component_id: str,
+) -> "AsyncioTcpConnection":
+    """
+    Open one TCP session and return an initialized connection object.
+
+    Applies keepalive, builds the connection ID, and starts the connection.
+    The caller is responsible for heartbeat start after this returns.
+    """
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+
+    connect_coro = connection_opener(host=settings.host, port=settings.port)
+    timeout = settings.connect_timeout_seconds
+    if timeout is not None:
+        try:
+            reader, writer = await asyncio.wait_for(connect_coro, timeout=timeout)
+        except asyncio.TimeoutError:
+            raise ConnectionError(
+                f"TCP connect to {settings.host}:{settings.port} timed out after {timeout:.3g}s."
+            ) from None
+    else:
+        reader, writer = await connect_coro
+    logger.debug("Established socket to %s:%s.", settings.host, settings.port)
+    _apply_tcp_keepalive(writer=writer, component_id=component_id, logger=logger)
+    peer_info = writer.get_extra_info("peername")
+    connection_id = tcp_client_connection_id(settings.host, settings.port, peer_info)
+    connection = AsyncioTcpConnection(
+        connection_id=connection_id,
+        role=ConnectionRole.CLIENT,
+        reader=reader,
+        writer=writer,
+        event_dispatcher=event_dispatcher,
+        receive_buffer_size=settings.receive_buffer_size,
+        on_closed_callback=on_closed_callback,
+    )
+    try:
+        await connection.start()
+    except BaseException:
+        with contextlib.suppress(BaseException):
+            await connection.close()
+        raise
+    return connection
+
+
+def _apply_tcp_keepalive(
+    *,
+    writer: asyncio.StreamWriter,
+    component_id: str,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+) -> None:
+    raw_socket = writer.get_extra_info("socket")
+    if raw_socket is None:
+        return
+    try:
+        raw_socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError:
+        if _warning_limiter.should_log(f"{component_id}/keepalive"):
+            logger.warning("Failed to enable TCP keepalive on client socket.")
+
+
+async def start_heartbeat_sender(
+    *,
+    connection: "AsyncioTcpConnection",
+    settings: "TcpClientSettings",
+    heartbeat_provider: "HeartbeatProviderProtocol | None",
+    event_dispatcher: AsyncioEventDispatcher,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+) -> "AsyncioHeartbeatSender | None":
+    """Start a heartbeat sender for the connection and return it, or ``None`` if disabled."""
+    validate_heartbeat_provider(
+        heartbeat_settings=settings.heartbeat,
+        heartbeat_provider=heartbeat_provider,
+    )
+    if not settings.heartbeat.enabled:
+        return None
+    # Keep the invariant explicit at this boundary so a missing provider fails
+    # immediately even if the validation call above changes in the future.
+    if heartbeat_provider is None:
+        raise RuntimeError(
+            "Heartbeat is enabled but no heartbeat_provider was supplied. "
+            "This is an internal invariant violation."
+        )
+    sender = AsyncioHeartbeatSender(
+        connection=connection,
+        settings=settings.heartbeat,
+        heartbeat_provider=heartbeat_provider,
+        event_dispatcher=event_dispatcher,
+    )
+    await sender.start()
+    logger.debug("Started TCP client heartbeat sender.")
+    return sender
+
+
+async def stop_heartbeat_sender(
+    *,
+    sender: "AsyncioHeartbeatSender | None",
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+) -> None:
+    """Stop a heartbeat sender if one is active."""
+    if sender is not None:
+        await sender.stop()
+        logger.debug("Stopped TCP client heartbeat sender.")
+
+
+async def wait_until_client_connected(
+    *,
+    get_connection: Callable[[], "ConnectionProtocol | None"],
+    get_lifecycle_state: Callable[[], ComponentLifecycleState],
+    get_has_started: Callable[[], bool],
+    get_last_connect_error: Callable[[], Exception | None],
+    get_reconnect_enabled: Callable[[], bool],
+    get_status_version: Callable[[], int],
+    status_changed: asyncio.Event,
+    host: str,
+    port: int,
+    poll_interval_seconds: float,
+) -> "ConnectionProtocol":
+    """Core poll loop for :meth:`AsyncioTcpClient.wait_until_connected`."""
+    while True:
+        connection = get_connection()
+        if connection is not None and connection.is_connected:
+            return connection
+        if get_lifecycle_state() == ComponentLifecycleState.STOPPED and get_has_started():
+            raise ConnectionError(f"TCP client for {host}:{port} is stopped.")
+        last_error = get_last_connect_error()
+        if last_error is not None and (
+            not get_reconnect_enabled() or get_lifecycle_state() == ComponentLifecycleState.STOPPED
+        ):
+            raise ConnectionError(f"TCP client failed to connect to {host}:{port}.") from last_error
+        observed_version = get_status_version()
+        status_changed.clear()
+        if get_status_version() != observed_version:
+            continue
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(status_changed.wait(), timeout=poll_interval_seconds)

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_lifecycle import ConnectionRole
 from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.tcp_client import TcpClientSettings
 from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.identifier_utils import tcp_client_connection_id
@@ -26,8 +28,6 @@ from aionetx.implementations.asyncio_impl.runtime_utils import (
 )
 
 if TYPE_CHECKING:
-    from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
-    from aionetx.api.tcp_client import TcpClientSettings
     from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
 
 _warning_limiter = WarningRateLimiter(interval_seconds=30.0)
@@ -35,7 +35,7 @@ _warning_limiter = WarningRateLimiter(interval_seconds=30.0)
 
 async def connect_once(
     *,
-    settings: "TcpClientSettings",
+    settings: TcpClientSettings,
     connection_opener: Callable[..., Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]],
     event_dispatcher: AsyncioEventDispatcher,
     on_closed_callback: Callable[["AsyncioTcpConnection"], Awaitable[None] | None],
@@ -76,8 +76,8 @@ async def connect_once(
     )
     try:
         await connection.start()
-    except BaseException:
-        with contextlib.suppress(BaseException):
+    except (Exception, asyncio.CancelledError):
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await connection.close()
         raise
     return connection
@@ -102,8 +102,8 @@ def _apply_tcp_keepalive(
 async def start_heartbeat_sender(
     *,
     connection: "AsyncioTcpConnection",
-    settings: "TcpClientSettings",
-    heartbeat_provider: "HeartbeatProviderProtocol | None",
+    settings: TcpClientSettings,
+    heartbeat_provider: HeartbeatProviderProtocol | None,
     event_dispatcher: AsyncioEventDispatcher,
     logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
 ) -> "AsyncioHeartbeatSender | None":

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_runtime.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_runtime.py
@@ -1,0 +1,110 @@
+"""
+Internal runtime-state container for the asyncio TCP client.
+
+This module groups the mutable client state that supervision and tests both
+need to observe, while preserving the private attribute surface expected by the
+client implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+
+if TYPE_CHECKING:
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+
+
+@dataclass
+class _ClientRuntimeState:
+    """Mutable client runtime state with explicit per-client ownership."""
+
+    running: bool = False
+    has_started: bool = False
+    connection: AsyncioTcpConnection | None = None
+    heartbeat_sender: AsyncioHeartbeatSender | None = None
+    connection_closed_event: asyncio.Event = field(default_factory=asyncio.Event)
+    last_connect_error: Exception | None = None
+    status_version: int = 0
+    attempt_counter: int = 0
+
+
+class _HasClientRuntime(Protocol):
+    """Structural protocol for objects that expose ``_runtime`` state."""
+
+    _runtime: _ClientRuntimeState
+
+
+class _ClientRuntimeAccessors:
+    """
+    Compatibility accessors for the internal client runtime state.
+
+    The client's tests and supervision helper refer to these private
+    attributes directly. Keeping them as accessors preserves the current
+    surface while allowing the state container to live in a focused module.
+    """
+
+    _runtime: _ClientRuntimeState
+
+    @property
+    def _running(self: _HasClientRuntime) -> bool:
+        return self._runtime.running
+
+    @_running.setter
+    def _running(self: _HasClientRuntime, value: bool) -> None:
+        self._runtime.running = value
+
+    @property
+    def _has_started(self: _HasClientRuntime) -> bool:
+        return self._runtime.has_started
+
+    @_has_started.setter
+    def _has_started(self: _HasClientRuntime, value: bool) -> None:
+        self._runtime.has_started = value
+
+    @property
+    def _connection(self: _HasClientRuntime) -> AsyncioTcpConnection | None:
+        return self._runtime.connection
+
+    @_connection.setter
+    def _connection(self: _HasClientRuntime, value: AsyncioTcpConnection | None) -> None:
+        self._runtime.connection = value
+
+    @property
+    def _heartbeat_sender(self: _HasClientRuntime) -> AsyncioHeartbeatSender | None:
+        return self._runtime.heartbeat_sender
+
+    @_heartbeat_sender.setter
+    def _heartbeat_sender(self: _HasClientRuntime, value: AsyncioHeartbeatSender | None) -> None:
+        self._runtime.heartbeat_sender = value
+
+    @property
+    def _last_connect_error(self: _HasClientRuntime) -> Exception | None:
+        return self._runtime.last_connect_error
+
+    @_last_connect_error.setter
+    def _last_connect_error(self: _HasClientRuntime, value: Exception | None) -> None:
+        self._runtime.last_connect_error = value
+
+    @property
+    def _status_version(self: _HasClientRuntime) -> int:
+        return self._runtime.status_version
+
+    @_status_version.setter
+    def _status_version(self: _HasClientRuntime, value: int) -> None:
+        self._runtime.status_version = value
+
+    @property
+    def _attempt_counter(self: _HasClientRuntime) -> int:
+        return self._runtime.attempt_counter
+
+    @_attempt_counter.setter
+    def _attempt_counter(self: _HasClientRuntime, value: int) -> None:
+        self._runtime.attempt_counter = value
+
+    @property
+    def _connection_closed_event(self: _HasClientRuntime) -> asyncio.Event:
+        return self._runtime.connection_closed_event

--- a/src/aionetx/implementations/asyncio_impl/_tcp_connection_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_connection_helpers.py
@@ -1,0 +1,130 @@
+"""
+TCP connection teardown and metadata helpers.
+
+These free functions keep shutdown waiting, writer teardown, and metadata
+construction logic shared and testable outside the connection class itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+
+
+async def await_read_task_shutdown(
+    *,
+    connection_id: str,
+    read_task: asyncio.Task[None],
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    warning_limiter: WarningRateLimiter,
+    timeout_seconds: float,
+) -> None:
+    """
+    Wait for the read task to finish after cancellation, logging anomalies.
+
+    Args:
+        connection_id: Canonical connection identifier used in logs.
+        read_task: Task running the connection read loop.
+        logger: Logger used for warnings and unexpected shutdown errors.
+        warning_limiter: Rate limiter used for repeated timeout warnings.
+        timeout_seconds: Maximum time to wait for task shutdown.
+    """
+    try:
+        await asyncio.wait_for(read_task, timeout=timeout_seconds)
+    except asyncio.CancelledError:
+        current_task = asyncio.current_task()
+        cancelling = getattr(current_task, "cancelling", None)
+        if current_task is not None and callable(cancelling) and cancelling():
+            raise
+    except TimeoutError:
+        if warning_limiter.should_log(f"tcp-connection-read-task-timeout:{connection_id}"):
+            logger.warning(
+                "Timed out waiting for read task shutdown during close after %.2fs.",
+                timeout_seconds,
+            )
+    except Exception:
+        logger.exception("Unexpected error while awaiting read task during close.")
+
+
+async def await_writer_shutdown(
+    *,
+    connection_id: str,
+    writer: asyncio.StreamWriter,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    warning_limiter: WarningRateLimiter,
+    timeout_seconds: float,
+) -> None:
+    """
+    Wait for ``writer.wait_closed()`` to finish, logging anomalies.
+
+    Args:
+        connection_id: Canonical connection identifier used in logs.
+        writer: Stream writer being shut down.
+        logger: Logger used for warnings and unexpected shutdown errors.
+        warning_limiter: Rate limiter used for repeated timeout warnings.
+        timeout_seconds: Maximum time to wait for writer shutdown.
+    """
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=timeout_seconds)
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
+        if warning_limiter.should_log(f"tcp-connection-wait-closed-timeout:{connection_id}"):
+            logger.warning(
+                "Timed out waiting for writer.wait_closed() during close after %.2fs.",
+                timeout_seconds,
+            )
+    except Exception:
+        logger.exception("Unexpected error while awaiting writer.wait_closed() during close.")
+
+
+def build_connection_metadata(
+    *,
+    connection_id: str,
+    role: ConnectionRole,
+    writer: asyncio.StreamWriter,
+) -> ConnectionMetadata:
+    """
+    Build connection metadata from the stream writer's addressing information.
+
+    Args:
+        connection_id: Canonical connection identifier.
+        role: Logical role of the connection endpoint.
+        writer: Stream writer exposing socket addressing details.
+
+    Returns:
+        A ``ConnectionMetadata`` snapshot with best-effort local and remote
+        host/port information.
+    """
+    local_info = writer.get_extra_info("sockname")
+    remote_info = writer.get_extra_info("peername")
+    local_host = (
+        str(local_info[0]) if isinstance(local_info, tuple) and len(local_info) >= 2 else None
+    )
+    local_port: int | None = None
+    if isinstance(local_info, tuple) and len(local_info) >= 2:
+        try:
+            local_port = int(local_info[1])
+        except (TypeError, ValueError):
+            local_port = None
+    remote_host = (
+        str(remote_info[0]) if isinstance(remote_info, tuple) and len(remote_info) >= 2 else None
+    )
+    remote_port: int | None = None
+    if isinstance(remote_info, tuple) and len(remote_info) >= 2:
+        try:
+            remote_port = int(remote_info[1])
+        except (TypeError, ValueError):
+            remote_port = None
+    return ConnectionMetadata(
+        connection_id=connection_id,
+        role=role,
+        local_host=local_host,
+        local_port=local_port,
+        remote_host=remote_host,
+        remote_port=remote_port,
+    )

--- a/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
@@ -1,0 +1,364 @@
+"""
+Shared helpers for TCP server coordination and teardown reporting.
+
+These free functions keep accept handling, heartbeat sender ownership,
+best-effort broadcast, and wait/poll logic focused and reusable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable, Iterable
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionRejectedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import (
+    AsyncioTcpConnection,
+    ConnectionClosedCallback,
+)
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.runtime_utils import validate_heartbeat_provider
+
+
+async def report_teardown_errors(
+    *,
+    event_dispatcher: AsyncioEventDispatcher,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    component_id: str,
+    operation: str,
+    targets: Iterable[str],
+    results: Iterable[object],
+) -> None:
+    """
+    Emit warnings and best-effort error events for teardown failures.
+
+    Args:
+        event_dispatcher: Dispatcher used for ``NetworkErrorEvent`` emission.
+        logger: Logger used for human-readable teardown warnings.
+        component_id: Canonical component identifier for emitted errors.
+        operation: Short operation label such as ``TCP connection close``.
+        targets: Logical targets paired with ``results`` for diagnostics.
+        results: Gathered teardown results that may include exceptions.
+    """
+    for target, result in zip(targets, results, strict=False):
+        if result is None:
+            continue
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Best-effort teardown %s failed for %s: %s",
+                operation,
+                target,
+                result,
+            )
+            if isinstance(result, Exception):
+                try:
+                    await event_dispatcher.emit(
+                        NetworkErrorEvent(resource_id=component_id, error=result),
+                    )
+                except Exception as reporting_error:
+                    logger.warning(
+                        "Failed to emit teardown NetworkErrorEvent for %s on %s: %s",
+                        operation,
+                        target,
+                        reporting_error,
+                    )
+
+
+async def wait_until_server_running(
+    *,
+    get_lifecycle_state: Callable[[], ComponentLifecycleState],
+    get_has_started: Callable[[], bool],
+    get_status_version: Callable[[], int],
+    status_changed: asyncio.Event,
+    host: str,
+    port: int,
+    poll_interval_seconds: float,
+) -> None:
+    """Poll loop core for AsyncioTcpServer.wait_until_running."""
+    while True:
+        if get_lifecycle_state() == ComponentLifecycleState.RUNNING:
+            return
+        if get_lifecycle_state() == ComponentLifecycleState.STOPPED and get_has_started():
+            raise ConnectionError(f"TCP server for {host}:{port} is stopped.")
+        observed_version = get_status_version()
+        status_changed.clear()
+        if get_status_version() != observed_version:
+            continue
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(status_changed.wait(), timeout=poll_interval_seconds)
+
+
+async def start_server_heartbeat_if_needed(
+    *,
+    connection: AsyncioTcpConnection,
+    heartbeat_settings: TcpHeartbeatSettings,
+    heartbeat_provider: HeartbeatProviderProtocol | None,
+    event_dispatcher: AsyncioEventDispatcher,
+    state_lock: asyncio.Lock,
+    get_lifecycle_state: Callable[[], ComponentLifecycleState],
+    connections: dict[str, AsyncioTcpConnection],
+    heartbeat_senders: dict[str, AsyncioHeartbeatSender],
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+) -> None:
+    """Start a heartbeat sender for a newly accepted connection if heartbeat is enabled."""
+    validate_heartbeat_provider(
+        heartbeat_settings=heartbeat_settings,
+        heartbeat_provider=heartbeat_provider,
+    )
+    if not heartbeat_settings.enabled:
+        return
+    # Keep the invariant explicit at this boundary so a missing provider fails
+    # immediately even if the validation call above changes in the future.
+    if heartbeat_provider is None:
+        raise RuntimeError(
+            "Heartbeat is enabled but no heartbeat_provider was supplied. "
+            "This is an internal invariant violation."
+        )
+    sender = AsyncioHeartbeatSender(
+        connection=connection,
+        settings=heartbeat_settings,
+        heartbeat_provider=heartbeat_provider,
+        event_dispatcher=event_dispatcher,
+    )
+    should_start = False
+    async with state_lock:
+        if (
+            get_lifecycle_state() == ComponentLifecycleState.RUNNING
+            and connection.connection_id in connections
+        ):
+            heartbeat_senders[connection.connection_id] = sender
+            should_start = True
+    if not should_start:
+        return
+    logger.debug("Starting heartbeat sender for %s.", connection.connection_id)
+    try:
+        await sender.start()
+    except Exception:
+        async with state_lock:
+            heartbeat_senders.pop(connection.connection_id, None)
+        raise
+
+
+async def stop_server_heartbeat_senders(
+    *,
+    senders: Iterable[AsyncioHeartbeatSender],
+    event_dispatcher: AsyncioEventDispatcher,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    component_id: str,
+) -> None:
+    """Stop a collection of heartbeat senders and report any teardown errors."""
+    sender_list = tuple(senders)
+    if sender_list:
+        stop_results = await asyncio.gather(
+            *(sender.stop() for sender in sender_list),
+            return_exceptions=True,
+        )
+        await report_teardown_errors(
+            event_dispatcher=event_dispatcher,
+            logger=logger,
+            component_id=component_id,
+            operation="heartbeat sender stop",
+            targets=(f"sender[{index}]" for index, _sender in enumerate(sender_list, start=1)),
+            results=stop_results,
+        )
+
+
+async def broadcast_to_connections(
+    *,
+    connections: Iterable[AsyncioTcpConnection],
+    data: BytesLike,
+    event_dispatcher: AsyncioEventDispatcher,
+    component_id: str,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+    concurrency_limit: int,
+    send_timeout_seconds: float | None,
+) -> None:
+    """Send data to a snapshot of live connections with bounded fan-out concurrency."""
+    live_connections = tuple(connection for connection in connections if connection.is_connected)
+    if not live_connections:
+        return
+
+    semaphore = asyncio.Semaphore(concurrency_limit)
+
+    async def _send_one(connection: AsyncioTcpConnection) -> Exception | None:
+        async with semaphore:
+            try:
+                if send_timeout_seconds is None:
+                    await connection.send(data)
+                else:
+                    await asyncio.wait_for(
+                        connection.send(data),
+                        timeout=send_timeout_seconds,
+                    )
+                return None
+            except Exception as error:
+                return error
+
+    results = await asyncio.gather(*(_send_one(connection) for connection in live_connections))
+
+    failed_connections: list[AsyncioTcpConnection] = []
+    for connection, result in zip(live_connections, results, strict=True):
+        if result is None:
+            continue
+        logger.warning(
+            "TCP server broadcast send failed for connection %s: %s",
+            connection.connection_id,
+            result,
+        )
+        failed_connections.append(connection)
+        with contextlib.suppress(Exception):
+            await event_dispatcher.emit(NetworkErrorEvent(resource_id=component_id, error=result))
+
+    if not failed_connections:
+        return
+
+    close_results = await asyncio.gather(
+        *(connection.close() for connection in failed_connections),
+        return_exceptions=True,
+    )
+    await report_teardown_errors(
+        event_dispatcher=event_dispatcher,
+        logger=logger,
+        component_id=component_id,
+        operation="TCP broadcast failed connection close",
+        targets=(connection.connection_id for connection in failed_connections),
+        results=close_results,
+    )
+
+
+def _extract_remote_peer_address(peer_info: object) -> tuple[str | None, int | None]:
+    """Return best-effort remote host/port extracted from ``peername``-style metadata."""
+    if not (isinstance(peer_info, tuple) and len(peer_info) >= 2):
+        return None, None
+    remote_host = str(peer_info[0])
+    try:
+        remote_port = int(peer_info[1])
+    except (TypeError, ValueError):
+        remote_port = None
+    return remote_host, remote_port
+
+
+async def handle_accepted_client(
+    *,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    state_lock: asyncio.Lock,
+    get_lifecycle_state: Callable[[], ComponentLifecycleState],
+    get_connection_id: Callable[[], str],
+    connections: dict[str, AsyncioTcpConnection],
+    event_dispatcher: AsyncioEventDispatcher,
+    max_connections: int,
+    receive_buffer_size: int,
+    idle_timeout_seconds: float | None,
+    on_closed_callback: ConnectionClosedCallback,
+    heartbeat_settings: TcpHeartbeatSettings,
+    heartbeat_provider: HeartbeatProviderProtocol | None,
+    heartbeat_senders: dict[str, AsyncioHeartbeatSender],
+    component_id: str,
+    logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+) -> None:
+    """Initialize one accepted socket into managed connection state."""
+    peer_info = writer.get_extra_info("peername")
+    remote_host, remote_port = _extract_remote_peer_address(peer_info)
+    rejection_event: ConnectionRejectedEvent | None = None
+    async with state_lock:
+        connection_id = get_connection_id()
+        if get_lifecycle_state() != ComponentLifecycleState.RUNNING:
+            logger.debug(
+                "Rejecting accepted TCP client connection %s because lifecycle=%s.",
+                connection_id,
+                get_lifecycle_state().value,
+            )
+            should_reject = True
+            connection = None
+        elif len(connections) >= max_connections:
+            logger.warning(
+                "Rejecting accepted TCP client connection %s because max_connections=%s is reached.",
+                connection_id,
+                max_connections,
+            )
+            should_reject = True
+            connection = None
+            rejection_event = ConnectionRejectedEvent(
+                resource_id=component_id,
+                connection_id=connection_id,
+                reason="max_connections_reached",
+                remote_host=remote_host,
+                remote_port=remote_port,
+            )
+        else:
+            logger.debug("Accepted TCP client connection %s.", connection_id)
+            should_reject = False
+            connection = AsyncioTcpConnection(
+                connection_id=connection_id,
+                role=ConnectionRole.SERVER,
+                reader=reader,
+                writer=writer,
+                event_dispatcher=event_dispatcher,
+                receive_buffer_size=receive_buffer_size,
+                idle_timeout_seconds=idle_timeout_seconds,
+                on_closed_callback=on_closed_callback,
+            )
+            connections[connection_id] = connection
+    if should_reject:
+        if rejection_event is not None:
+            try:
+                await event_dispatcher.emit(rejection_event)
+            except Exception as error:
+                logger.warning(
+                    "Failed to emit ConnectionRejectedEvent for %s: %s",
+                    connection_id,
+                    error,
+                )
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+        return
+    if connection is None:
+        raise RuntimeError(
+            "Connection is None after non-rejected accept. This is an internal invariant violation."
+        )
+    try:
+        await connection.start()
+        await start_server_heartbeat_if_needed(
+            connection=connection,
+            heartbeat_settings=heartbeat_settings,
+            heartbeat_provider=heartbeat_provider,
+            event_dispatcher=event_dispatcher,
+            state_lock=state_lock,
+            get_lifecycle_state=get_lifecycle_state,
+            connections=connections,
+            heartbeat_senders=heartbeat_senders,
+            logger=logger,
+        )
+    except BaseException as error:
+        logger.warning("Failed to initialize connection %s: %s", connection_id, error)
+        if isinstance(error, Exception):
+            try:
+                await event_dispatcher.emit(
+                    NetworkErrorEvent(resource_id=component_id, error=error)
+                )
+            except Exception as reporting_error:
+                logger.warning(
+                    "Failed to emit NetworkErrorEvent for accepted connection %s: %s",
+                    connection_id,
+                    reporting_error,
+                )
+        try:
+            await connection.close()
+        except Exception as close_error:
+            logger.warning(
+                "Failed to close partially accepted connection %s: %s",
+                connection_id,
+                close_error,
+            )
+        if not isinstance(error, Exception):
+            raise

--- a/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
@@ -268,6 +268,7 @@ async def handle_accepted_client(
     """Initialize one accepted socket into managed connection state."""
     peer_info = writer.get_extra_info("peername")
     remote_host, remote_port = _extract_remote_peer_address(peer_info)
+    connection: AsyncioTcpConnection | None = None
     rejection_event: ConnectionRejectedEvent | None = None
     async with state_lock:
         connection_id = get_connection_id()
@@ -278,7 +279,6 @@ async def handle_accepted_client(
                 get_lifecycle_state().value,
             )
             should_reject = True
-            connection = None
         elif len(connections) >= max_connections:
             logger.warning(
                 "Rejecting accepted TCP client connection %s because max_connections=%s is reached.",
@@ -286,7 +286,6 @@ async def handle_accepted_client(
                 max_connections,
             )
             should_reject = True
-            connection = None
             rejection_event = ConnectionRejectedEvent(
                 resource_id=component_id,
                 connection_id=connection_id,
@@ -339,7 +338,7 @@ async def handle_accepted_client(
             heartbeat_senders=heartbeat_senders,
             logger=logger,
         )
-    except BaseException as error:
+    except (Exception, asyncio.CancelledError) as error:
         logger.warning("Failed to initialize connection %s: %s", connection_id, error)
         if isinstance(error, Exception):
             try:
@@ -360,5 +359,5 @@ async def handle_accepted_client(
                 connection_id,
                 close_error,
             )
-        if not isinstance(error, Exception):
+        if isinstance(error, asyncio.CancelledError):
             raise

--- a/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import Awaitable
+from typing import cast
 
 from aionetx.api.connection_protocol import ConnectionProtocol
 from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
@@ -107,7 +109,7 @@ class AsyncioHeartbeatSender:
             self._logger.debug("Stopping heartbeat sender for %s.", self._connection.connection_id)
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                _ = await cast(Awaitable[object], task)
 
     async def _run(self) -> None:
         """

--- a/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
@@ -1,0 +1,185 @@
+"""
+Asyncio heartbeat loop bound to one logical connection.
+
+This module contains the periodic sender used by TCP client and server
+heartbeats. It polls a heartbeat provider, optionally sends payload bytes, and
+reports failures through the shared event dispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.heartbeat import HeartbeatRequest, HeartbeatResult, TcpHeartbeatSettings
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+
+
+logger = logging.getLogger(__name__)
+_warning_limiter = WarningRateLimiter(interval_seconds=30.0)
+
+
+class AsyncioHeartbeatSender:
+    """
+    Periodic heartbeat sender bound to a single connection.
+
+    The sender exits automatically when the connection is no longer connected,
+    which prevents stale heartbeat loops after teardown/reconnect.
+    """
+
+    def __init__(
+        self,
+        connection: ConnectionProtocol,
+        settings: TcpHeartbeatSettings,
+        heartbeat_provider: HeartbeatProviderProtocol,
+        event_dispatcher: AsyncioEventDispatcher,
+    ) -> None:
+        """Create a heartbeat scheduler for one connection."""
+        settings.validate()
+        if not settings.enabled:
+            raise ValueError("AsyncioHeartbeatSender requires TcpHeartbeatSettings.enabled=True.")
+
+        self._connection = connection
+        self._settings = settings
+        self._heartbeat_provider = heartbeat_provider
+        self._event_dispatcher = event_dispatcher
+
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self._state_lock = asyncio.Lock()
+        self._logger = logging.LoggerAdapter(
+            logger,
+            {
+                "component": "heartbeat_sender",
+                "connection_id": self._connection.connection_id,
+            },
+        )
+
+    @property
+    def is_running(self) -> bool:
+        """Return ``True`` while the heartbeat loop is scheduled to keep running."""
+        return self._running
+
+    async def start(self) -> None:
+        """Start periodic heartbeat scheduling."""
+        async with self._state_lock:
+            if self._running:
+                self._logger.debug(
+                    "Heartbeat sender start called while already running for %s.",
+                    self._connection.connection_id,
+                )
+                return
+            self._running = True
+            self._logger.debug(
+                "Starting heartbeat sender for %s (interval=%ss).",
+                self._connection.connection_id,
+                self._settings.interval_seconds,
+                extra={"heartbeat_interval_seconds": self._settings.interval_seconds},
+            )
+            self._task = asyncio.create_task(
+                self._run(),
+                name=f"{self._connection.connection_id}-heartbeat-sender",
+            )
+
+    async def stop(self) -> None:
+        """
+        Stop heartbeat scheduling.
+
+        This method is idempotent.
+        """
+        async with self._state_lock:
+            if not self._running:
+                self._logger.debug(
+                    "Heartbeat sender stop called while already stopped for %s.",
+                    self._connection.connection_id,
+                )
+                return
+            self._running = False
+            task = self._task
+            self._task = None
+
+        if task is not None:
+            self._logger.debug("Stopping heartbeat sender for %s.", self._connection.connection_id)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _run(self) -> None:
+        """
+        Drive heartbeat ticks until stopped or connection closes.
+
+        Any exception from provider/send is emitted as an error event and stops
+        the loop to avoid repeatedly failing at high frequency.
+
+        TOCTOU note: ``is_connected`` is checked before calling ``send()``, but
+        the connection may close in the interval between the check and the actual
+        send call.  If that happens, ``send()`` raises ``ConnectionClosedError``
+        (or a subclass), which falls through to the ``except Exception`` handler
+        and is emitted as a ``NetworkErrorEvent`` — the same path used for any
+        other send failure.  The loop then exits so no further heartbeats are
+        attempted on the dead connection.
+        """
+        try:
+            while self._running:
+                await asyncio.sleep(self._settings.interval_seconds)
+                if not self._running or not self._connection.is_connected:
+                    self._logger.debug(
+                        "Heartbeat sender exiting for %s because running=%s connected=%s.",
+                        self._connection.connection_id,
+                        self._running,
+                        self._connection.is_connected,
+                        extra={
+                            "running": self._running,
+                            "connected": self._connection.is_connected,
+                        },
+                    )
+                    break
+
+                result = await self._heartbeat_provider.create_heartbeat(
+                    HeartbeatRequest(connection_id=self._connection.connection_id)
+                )
+                if not isinstance(result, HeartbeatResult):
+                    raise TypeError(
+                        "heartbeat_provider.create_heartbeat must return HeartbeatResult."
+                    )
+                if result.should_send:
+                    if not isinstance(result.payload, (bytes, bytearray, memoryview)):
+                        raise TypeError(
+                            "HeartbeatResult.payload must be bytes-like when should_send=True."
+                        )
+                    await self._connection.send(result.payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            if _warning_limiter.should_log(f"heartbeat-sender:{self._connection.connection_id}"):
+                self._logger.warning(
+                    "Heartbeat sender failed for %s: %s",
+                    self._connection.connection_id,
+                    error,
+                    extra={"error_type": type(error).__name__},
+                )
+            await self._safe_emit_error(error)
+        finally:
+            async with self._state_lock:
+                self._running = False
+                self._task = None
+            self._logger.debug("Heartbeat sender finalized for %s.", self._connection.connection_id)
+
+    async def _safe_emit_error(self, error: Exception) -> None:
+        """Best-effort error emission for heartbeat loop failures."""
+        try:
+            await self._event_dispatcher.emit(
+                NetworkErrorEvent(
+                    resource_id=f"{self._connection.connection_id}:heartbeat",
+                    error=error,
+                )
+            )
+        except Exception:
+            self._logger.exception(
+                "Failed to emit heartbeat error event for %s.", self._connection.connection_id
+            )

--- a/src/aionetx/implementations/asyncio_impl/asyncio_multicast_receiver.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_multicast_receiver.py
@@ -7,7 +7,6 @@ group membership management, and multicast-specific cleanup behavior.
 
 from __future__ import annotations
 
-import asyncio  # noqa: F401 - test seam: monkeypatched in unit tests
 import contextlib
 import logging
 import socket

--- a/src/aionetx/implementations/asyncio_impl/asyncio_multicast_receiver.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_multicast_receiver.py
@@ -1,0 +1,159 @@
+"""
+Asyncio implementation of the managed multicast receiver role.
+
+This module adapts the shared datagram receiver base to multicast socket setup,
+group membership management, and multicast-specific cleanup behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio  # noqa: F401 - test seam: monkeypatched in unit tests
+import contextlib
+import logging
+import socket
+import struct
+from types import TracebackType
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.multicast_receiver_protocol import MulticastReceiverProtocol
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.implementations.asyncio_impl._asyncio_datagram_receiver_base import (
+    _AsyncioDatagramReceiverBase,
+)
+from aionetx.implementations.asyncio_impl.identifier_utils import multicast_receiver_component_id
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
+from aionetx.implementations.asyncio_impl.runtime_utils import configure_listener_bind_socket
+
+
+class AsyncioMulticastReceiver(_AsyncioDatagramReceiverBase, MulticastReceiverProtocol):
+    """Managed asyncio multicast receiver built on the shared datagram base."""
+
+    def __init__(
+        self, settings: MulticastReceiverSettings, event_handler: NetworkEventHandlerProtocol
+    ) -> None:
+        settings.validate()
+        self._settings = settings
+        connection_id = multicast_receiver_component_id(settings.group_ip, settings.port)
+        logger = logging.LoggerAdapter(
+            logging.getLogger(__name__),
+            {"component": "multicast_receiver", "connection_id": connection_id},
+        )
+        event_dispatcher = AsyncioEventDispatcher(
+            event_handler=event_handler,
+            delivery=settings.event_delivery,
+            logger=logger,
+            error_source=connection_id,
+            stop_component_callback=self.stop,
+        )
+        super().__init__(
+            receiver_name="Multicast",
+            connection_id=connection_id,
+            logger=logger,
+            event_dispatcher=event_dispatcher,
+            lifecycle_role=LifecycleRole.MULTICAST_RECEIVER,
+        )
+
+    @property
+    def lifecycle_state(self) -> ComponentLifecycleState:
+        """Return the current managed lifecycle state."""
+        return self._lifecycle_state
+
+    async def start(self) -> None:
+        """
+        Join the multicast group, publish lifecycle transitions, and start receiving.
+
+        Raises:
+            OSError: If socket setup, bind, or group membership setup fails.
+        """
+        self._assert_owner_loop()
+        # Follow the shared datagram lifecycle startup pattern documented on the
+        # base class for consistency with UDP receiver startup semantics.
+        if not await self._begin_startup():
+            return
+        self._logger.debug("Starting multicast receiver.")
+        sock: socket.socket | None = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            configure_listener_bind_socket(sock, allow_address_reuse=True)
+            # SO_REUSEPORT is not available on Windows; getattr avoids the
+            # mypy attr-defined error while OSError suppression handles kernels
+            # that define the constant but do not support the option (e.g. some
+            # container environments).
+            _so_reuseport: int | None = getattr(socket, "SO_REUSEPORT", None)
+            if _so_reuseport is not None:
+                with contextlib.suppress(OSError):
+                    sock.setsockopt(socket.SOL_SOCKET, _so_reuseport, 1)
+            sock.bind((self._settings.bind_ip, self._settings.port))
+            membership = struct.pack(
+                "4s4s",
+                socket.inet_aton(self._settings.group_ip),
+                socket.inet_aton(self._settings.interface_ip),
+            )
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, membership)
+            sock.setblocking(False)
+            metadata = ConnectionMetadata(
+                connection_id=self._connection_id,
+                role=ConnectionRole.MULTICAST_RECEIVER,
+                local_host=self._settings.bind_ip,
+                local_port=self._settings.port,
+                remote_host=self._settings.group_ip,
+                remote_port=self._settings.port,
+            )
+        except Exception:
+            if sock is not None:
+                try:
+                    sock.close()
+                except Exception:
+                    self._logger.warning(
+                        "Multicast receiver startup cleanup could not close socket cleanly.",
+                        exc_info=True,
+                    )
+            await self._fail_startup()
+            raise
+
+        await self._complete_startup(
+            sock=sock,
+            metadata=metadata,
+            receive_buffer_size=self._settings.receive_buffer_size,
+        )
+        self._logger.debug("Multicast receiver joined group and is running.")
+
+    async def stop(self) -> None:
+        """Leave the multicast group and stop the receiver lifecycle."""
+        self._assert_owner_loop()
+        self._logger.debug("Stopping multicast receiver.")
+        await super().stop()
+        self._logger.debug("Multicast receiver stopped.")
+
+    async def __aenter__(self) -> AsyncioMulticastReceiver:
+        """Start the receiver and return ``self``."""
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Stop the receiver unconditionally."""
+        await self.stop()
+
+    def _cleanup_socket(self, sock: socket.socket) -> None:
+        """Attempt to drop multicast membership before the socket is closed."""
+        try:
+            membership = struct.pack(
+                "4s4s",
+                socket.inet_aton(self._settings.group_ip),
+                socket.inet_aton(self._settings.interface_ip),
+            )
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, membership)
+        except OSError:
+            self._logger.warning(
+                "Multicast receiver cleanup suppressed IP_DROP_MEMBERSHIP failure.",
+                exc_info=True,
+            )

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -1,0 +1,423 @@
+"""
+Asyncio TCP client with explicit supervision and lifecycle publication.
+
+This module owns client-side connect/reconnect orchestration and keeps
+connection-level behavior in :class:`AsyncioTcpConnection`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from types import TracebackType
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.tcp_client import TcpClientProtocol, TcpClientSettings
+from aionetx.implementations.asyncio_impl._tcp_client_connect import (
+    connect_once,
+    start_heartbeat_sender,
+    stop_heartbeat_sender,
+    wait_until_client_connected,
+)
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl._tcp_client_runtime import (
+    _ClientRuntimeAccessors,
+    _ClientRuntimeState,
+)
+from aionetx.implementations.asyncio_impl.identifier_utils import (
+    tcp_client_component_id,
+)
+from aionetx.implementations.asyncio_impl.event_dispatcher import (
+    AsyncioEventDispatcher,
+    DispatcherRuntimeStats,
+)
+from aionetx.implementations.asyncio_impl.lifecycle_internal import (
+    LifecycleRole,
+    LifecycleTransitionPublisher,
+    emit_lifecycle_event,
+)
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    ReconnectBackoff,
+    assert_running_on_owner_loop,
+    validate_heartbeat_provider,
+)
+from aionetx.implementations.asyncio_impl.tcp_client_supervision import (
+    TcpClientConnectionSupervisor,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
+    """
+    Managed asyncio TCP client with optional reconnect and heartbeats.
+
+    The client owns component lifecycle state and supervision. Individual
+    socket read/write behavior remains in :class:`AsyncioTcpConnection`.
+    """
+
+    def __init__(
+        self,
+        settings: TcpClientSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+        connection_opener: Callable[
+            ..., Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]]
+        ]
+        | None = None,
+    ) -> None:
+        settings.validate()
+        validate_heartbeat_provider(
+            heartbeat_settings=settings.heartbeat,
+            heartbeat_provider=heartbeat_provider,
+        )
+        self._settings = settings
+        self._heartbeat_provider = heartbeat_provider
+        # Seam for deterministic tests and explicit connect-attempt control.
+        self._connection_opener = connection_opener or asyncio.open_connection
+        self._runtime = _ClientRuntimeState()
+        self._supervisor_task: asyncio.Task[None] | None = None
+        self._state_lock = asyncio.Lock()
+        self._lifecycle_state = ComponentLifecycleState.STOPPED
+        self._backoff = ReconnectBackoff(settings.reconnect)
+        self._status_changed = asyncio.Event()
+        self._runtime.connection_closed_event.set()
+        self._connection_supervisor = TcpClientConnectionSupervisor(self)
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+        self._component_id = tcp_client_component_id(settings.host, settings.port)
+        self._logger = logging.LoggerAdapter(
+            logger, {"component": "tcp_client", "host": settings.host, "port": settings.port}
+        )
+        self._event_dispatcher = AsyncioEventDispatcher(
+            event_handler=event_handler,
+            delivery=settings.event_delivery,
+            logger=self._logger,
+            error_source=self._component_id,
+            stop_component_callback=self.stop,
+        )
+        self._lifecycle_publisher = LifecycleTransitionPublisher(
+            component_name=self._component_id,
+            resource_id=self._component_id,
+            role=LifecycleRole.TCP_CLIENT,
+            get_state=lambda: self._lifecycle_state,
+            set_state=lambda state: setattr(self, "_lifecycle_state", state),
+            on_state_applied=self._on_lifecycle_state_applied,
+        )
+
+    @property
+    def connection(self) -> ConnectionProtocol | None:
+        """
+        Return the current live connection when connected.
+
+        Returns:
+            ConnectionProtocol | None: Active connection object, or ``None``
+            when no connected session is currently available.
+        """
+        if self._connection is None or self._connection.state == ConnectionState.CLOSED:
+            return None
+        return self._connection
+
+    @property
+    def lifecycle_state(self) -> ComponentLifecycleState:
+        """Current component lifecycle state exposed by the managed client."""
+        return self._lifecycle_state
+
+    def __repr__(self) -> str:
+        return (
+            f"AsyncioTcpClient("
+            f"host={self._settings.host!r}, "
+            f"port={self._settings.port!r}, "
+            f"state={self._lifecycle_state.value!r})"
+        )
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Dispatcher operational snapshot for runtime diagnostics."""
+        return self._event_dispatcher.runtime_stats
+
+    def _assert_owner_loop(self) -> None:
+        """
+        Raise RuntimeError if called outside the owner event loop.
+
+        Also pins ``_owner_loop`` on first call so all subsequent guard checks
+        use the same loop identity drawn from ``runtime_utils.asyncio`` - not
+        from a potentially test-patched module-level asyncio import.
+        """
+        self._owner_loop = assert_running_on_owner_loop(
+            class_name=type(self).__name__, owner_loop=self._owner_loop
+        )
+
+    async def start(self) -> None:
+        """Start lifecycle supervision and begin connect attempts."""
+        self._assert_owner_loop()
+        self._logger.debug("Starting TCP client.")
+        starting_event: ComponentLifecycleChangedEvent | None = None
+        running_event: ComponentLifecycleChangedEvent | None = None
+        async with self._state_lock:
+            if self._lifecycle_state in (
+                ComponentLifecycleState.STARTING,
+                ComponentLifecycleState.RUNNING,
+            ):
+                self._logger.debug("TCP client start called while already running.")
+                return
+            self._last_connect_error = None
+            self._has_started = True
+            # Keep dispatcher startup and the initial lifecycle transitions in one
+            # locked section so stop() cannot observe a half-started client.
+            await self._event_dispatcher.start()
+            starting_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
+            self._supervisor_task = asyncio.create_task(
+                self._supervise(), name="tcp-client-supervisor"
+            )
+            running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
+        try:
+            await self._emit_lifecycle_event(starting_event)
+            await self._emit_lifecycle_event(running_event)
+        except BaseException:
+            await self._rollback_failed_startup()
+            raise
+
+    async def stop(self) -> None:
+        """Stop supervision, close active resources, and publish STOPPED."""
+        self._assert_owner_loop()
+        self._logger.debug("Stopping TCP client.")
+        stopping_event: ComponentLifecycleChangedEvent | None = None
+        stopped_event: ComponentLifecycleChangedEvent | None = None
+        should_stop_dispatcher = False
+        await_supervisor_completion_only = False
+        skip_await_supervisor = False
+        current_task = asyncio.current_task()
+        async with self._state_lock:
+            if self._lifecycle_state in (
+                ComponentLifecycleState.STOPPING,
+                ComponentLifecycleState.STOPPED,
+            ):
+                supervisor_task = self._supervisor_task
+                if supervisor_task is not None and supervisor_task.done():
+                    self._supervisor_task = None
+                    supervisor_task = None
+                else:
+                    await_supervisor_completion_only = supervisor_task is not None
+            else:
+                stopping_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPING)
+                supervisor_task = self._supervisor_task
+                self._supervisor_task = None
+                should_stop_dispatcher = True
+                skip_await_supervisor = (
+                    current_task is not None
+                    and self._event_dispatcher.current_task_is_worker()
+                    and supervisor_task is not None
+                )
+        inline_delivery_context = (
+            self._event_dispatcher.inline_delivery_context()
+            if self._event_dispatcher.current_task_is_worker()
+            else contextlib.nullcontext()
+        )
+        with inline_delivery_context:
+            first_error: BaseException | None = None
+            try:
+                await self._emit_lifecycle_event(stopping_event)
+            except BaseException as error:
+                first_error = error
+            try:
+                if supervisor_task is not None and not skip_await_supervisor:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        if not await_supervisor_completion_only:
+                            supervisor_task.cancel()
+                        await supervisor_task
+                    if self._supervisor_task is supervisor_task:
+                        self._supervisor_task = None
+                await self._stop_heartbeat_sender()
+                await self._close_current_connection()
+                if (
+                    supervisor_task is not None
+                    and skip_await_supervisor
+                    and not await_supervisor_completion_only
+                ):
+                    supervisor_task.cancel()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+            if should_stop_dispatcher:
+                async with self._state_lock:
+                    stopped_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+                if first_error is None:
+                    try:
+                        await self._emit_lifecycle_event(stopped_event)
+                    except BaseException as error:
+                        first_error = error
+                try:
+                    await self._event_dispatcher.stop()
+                except BaseException as error:
+                    if first_error is None:
+                        first_error = error
+            if first_error is not None:
+                raise first_error
+        self._logger.debug("TCP client stopped.")
+
+    async def __aenter__(self) -> AsyncioTcpClient:
+        """Start the client and return ``self``."""
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Stop the client unconditionally."""
+        await self.stop()
+
+    async def wait_until_connected(
+        self, timeout_seconds: float | None = None, poll_interval_seconds: float = 0.1
+    ) -> ConnectionProtocol:
+        """
+        Wait for an active connected connection.
+
+        Raises:
+            ValueError: If ``poll_interval_seconds`` is less than or equal to zero.
+            ConnectionError: If the client stops before a connection is available.
+            asyncio.TimeoutError: If ``timeout_seconds`` elapses first.
+        """
+        self._assert_owner_loop()
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be > 0.")
+        coro = wait_until_client_connected(
+            get_connection=lambda: self.connection,
+            get_lifecycle_state=lambda: self._lifecycle_state,
+            get_has_started=lambda: self._has_started,
+            get_last_connect_error=lambda: self._last_connect_error,
+            get_reconnect_enabled=lambda: self._settings.reconnect.enabled,
+            get_status_version=lambda: self._status_version,
+            status_changed=self._status_changed,
+            host=self._settings.host,
+            port=self._settings.port,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+        if timeout_seconds is None:
+            return await coro
+        return await asyncio.wait_for(coro, timeout=timeout_seconds)
+
+    async def _supervise(self) -> None:
+        """Delegate the connect/reconnect loop to the supervision helper."""
+        await self._connection_supervisor.run()
+
+    async def _rollback_failed_startup(self) -> None:
+        """Clean up startup-owned resources after lifecycle publication fails."""
+        async with self._state_lock:
+            supervisor_task = self._supervisor_task
+            self._supervisor_task = None
+            if self._lifecycle_state == ComponentLifecycleState.RUNNING:
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPING)
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+            elif self._lifecycle_state == ComponentLifecycleState.STARTING:
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+        if supervisor_task is not None:
+            supervisor_task.cancel()
+            with contextlib.suppress(BaseException):
+                await supervisor_task
+        with contextlib.suppress(BaseException):
+            await self._stop_heartbeat_sender()
+        with contextlib.suppress(BaseException):
+            await self._close_current_connection()
+        with contextlib.suppress(BaseException):
+            await self._event_dispatcher.stop()
+
+    async def _connect_once(self) -> None:
+        """Open one TCP session and attach connection-level event handling."""
+        connection = await connect_once(
+            settings=self._settings,
+            connection_opener=self._connection_opener,
+            event_dispatcher=self._event_dispatcher,
+            on_closed_callback=self._on_connection_closed,
+            logger=self._logger,
+            component_id=self._component_id,
+        )
+        self._connection = connection
+        self._connection_closed_event.clear()
+        self._notify_status_changed()
+        await self._start_heartbeat_sender(connection)
+
+    async def _start_heartbeat_sender(self, connection: AsyncioTcpConnection) -> None:
+        """Create and retain the optional heartbeat sender bound to ``connection``."""
+        self._heartbeat_sender = await start_heartbeat_sender(
+            connection=connection,
+            settings=self._settings,
+            heartbeat_provider=self._heartbeat_provider,
+            event_dispatcher=self._event_dispatcher,
+            logger=self._logger,
+        )
+
+    async def _stop_heartbeat_sender(self) -> None:
+        """Stop and detach the current heartbeat sender, if one exists."""
+        sender = self._heartbeat_sender
+        self._heartbeat_sender = None
+        await stop_heartbeat_sender(sender=sender, logger=self._logger)
+
+    async def _close_current_connection(self) -> None:
+        """Detach and close the current connection, if one is tracked."""
+        connection = self._connection
+        if connection is not None and connection.state != ConnectionState.CLOSED:
+            try:
+                await connection.close()
+            finally:
+                if self._connection is connection:
+                    self._connection = None
+                self._connection_closed_event.set()
+                self._notify_status_changed()
+            return
+        self._connection = None
+        self._connection_closed_event.set()
+        self._notify_status_changed()
+
+    async def _on_connection_closed(self, connection: AsyncioTcpConnection) -> None:
+        """Detach the closed connection, notify waiters, and stop heartbeats."""
+        if self._connection is connection:
+            self._connection = None
+            if self._lifecycle_state != ComponentLifecycleState.STOPPING:
+                self._connection_closed_event.set()
+                self._notify_status_changed()
+        await self._stop_heartbeat_sender()
+
+    def _on_lifecycle_state_applied(self, target: ComponentLifecycleState) -> None:
+        """Mirror published lifecycle state into runtime flags and wait conditions."""
+        self._running = target in (
+            ComponentLifecycleState.STARTING,
+            ComponentLifecycleState.RUNNING,
+        )
+        self._notify_status_changed()
+
+    def _apply_lifecycle_state(
+        self, target: ComponentLifecycleState
+    ) -> ComponentLifecycleChangedEvent | None:
+        """Apply one lifecycle transition and return the corresponding event, if any."""
+        return self._lifecycle_publisher.apply(target)
+
+    async def _emit_lifecycle_event(self, event: ComponentLifecycleChangedEvent | None) -> None:
+        """Emit a lifecycle event when the transition publisher produced one."""
+        await emit_lifecycle_event(dispatcher=self._event_dispatcher, event=event)
+
+    async def _transition_lifecycle_state(self, target: ComponentLifecycleState) -> None:
+        """Convenience helper that applies and emits a lifecycle transition."""
+        event = self._apply_lifecycle_state(target)
+        await self._emit_lifecycle_event(event)
+
+    def _resolve_error_policy(self) -> ErrorPolicy:
+        """Resolve the effective error policy after considering reconnect settings."""
+        if self._settings.error_policy is not None:
+            return self._settings.error_policy
+        return ErrorPolicy.RETRY if self._settings.reconnect.enabled else ErrorPolicy.FAIL_FAST
+
+    def _notify_status_changed(self) -> None:
+        """Bump the status version and wake polling/waiting helpers."""
+        self._status_version += 1
+        self._status_changed.set()

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from types import TracebackType
+from typing import cast
 
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
@@ -181,7 +182,7 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         try:
             await self._emit_lifecycle_event(starting_event)
             await self._emit_lifecycle_event(running_event)
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             await self._rollback_failed_startup()
             raise
 
@@ -225,14 +226,14 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
             first_error: BaseException | None = None
             try:
                 await self._emit_lifecycle_event(stopping_event)
-            except BaseException as error:
+            except (Exception, asyncio.CancelledError) as error:
                 first_error = error
             try:
                 if supervisor_task is not None and not skip_await_supervisor:
                     with contextlib.suppress(asyncio.CancelledError):
                         if not await_supervisor_completion_only:
                             supervisor_task.cancel()
-                        await supervisor_task
+                        _ = await cast(Awaitable[object], supervisor_task)
                     if self._supervisor_task is supervisor_task:
                         self._supervisor_task = None
                 await self._stop_heartbeat_sender()
@@ -243,7 +244,7 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     and not await_supervisor_completion_only
                 ):
                     supervisor_task.cancel()
-            except BaseException as error:
+            except (Exception, asyncio.CancelledError) as error:
                 if first_error is None:
                     first_error = error
             if should_stop_dispatcher:
@@ -252,11 +253,11 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                 if first_error is None:
                     try:
                         await self._emit_lifecycle_event(stopped_event)
-                    except BaseException as error:
+                    except (Exception, asyncio.CancelledError) as error:
                         first_error = error
                 try:
                     await self._event_dispatcher.stop()
-                except BaseException as error:
+                except (Exception, asyncio.CancelledError) as error:
                     if first_error is None:
                         first_error = error
             if first_error is not None:
@@ -323,13 +324,13 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                 self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
         if supervisor_task is not None:
             supervisor_task.cancel()
-            with contextlib.suppress(BaseException):
-                await supervisor_task
-        with contextlib.suppress(BaseException):
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                _ = await cast(Awaitable[object], supervisor_task)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._stop_heartbeat_sender()
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._close_current_connection()
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._event_dispatcher.stop()
 
     async def _connect_once(self) -> None:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -1,0 +1,406 @@
+"""Asyncio TCP connection primitive with explicit close coordination."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Awaitable, Callable
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.errors import ConnectionClosedError
+from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.implementations.asyncio_impl._tcp_connection_helpers import (
+    await_read_task_shutdown,
+    await_writer_shutdown,
+    build_connection_metadata,
+)
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+
+ConnectionClosedCallback = Callable[["AsyncioTcpConnection"], Awaitable[None] | None]
+
+logger = logging.getLogger(__name__)
+_warning_limiter = WarningRateLimiter(interval_seconds=30.0)
+_SHUTDOWN_AWAIT_TIMEOUT_SECONDS = 1.0
+
+
+class AsyncioTcpConnection(ConnectionProtocol):
+    """
+    Concrete TCP connection used by client and server transports.
+
+    The class owns socket read/write loops and emits connection lifecycle/data
+    events through :class:`AsyncioEventDispatcher`.
+    """
+
+    def __init__(
+        self,
+        connection_id: str,
+        role: ConnectionRole,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        event_dispatcher: AsyncioEventDispatcher,
+        receive_buffer_size: int,
+        idle_timeout_seconds: float | None = None,
+        on_closed_callback: ConnectionClosedCallback | None = None,
+    ) -> None:
+        if not connection_id:
+            raise ValueError("connection_id must not be empty.")
+        if receive_buffer_size <= 0:
+            raise ValueError("receive_buffer_size must be > 0.")
+        if idle_timeout_seconds is not None and idle_timeout_seconds <= 0:
+            raise ValueError("idle_timeout_seconds must be > 0 when provided.")
+        self._connection_id = connection_id
+        self._role = role
+        self._reader = reader
+        self._writer = writer
+        self._event_dispatcher = event_dispatcher
+        self._receive_buffer_size = receive_buffer_size
+        self._idle_timeout_seconds = idle_timeout_seconds
+        self._on_closed_callback = on_closed_callback
+        self._state = ConnectionState.CREATED
+        self._metadata = self._build_metadata()
+        self._read_task: asyncio.Task[None] | None = None
+        self._close_lock = asyncio.Lock()
+        self._logger = logging.LoggerAdapter(
+            logger, {"connection_id": connection_id, "role": role.value}
+        )
+        self._closed_event_published = False
+        self._close_event_previous_state: ConnectionState | None = None
+        self._close_task: asyncio.Task[None] | None = None
+        self._close_event_task: asyncio.Task[None] | None = None
+
+    @property
+    def connection_id(self) -> str:
+        """Stable identifier used for lifecycle, data, and error events."""
+        return self._connection_id
+
+    @property
+    def role(self) -> ConnectionRole:
+        """Whether this connection belongs to a client or server transport."""
+        return self._role
+
+    @property
+    def state(self) -> ConnectionState:
+        """Current transport-facing lifecycle state of the connection."""
+        return self._state
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the connection is currently able to send and receive payloads."""
+        return self._state == ConnectionState.CONNECTED
+
+    @property
+    def metadata(self) -> ConnectionMetadata:
+        """Static connection metadata derived from the underlying stream writer."""
+        return self._metadata
+
+    async def start(self) -> None:
+        """
+        Transition to connected state and start read-loop publication.
+
+        Raises:
+            RuntimeError: If called from an invalid non-startable state.
+        """
+        if self._state == ConnectionState.CONNECTED:
+            return
+        if self._state not in (ConnectionState.CREATED, ConnectionState.CONNECTING):
+            raise RuntimeError(
+                f"Connection '{self._connection_id}' cannot be started from state '{self._state.value}'."
+            )
+        self._state = ConnectionState.CONNECTING
+        self._read_task = asyncio.create_task(
+            self._read_loop(), name=f"{self._connection_id}-read-loop"
+        )
+        self._state = ConnectionState.CONNECTED
+        await self._event_dispatcher.emit(
+            ConnectionOpenedEvent(resource_id=self._metadata.connection_id, metadata=self._metadata)
+        )
+
+    async def send(self, data: BytesLike) -> None:
+        """
+        Write bytes-like payload to the socket stream.
+
+        Arguments:
+            data (BytesLike): Raw payload to write to the peer.
+
+        Raises:
+            ConnectionClosedError: If the connection is not in CONNECTED state.
+            TypeError: If ``data`` is not bytes-like.
+            OSError: If the underlying stream reports a socket failure while
+                flushing the write buffer.
+        """
+        if self._state != ConnectionState.CONNECTED:
+            raise ConnectionClosedError(f"Connection '{self._connection_id}' is not connected.")
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError("send expects bytes-like data.")
+        self._writer.write(bytes(data))
+        await self._writer.drain()
+
+    async def close(self) -> None:
+        """
+        Close the connection with shared full-lifecycle coordination.
+
+        Close flow:
+            close()
+              -> mark ``CLOSING`` and detach read task
+              -> cancel read loop / close writer
+              -> run ``on_closed_callback`` once
+              -> transition to ``CLOSED``
+              -> emit ``ConnectionClosedEvent`` once
+
+        Concurrency contract:
+        - Only one full close operation runs at a time.
+        - Concurrent callers await the same in-flight close task and therefore
+          observe the same terminal success/failure outcome.
+        - Teardown, callback, and close-event publication are each executed once.
+
+        Cancellation contract:
+        - Caller cancellation is shielded from the shared close task.
+        - If caller cancellation happens, close waits for shared finalization and
+          then re-raises ``CancelledError``.
+        - If caller cancellation and a real close failure race, the real close
+          failure (task exception) takes precedence for all waiters; cancellation
+          is re-raised only when the shared close task completes successfully.
+        - Publication failures still propagate and leave reconciliation coherent.
+        """
+        close_task: asyncio.Task[None]
+        async with self._close_lock:
+            if self._state == ConnectionState.CLOSED and self._closed_event_published:
+                return
+            if self._close_task is None or self._close_task.done():
+                needs_teardown = False
+                read_task: asyncio.Task[None] | None = None
+                if self._state not in (ConnectionState.CLOSING, ConnectionState.CLOSED):
+                    needs_teardown = True
+                    read_task = self._read_task
+                    self._read_task = None
+                if self._state != ConnectionState.CLOSED:
+                    # preserve first pre-close state across retries/reconciliation
+                    self._close_event_previous_state = (
+                        self._close_event_previous_state or self._state
+                    )
+                    self._state = ConnectionState.CLOSING
+                callback = self._on_closed_callback
+                close_caller_task = asyncio.current_task()
+                inline_delivery_context = (
+                    self._event_dispatcher.inline_delivery_context()
+                    if self._event_dispatcher.current_task_is_worker()
+                    else contextlib.nullcontext()
+                )
+                with inline_delivery_context:
+                    self._close_task = asyncio.create_task(
+                        self._run_close_lifecycle(
+                            needs_teardown=needs_teardown,
+                            read_task=read_task,
+                            callback=callback,
+                            close_caller_task=close_caller_task,
+                        )
+                    )
+            close_task = self._close_task
+
+        if close_task is asyncio.current_task():
+            return
+        if self._close_event_task is asyncio.current_task():
+            return
+
+        cancellation_requested = False
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            if close_task.done() and close_task.cancelled():
+                raise
+            cancellation_requested = True
+            await close_task
+        if cancellation_requested:
+            raise asyncio.CancelledError
+
+    async def _run_close_lifecycle(
+        self,
+        *,
+        needs_teardown: bool,
+        read_task: asyncio.Task[None] | None,
+        callback: ConnectionClosedCallback | None,
+        close_caller_task: asyncio.Task[None] | None,
+    ) -> None:
+        """
+        Execute the shared teardown portion of ``close()`` exactly once.
+
+        Args:
+            needs_teardown: Whether this caller owns the socket teardown path.
+            read_task: Detached read-loop task to cancel and await.
+            callback: Optional close callback invoked before terminal publication.
+            close_caller_task: Task that created the shared close lifecycle task.
+        """
+        cancellation_requested = False
+        try:
+            if needs_teardown:
+                try:
+                    current_task = asyncio.current_task()
+                    if (
+                        read_task is not None
+                        and read_task is not current_task
+                        and read_task is not close_caller_task
+                    ):
+                        read_task.cancel()
+                        await self._await_read_task_shutdown(read_task)
+
+                    self._writer.close()
+                    await self._await_writer_shutdown()
+
+                    if callback is not None:
+                        try:
+                            result = callback(self)
+                            if asyncio.iscoroutine(result):
+                                await result
+                        except Exception as error:
+                            if _warning_limiter.should_log(
+                                f"tcp-connection-close-callback:{self._connection_id}"
+                            ):
+                                self._logger.warning("Connection close callback raised: %s", error)
+                            await self._safe_emit_error(error)
+                except asyncio.CancelledError:
+                    cancellation_requested = True
+            await self._finalize_close()
+        finally:
+            async with self._close_lock:
+                current_task = asyncio.current_task()
+                if self._close_task is current_task:
+                    self._close_task = None
+            if cancellation_requested:
+                raise asyncio.CancelledError
+
+    async def _await_read_task_shutdown(self, read_task: asyncio.Task[None]) -> None:
+        """Await read-loop cancellation with bounded shutdown warnings."""
+        await await_read_task_shutdown(
+            connection_id=self._connection_id,
+            read_task=read_task,
+            logger=self._logger,
+            warning_limiter=_warning_limiter,
+            timeout_seconds=_SHUTDOWN_AWAIT_TIMEOUT_SECONDS,
+        )
+
+    async def _await_writer_shutdown(self) -> None:
+        """Close the stream writer and await drain/transport shutdown safely."""
+        await await_writer_shutdown(
+            connection_id=self._connection_id,
+            writer=self._writer,
+            logger=self._logger,
+            warning_limiter=_warning_limiter,
+            timeout_seconds=_SHUTDOWN_AWAIT_TIMEOUT_SECONDS,
+        )
+
+    async def _finalize_close(self) -> None:
+        """
+        Publish terminal close state/event with shared in-flight finalization.
+
+        Publication semantics:
+        - Only one close-event publication task is created at a time.
+        - Concurrent close() callers await that same task so they observe the
+          same publication success/failure outcome.
+        - ``_closed_event_published`` is set only after successful emission.
+
+        Cancellation semantics:
+        - Caller cancellation is isolated with ``asyncio.shield`` so the shared
+          publication task continues to completion.
+        - If caller cancellation happens, this method waits for publication and
+          then re-raises cancellation.
+        - If the publication task itself fails/cancels, that failure is surfaced
+          to callers and publication is not marked successful.
+        """
+        publication_task: asyncio.Task[None]
+        async with self._close_lock:
+            if self._closed_event_published:
+                return
+            if self._close_event_task is None or self._close_event_task.done():
+                previous_state = self._close_event_previous_state or ConnectionState.CLOSING
+                self._state = ConnectionState.CLOSED
+                self._close_event_task = asyncio.create_task(
+                    self._run_close_event_publication(previous_state)
+                )
+            publication_task = self._close_event_task
+
+        # Re-entrant close() from within close-event handlers can execute on the
+        # same task that is currently publishing ``ConnectionClosedEvent``.
+        # That caller must not await itself.
+        if publication_task is asyncio.current_task():
+            return
+
+        cancelled_during_emit = False
+        try:
+            await asyncio.shield(publication_task)
+        except asyncio.CancelledError:
+            # Distinguish caller cancellation from publication task cancellation:
+            # if the shared task was cancelled, propagate that directly.
+            if publication_task.done() and publication_task.cancelled():
+                raise
+            cancelled_during_emit = True
+            await publication_task
+        if cancelled_during_emit:
+            raise asyncio.CancelledError
+
+    async def _run_close_event_publication(self, previous_state: ConnectionState) -> None:
+        """Emit the terminal close event and mark publication success atomically."""
+        closed_event = ConnectionClosedEvent(
+            resource_id=self._connection_id,
+            previous_state=previous_state,
+            metadata=self._metadata,
+        )
+        published_successfully = False
+        try:
+            await self._event_dispatcher.emit(closed_event)
+            published_successfully = True
+        finally:
+            async with self._close_lock:
+                if published_successfully:
+                    self._closed_event_published = True
+                    self._close_event_previous_state = None
+                current_task = asyncio.current_task()
+                if self._close_event_task is current_task:
+                    self._close_event_task = None
+
+    async def _read_loop(self) -> None:
+        """Read payloads until EOF or failure, then trigger shared close reconciliation."""
+        try:
+            while self._state == ConnectionState.CONNECTED:
+                if self._idle_timeout_seconds is None:
+                    data = await self._reader.read(self._receive_buffer_size)
+                else:
+                    data = await asyncio.wait_for(
+                        self._reader.read(self._receive_buffer_size),
+                        timeout=self._idle_timeout_seconds,
+                    )
+                if not data:
+                    break
+                await self._event_dispatcher.emit(
+                    BytesReceivedEvent(resource_id=self._connection_id, data=data)
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            if _warning_limiter.should_log(f"tcp-connection-read-loop:{self._connection_id}"):
+                self._logger.warning("Connection read loop error: %s", error)
+            await self._safe_emit_error(error)
+        finally:
+            if self._state not in (ConnectionState.CLOSING, ConnectionState.CLOSED):
+                await self.close()
+
+    async def _safe_emit_error(self, error: Exception) -> None:
+        """Emit a connection-scoped error event without adding extra policy logic here."""
+        await self._event_dispatcher.emit(
+            NetworkErrorEvent(resource_id=self._connection_id, error=error)
+        )
+
+    def _build_metadata(self) -> ConnectionMetadata:
+        """Build the immutable metadata snapshot exposed by ``metadata`` and events."""
+        return build_connection_metadata(
+            connection_id=self._connection_id,
+            role=self._role,
+            writer=self._writer,
+        )

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, cast
 
 from aionetx.api.bytes_like import BytesLike
 from aionetx.api.bytes_received_event import BytesReceivedEvent
@@ -217,7 +217,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
             if close_task.done() and close_task.cancelled():
                 raise
             cancellation_requested = True
-            await close_task
+            _ = await cast(Awaitable[object], close_task)
         if cancellation_requested:
             raise asyncio.CancelledError
 
@@ -258,7 +258,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
                         try:
                             result = callback(self)
                             if asyncio.iscoroutine(result):
-                                await result
+                                _ = await result
                         except Exception as error:
                             if _warning_limiter.should_log(
                                 f"tcp-connection-close-callback:{self._connection_id}"
@@ -341,7 +341,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
             if publication_task.done() and publication_task.cancelled():
                 raise
             cancelled_during_emit = True
-            await publication_task
+            _ = await cast(Awaitable[object], publication_task)
         if cancelled_during_emit:
             raise asyncio.CancelledError
 

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -1,0 +1,488 @@
+"""
+Asyncio TCP server lifecycle and multi-connection coordination.
+
+This module coordinates accept-loop lifecycle, per-connection registration,
+and optional heartbeat sender ownership for server-side sessions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import socket
+from types import TracebackType
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.tcp_server import TcpServerProtocol, TcpServerSettings
+from aionetx.implementations.asyncio_impl._tcp_server_helpers import (
+    broadcast_to_connections,
+    handle_accepted_client,
+    report_teardown_errors,
+    start_server_heartbeat_if_needed,
+    stop_server_heartbeat_senders,
+    wait_until_server_running,
+)
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl.identifier_utils import (
+    tcp_server_component_id,
+    tcp_server_connection_id,
+)
+from aionetx.implementations.asyncio_impl.event_dispatcher import (
+    AsyncioEventDispatcher,
+    DispatcherRuntimeStats,
+)
+from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
+from aionetx.implementations.asyncio_impl.lifecycle_internal import (
+    LifecycleTransitionPublisher,
+    apply_stopped_transition_if_stopping,
+    apply_stopping_transition_if_active,
+    emit_lifecycle_event,
+)
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    assert_running_on_owner_loop,
+    configure_listener_bind_socket,
+    validate_heartbeat_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncioTcpServer(TcpServerProtocol):
+    """Managed asyncio TCP server with explicit connection tracking."""
+
+    def __init__(
+        self,
+        settings: TcpServerSettings,
+        event_handler: NetworkEventHandlerProtocol,
+        heartbeat_provider: HeartbeatProviderProtocol | None = None,
+    ) -> None:
+        settings.validate()
+        validate_heartbeat_provider(
+            heartbeat_settings=settings.heartbeat,
+            heartbeat_provider=heartbeat_provider,
+        )
+        self._settings = settings
+        self._heartbeat_provider = heartbeat_provider
+        self._server: asyncio.AbstractServer | None = None
+        self._has_started = False
+        self._status_changed = asyncio.Event()
+        self._status_version = 0
+        self._lifecycle_state = ComponentLifecycleState.STOPPED
+        self._connections: dict[str, AsyncioTcpConnection] = {}
+        self._heartbeat_senders: dict[str, AsyncioHeartbeatSender] = {}
+        self._connection_sequence = 0
+        self._state_lock = asyncio.Lock()
+        self._stop_waiter: asyncio.Future[None] | None = None
+        self._component_id = tcp_server_component_id(settings.host, settings.port)
+        self._logger = logging.LoggerAdapter(
+            logger, {"component": "tcp_server", "host": settings.host, "port": settings.port}
+        )
+        self._event_dispatcher = AsyncioEventDispatcher(
+            event_handler=event_handler,
+            delivery=settings.event_delivery,
+            logger=self._logger,
+            error_source=self._component_id,
+            stop_component_callback=self.stop,
+        )
+        self._lifecycle_publisher = LifecycleTransitionPublisher(
+            component_name=self._component_id,
+            resource_id=self._component_id,
+            role=LifecycleRole.TCP_SERVER,
+            get_state=lambda: self._lifecycle_state,
+            set_state=lambda state: setattr(self, "_lifecycle_state", state),
+            on_state_applied=lambda _state: self._notify_status_changed(),
+        )
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def connections(self) -> tuple[ConnectionProtocol, ...]:
+        """Return an immutable snapshot of connections known to the server."""
+        return tuple(self._connections.values())
+
+    @property
+    def lifecycle_state(self) -> ComponentLifecycleState:
+        """Current component lifecycle state exposed by the managed server."""
+        return self._lifecycle_state
+
+    def __repr__(self) -> str:
+        return (
+            f"AsyncioTcpServer("
+            f"host={self._settings.host!r}, "
+            f"port={self._settings.port!r}, "
+            f"state={self._lifecycle_state.value!r})"
+        )
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Dispatcher operational snapshot for runtime diagnostics."""
+        return self._event_dispatcher.runtime_stats
+
+    def _assert_owner_loop(self) -> None:
+        """Raise RuntimeError if called outside the owner event loop."""
+        self._owner_loop = assert_running_on_owner_loop(
+            class_name=type(self).__name__, owner_loop=self._owner_loop
+        )
+
+    async def start(self) -> None:
+        """Start the accept loop and publish lifecycle transitions."""
+        self._assert_owner_loop()
+        # Keep dispatcher startup and the STARTING transition in one locked
+        # section so stop() cannot observe a half-started server.
+        lifecycle_event: ComponentLifecycleChangedEvent | None = None
+        async with self._state_lock:
+            if self._lifecycle_state in (
+                ComponentLifecycleState.STARTING,
+                ComponentLifecycleState.RUNNING,
+            ):
+                self._logger.debug("TCP server start called while already running.")
+                return
+            self._logger.debug("Starting TCP server.")
+            self._has_started = True
+            await self._event_dispatcher.start()
+            lifecycle_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
+            self._notify_status_changed()
+        try:
+            await self._emit_lifecycle_event(lifecycle_event)
+        except BaseException:
+            await self._rollback_failed_startup()
+            raise
+        server: asyncio.AbstractServer | None = None
+        listening_socket: socket.socket | None = None
+        try:
+            listening_socket = self._create_listening_socket()
+            server = await asyncio.start_server(
+                self._handle_client,
+                sock=listening_socket,
+            )
+        except Exception:
+            lifecycle_event = None
+            if listening_socket is not None:
+                with contextlib.suppress(Exception):
+                    listening_socket.close()
+            async with self._state_lock:
+                self._server = None
+                lifecycle_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+            await self._emit_lifecycle_event(lifecycle_event)
+            await self._event_dispatcher.stop()
+            self._notify_status_changed()
+            raise
+
+        lifecycle_event = None
+        async with self._state_lock:
+            if self._lifecycle_state != ComponentLifecycleState.STARTING:
+                # stop() may have completed while ``asyncio.start_server()``
+                # was still in flight. Close this just-created server locally
+                # because the stop path could not yet see it.
+                server.close()
+                await server.wait_closed()
+                return
+            self._server = server
+            lifecycle_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
+            self._notify_status_changed()
+        try:
+            await self._emit_lifecycle_event(lifecycle_event)
+        except BaseException:
+            await self._rollback_failed_startup(server=server)
+            raise
+
+    async def stop(self) -> None:
+        """Stop accepting clients and best-effort close active resources."""
+        self._assert_owner_loop()
+        stopping_event: ComponentLifecycleChangedEvent | None = None
+        stopped_event: ComponentLifecycleChangedEvent | None = None
+        should_transition_to_stopped = False
+        stop_waiter: asyncio.Future[None] | None = None
+        owns_stop = False
+        async with self._state_lock:
+            self._logger.debug("Stopping TCP server.")
+            if (
+                self._lifecycle_state == ComponentLifecycleState.STOPPING
+                and self._stop_waiter is not None
+            ):
+                stop_waiter = self._stop_waiter
+            else:
+                stop_waiter = asyncio.get_running_loop().create_future()
+                self._stop_waiter = stop_waiter
+                owns_stop = True
+            server = self._server
+            self._server = None
+            if owns_stop:
+                stopping_event = apply_stopping_transition_if_active(
+                    get_state=lambda: self._lifecycle_state,
+                    apply_transition=self._apply_lifecycle_state,
+                )
+                if stopping_event is not None:
+                    should_transition_to_stopped = True
+                heartbeat_senders = tuple(self._heartbeat_senders.values())
+                self._heartbeat_senders.clear()
+                connections = tuple(self._connections.values())
+                self._connections.clear()
+            else:
+                heartbeat_senders = ()
+                connections = ()
+        if not owns_stop:
+            if stop_waiter is not None:
+                if self._event_dispatcher.current_task_is_worker():
+                    return
+                await stop_waiter
+            return
+        inline_delivery_context = (
+            self._event_dispatcher.inline_delivery_context()
+            if self._event_dispatcher.current_task_is_worker()
+            else contextlib.nullcontext()
+        )
+        try:
+            with inline_delivery_context:
+                first_error: BaseException | None = None
+                try:
+                    await self._emit_lifecycle_event(stopping_event)
+                except BaseException as error:
+                    first_error = error
+                try:
+                    if server is not None:
+                        server.close()
+                    await stop_server_heartbeat_senders(
+                        senders=heartbeat_senders,
+                        event_dispatcher=self._event_dispatcher,
+                        logger=self._logger,
+                        component_id=self._component_id,
+                    )
+                    if connections:
+                        close_results = await asyncio.gather(
+                            *(connection.close() for connection in connections),
+                            return_exceptions=True,
+                        )
+                        await report_teardown_errors(
+                            event_dispatcher=self._event_dispatcher,
+                            logger=self._logger,
+                            component_id=self._component_id,
+                            operation="TCP connection close",
+                            targets=(connection.connection_id for connection in connections),
+                            results=close_results,
+                        )
+                    if server is not None:
+                        await server.wait_closed()
+                except BaseException as error:
+                    if first_error is None:
+                        first_error = error
+                if should_transition_to_stopped:
+                    async with self._state_lock:
+                        stopped_event = apply_stopped_transition_if_stopping(
+                            get_state=lambda: self._lifecycle_state,
+                            apply_transition=self._apply_lifecycle_state,
+                        )
+                    if first_error is None:
+                        try:
+                            await self._emit_lifecycle_event(stopped_event)
+                        except BaseException as error:
+                            first_error = error
+                    try:
+                        await self._event_dispatcher.stop()
+                    except BaseException as error:
+                        if first_error is None:
+                            first_error = error
+                self._notify_status_changed()
+                self._logger.debug("TCP server stopped.")
+                if first_error is not None:
+                    raise first_error
+        except BaseException as error:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_exception(error)
+                with contextlib.suppress(BaseException):
+                    stop_waiter.exception()
+            raise
+        else:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_result(None)
+        finally:
+            async with self._state_lock:
+                if self._stop_waiter is stop_waiter:
+                    self._stop_waiter = None
+
+    async def __aenter__(self) -> AsyncioTcpServer:
+        """Start the server and return ``self``."""
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Stop the server unconditionally."""
+        await self.stop()
+
+    async def wait_until_running(
+        self, timeout_seconds: float | None = None, poll_interval_seconds: float = 0.1
+    ) -> None:
+        """
+        Wait until lifecycle reaches ``RUNNING``.
+
+        Raises:
+            ValueError: ``poll_interval_seconds`` <= 0.
+            ConnectionError: Server stopped before reaching RUNNING.
+            asyncio.TimeoutError: ``timeout_seconds`` elapsed first.
+        """
+        self._assert_owner_loop()
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be > 0.")
+        coro = wait_until_server_running(
+            get_lifecycle_state=lambda: self._lifecycle_state,
+            get_has_started=lambda: self._has_started,
+            get_status_version=lambda: self._status_version,
+            status_changed=self._status_changed,
+            host=self._settings.host,
+            port=self._settings.port,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+        if timeout_seconds is None:
+            await coro
+            return
+        await asyncio.wait_for(coro, timeout=timeout_seconds)
+
+    async def broadcast(self, data: BytesLike) -> None:
+        """Send data to all live clients; per-connection failures are best-effort."""
+        self._assert_owner_loop()
+        await broadcast_to_connections(
+            connections=tuple(self._connections.values()),
+            data=data,
+            event_dispatcher=self._event_dispatcher,
+            component_id=self._component_id,
+            logger=self._logger,
+            concurrency_limit=self._settings.broadcast_concurrency_limit,
+            send_timeout_seconds=self._settings.broadcast_send_timeout_seconds,
+        )
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Initialize one accepted socket into managed connection state."""
+
+        def _next_connection_id() -> str:
+            self._connection_sequence += 1
+            return self._build_connection_id(
+                writer.get_extra_info("peername"), self._connection_sequence
+            )
+
+        await handle_accepted_client(
+            reader=reader,
+            writer=writer,
+            state_lock=self._state_lock,
+            get_lifecycle_state=lambda: self._lifecycle_state,
+            get_connection_id=_next_connection_id,
+            connections=self._connections,
+            event_dispatcher=self._event_dispatcher,
+            max_connections=self._settings.max_connections,
+            receive_buffer_size=self._settings.receive_buffer_size,
+            idle_timeout_seconds=self._settings.connection_idle_timeout_seconds,
+            on_closed_callback=self._on_connection_closed,
+            heartbeat_settings=self._settings.heartbeat,
+            heartbeat_provider=self._heartbeat_provider,
+            heartbeat_senders=self._heartbeat_senders,
+            component_id=self._component_id,
+            logger=self._logger,
+        )
+
+    async def _start_heartbeat_if_needed(self, connection: AsyncioTcpConnection) -> None:
+        """Create and register a heartbeat sender for ``connection`` when configured."""
+        await start_server_heartbeat_if_needed(
+            connection=connection,
+            heartbeat_settings=self._settings.heartbeat,
+            heartbeat_provider=self._heartbeat_provider,
+            event_dispatcher=self._event_dispatcher,
+            state_lock=self._state_lock,
+            get_lifecycle_state=lambda: self._lifecycle_state,
+            connections=self._connections,
+            heartbeat_senders=self._heartbeat_senders,
+            logger=self._logger,
+        )
+
+    async def _on_connection_closed(self, connection: AsyncioTcpConnection) -> None:
+        """Remove closed connection state and stop its heartbeat sender, if any."""
+        async with self._state_lock:
+            sender = self._heartbeat_senders.pop(connection.connection_id, None)
+            self._connections.pop(connection.connection_id, None)
+        if sender is not None:
+            await sender.stop()
+
+    def _apply_lifecycle_state(
+        self, next_state: ComponentLifecycleState
+    ) -> ComponentLifecycleChangedEvent | None:
+        """Apply one lifecycle transition and return the corresponding event, if any."""
+        return self._lifecycle_publisher.apply(next_state)
+
+    async def _emit_lifecycle_event(self, event: ComponentLifecycleChangedEvent | None) -> None:
+        """Emit a lifecycle event when the transition publisher produced one."""
+        await emit_lifecycle_event(dispatcher=self._event_dispatcher, event=event)
+
+    async def _set_lifecycle_state(self, next_state: ComponentLifecycleState) -> None:
+        """Convenience helper that applies and emits a lifecycle transition."""
+        event = self._apply_lifecycle_state(next_state)
+        await self._emit_lifecycle_event(event)
+
+    async def _rollback_failed_startup(self, server: asyncio.AbstractServer | None = None) -> None:
+        """Return startup-owned resources to STOPPED after lifecycle publication fails."""
+        async with self._state_lock:
+            owned_server = self._server
+            self._server = None
+            if self._lifecycle_state == ComponentLifecycleState.RUNNING:
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPING)
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+            elif self._lifecycle_state == ComponentLifecycleState.STARTING:
+                self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+            self._notify_status_changed()
+        for server_to_close in (server, owned_server):
+            if server_to_close is not None:
+                server_to_close.close()
+                with contextlib.suppress(Exception):
+                    await server_to_close.wait_closed()
+        with contextlib.suppress(BaseException):
+            await self._event_dispatcher.stop()
+
+    def _build_connection_id(self, peer_info: object, sequence: int) -> str:
+        """Build the stable per-connection identifier used by server-side events."""
+        return tcp_server_connection_id(peer_info, sequence)
+
+    def _create_listening_socket(self) -> socket.socket:
+        """Create and bind the server listening socket with the configured bind policy."""
+        last_error: OSError | None = None
+        addrinfo_list = socket.getaddrinfo(
+            self._settings.host,
+            self._settings.port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+            flags=socket.AI_PASSIVE,
+        )
+        for family, socktype, proto, _canonname, sockaddr in addrinfo_list:
+            sock = socket.socket(family, socktype, proto)
+            try:
+                configure_listener_bind_socket(sock, allow_address_reuse=False)
+                if family == socket.AF_INET6:
+                    with contextlib.suppress(OSError):
+                        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+                sock.bind(sockaddr)
+                sock.listen(self._settings.backlog)
+                sock.setblocking(False)
+                return sock
+            except OSError as error:
+                last_error = error
+                with contextlib.suppress(OSError):
+                    sock.close()
+        if last_error is not None:
+            raise last_error
+        raise OSError(
+            f"Could not create listening socket for {self._settings.host}:{self._settings.port}."
+        )
+
+    def _notify_status_changed(self) -> None:
+        """Bump the status version and wake polling/waiting helpers."""
+        self._status_version += 1
+        self._status_changed.set()

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -11,7 +11,9 @@ import asyncio
 import contextlib
 import logging
 import socket
+from collections.abc import Awaitable
 from types import TracebackType
+from typing import cast
 
 from aionetx.api.bytes_like import BytesLike
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
@@ -150,7 +152,7 @@ class AsyncioTcpServer(TcpServerProtocol):
             self._notify_status_changed()
         try:
             await self._emit_lifecycle_event(lifecycle_event)
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             await self._rollback_failed_startup()
             raise
         server: asyncio.AbstractServer | None = None
@@ -188,7 +190,7 @@ class AsyncioTcpServer(TcpServerProtocol):
             self._notify_status_changed()
         try:
             await self._emit_lifecycle_event(lifecycle_event)
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             await self._rollback_failed_startup(server=server)
             raise
 
@@ -200,6 +202,8 @@ class AsyncioTcpServer(TcpServerProtocol):
         should_transition_to_stopped = False
         stop_waiter: asyncio.Future[None] | None = None
         owns_stop = False
+        heartbeat_senders: tuple[AsyncioHeartbeatSender, ...] = ()
+        connections: tuple[AsyncioTcpConnection, ...] = ()
         async with self._state_lock:
             self._logger.debug("Stopping TCP server.")
             if (
@@ -224,14 +228,11 @@ class AsyncioTcpServer(TcpServerProtocol):
                 self._heartbeat_senders.clear()
                 connections = tuple(self._connections.values())
                 self._connections.clear()
-            else:
-                heartbeat_senders = ()
-                connections = ()
         if not owns_stop:
             if stop_waiter is not None:
                 if self._event_dispatcher.current_task_is_worker():
                     return
-                await stop_waiter
+                _ = await cast(Awaitable[object], stop_waiter)
             return
         inline_delivery_context = (
             self._event_dispatcher.inline_delivery_context()
@@ -243,7 +244,7 @@ class AsyncioTcpServer(TcpServerProtocol):
                 first_error: BaseException | None = None
                 try:
                     await self._emit_lifecycle_event(stopping_event)
-                except BaseException as error:
+                except (Exception, asyncio.CancelledError) as error:
                     first_error = error
                 try:
                     if server is not None:
@@ -269,7 +270,7 @@ class AsyncioTcpServer(TcpServerProtocol):
                         )
                     if server is not None:
                         await server.wait_closed()
-                except BaseException as error:
+                except (Exception, asyncio.CancelledError) as error:
                     if first_error is None:
                         first_error = error
                 if should_transition_to_stopped:
@@ -281,21 +282,21 @@ class AsyncioTcpServer(TcpServerProtocol):
                     if first_error is None:
                         try:
                             await self._emit_lifecycle_event(stopped_event)
-                        except BaseException as error:
+                        except (Exception, asyncio.CancelledError) as error:
                             first_error = error
                     try:
                         await self._event_dispatcher.stop()
-                    except BaseException as error:
+                    except (Exception, asyncio.CancelledError) as error:
                         if first_error is None:
                             first_error = error
                 self._notify_status_changed()
                 self._logger.debug("TCP server stopped.")
                 if first_error is not None:
                     raise first_error
-        except BaseException as error:
+        except (Exception, asyncio.CancelledError) as error:
             if stop_waiter is not None and not stop_waiter.done():
                 stop_waiter.set_exception(error)
-                with contextlib.suppress(BaseException):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
                     stop_waiter.exception()
             raise
         else:
@@ -344,7 +345,7 @@ class AsyncioTcpServer(TcpServerProtocol):
             poll_interval_seconds=poll_interval_seconds,
         )
         if timeout_seconds is None:
-            await coro
+            _ = await cast(Awaitable[object], coro)
             return
         await asyncio.wait_for(coro, timeout=timeout_seconds)
 
@@ -444,7 +445,7 @@ class AsyncioTcpServer(TcpServerProtocol):
                 server_to_close.close()
                 with contextlib.suppress(Exception):
                     await server_to_close.wait_closed()
-        with contextlib.suppress(BaseException):
+        with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._event_dispatcher.stop()
 
     def _build_connection_id(self, peer_info: object, sequence: int) -> str:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_udp_receiver.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_udp_receiver.py
@@ -1,0 +1,125 @@
+"""
+Asyncio implementation of the managed UDP receiver role.
+
+This module adapts the shared datagram receiver base to plain UDP socket setup
+and UDP-specific receive metadata.
+"""
+
+from __future__ import annotations
+
+import asyncio  # noqa: F401 - test seam: monkeypatched in unit tests
+import contextlib
+import logging
+import socket
+from types import TracebackType
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.udp import UdpReceiverProtocol, UdpReceiverSettings
+from aionetx.implementations.asyncio_impl._asyncio_datagram_receiver_base import (
+    _AsyncioDatagramReceiverBase,
+)
+from aionetx.implementations.asyncio_impl.identifier_utils import udp_receiver_component_id
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
+from aionetx.implementations.asyncio_impl.runtime_utils import configure_listener_bind_socket
+
+
+class AsyncioUdpReceiver(_AsyncioDatagramReceiverBase, UdpReceiverProtocol):
+    """Managed asyncio UDP receiver built on the shared datagram base."""
+
+    def __init__(
+        self, settings: UdpReceiverSettings, event_handler: NetworkEventHandlerProtocol
+    ) -> None:
+        settings.validate()
+        self._settings = settings
+        connection_id = udp_receiver_component_id(settings.host, settings.port)
+        logger = logging.LoggerAdapter(
+            logging.getLogger(__name__),
+            {"component": "udp_receiver", "connection_id": connection_id},
+        )
+        event_dispatcher = AsyncioEventDispatcher(
+            event_handler=event_handler,
+            delivery=settings.event_delivery,
+            logger=logger,
+            error_source=connection_id,
+            stop_component_callback=self.stop,
+        )
+        super().__init__(
+            receiver_name="UDP",
+            connection_id=connection_id,
+            logger=logger,
+            event_dispatcher=event_dispatcher,
+            lifecycle_role=LifecycleRole.UDP_RECEIVER,
+        )
+
+    @property
+    def lifecycle_state(self) -> ComponentLifecycleState:
+        """Return the current managed lifecycle state."""
+        return self._lifecycle_state
+
+    def __repr__(self) -> str:
+        return (
+            f"AsyncioUdpReceiver("
+            f"host={self._settings.host!r}, "
+            f"port={self._settings.port!r}, "
+            f"state={self._lifecycle_state.value!r})"
+        )
+
+    async def start(self) -> None:
+        """
+        Bind the UDP socket, publish lifecycle transitions, and start receiving.
+
+        Raises:
+            OSError: If socket setup or bind fails.
+        """
+        self._assert_owner_loop()
+        if not await self._begin_startup():
+            return
+        sock: socket.socket | None = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            configure_listener_bind_socket(sock, allow_address_reuse=False)
+            if self._settings.enable_broadcast:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.bind((self._settings.host, self._settings.port))
+            sock.setblocking(False)
+            local_host, local_port = sock.getsockname()[:2]
+            metadata = ConnectionMetadata(
+                connection_id=self._connection_id,
+                role=ConnectionRole.UDP_RECEIVER,
+                local_host=str(local_host),
+                local_port=int(local_port),
+            )
+        except Exception:
+            if sock is not None:
+                with contextlib.suppress(Exception):
+                    sock.close()
+            await self._fail_startup()
+            raise
+        await self._complete_startup(
+            sock=sock,
+            metadata=metadata,
+            receive_buffer_size=self._settings.receive_buffer_size,
+        )
+
+    async def stop(self) -> None:
+        """Stop UDP reception and release owned socket resources."""
+        self._assert_owner_loop()
+        await super().stop()
+
+    async def __aenter__(self) -> AsyncioUdpReceiver:
+        """Start the receiver and return ``self``."""
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Stop the receiver unconditionally."""
+        await self.stop()

--- a/src/aionetx/implementations/asyncio_impl/asyncio_udp_receiver.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_udp_receiver.py
@@ -7,7 +7,6 @@ and UDP-specific receive metadata.
 
 from __future__ import annotations
 
-import asyncio  # noqa: F401 - test seam: monkeypatched in unit tests
 import contextlib
 import logging
 import socket

--- a/src/aionetx/implementations/asyncio_impl/asyncio_udp_sender.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_udp_sender.py
@@ -1,0 +1,240 @@
+"""
+Asyncio implementation of the lifecycle-light UDP sender role.
+
+This module provides lazy socket creation, optional target overrides, and
+best-effort nonblocking send behavior for UDP datagrams.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import socket
+from types import TracebackType
+
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.udp import (
+    UdpInvalidTargetError,
+    UdpSenderProtocol,
+    UdpSenderSettings,
+    UdpSenderStoppedError,
+)
+from aionetx.api._validation import require_int_range, require_non_empty_str
+from aionetx.implementations.asyncio_impl.identifier_utils import udp_sender_component_id
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    WarningRateLimiter,
+    assert_running_on_owner_loop,
+    configure_listener_bind_socket,
+)
+
+_send_fallback_warning_limiter = WarningRateLimiter(interval_seconds=300.0)
+
+
+class AsyncioUdpSender(UdpSenderProtocol):
+    """
+    Stateless UDP datagram sender.
+
+    Unlike receiver/server/client components this sender has no running/stopped
+    lifecycle stream. It lazily owns a socket and only exposes send() and
+    idempotent stop().
+    """
+
+    _WOULD_BLOCK_INITIAL_DELAY_SECONDS = 0.0005
+    _WOULD_BLOCK_MAX_DELAY_SECONDS = 0.02
+
+    def __init__(self, settings: UdpSenderSettings) -> None:
+        settings.validate()
+        self._settings = settings
+        self._socket: socket.socket | None = None
+        self._closed = False
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+        self._connection_id = udp_sender_component_id(settings.local_host, settings.local_port)
+        self._logger: logging.LoggerAdapter[logging.Logger] = logging.LoggerAdapter(
+            logging.getLogger(__name__),
+            {"component": "udp_sender", "connection_id": self._connection_id},
+        )
+        self._sendto_fallback_warning_emitted = False
+
+    @property
+    def is_socket_initialized(self) -> bool:
+        """
+        Whether the underlying UDP socket has been created.
+
+        The socket is created lazily on the first ``send()`` call and released
+        by ``stop()``.  This property allows tests and callers to verify
+        socket-lifecycle invariants via the public contract rather than private
+        attributes.
+        """
+        return self._socket is not None
+
+    def __repr__(self) -> str:
+        return (
+            f"AsyncioUdpSender("
+            f"default_host={self._settings.default_host!r}, "
+            f"default_port={self._settings.default_port!r}, "
+            f"closed={self._closed!r})"
+        )
+
+    def _assert_owner_loop(self) -> None:
+        """
+        Raise RuntimeError if called outside the owner event loop.
+
+        Also pins ``_owner_loop`` on first call so all subsequent guard checks
+        use the same loop identity drawn from ``runtime_utils.asyncio`` — not
+        from a potentially test-patched module-level asyncio import.
+        """
+        self._owner_loop = assert_running_on_owner_loop(
+            class_name=type(self).__name__, owner_loop=self._owner_loop
+        )
+
+    async def send(self, data: BytesLike, host: str | None = None, port: int | None = None) -> None:
+        """
+        Send one datagram to the configured default target or a per-call override.
+
+        Args:
+            data: Datagram payload to send.
+            host: Optional per-call target host override.
+            port: Optional per-call target port override.
+
+        Raises:
+            UdpSenderStoppedError: If the sender has already been stopped.
+            UdpInvalidTargetError: If target host or port cannot be resolved.
+            TypeError: If ``data`` is not bytes-like.
+        """
+        self._assert_owner_loop()
+        if self._closed:
+            raise UdpSenderStoppedError("UDP sender is stopped.")
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError("send expects bytes-like data.")
+
+        target_host = host if host is not None else self._settings.default_host
+        target_port = port if port is not None else self._settings.default_port
+        target_host = require_non_empty_str(
+            field_name="UDP target host",
+            value=target_host,
+            error_type=UdpInvalidTargetError,
+        )
+        if target_port is None:
+            raise UdpInvalidTargetError("UDP target port must be between 1 and 65535.")
+        require_int_range(
+            field_name="UDP target port",
+            value=target_port,
+            min_value=1,
+            max_value=65535,
+            error_type=UdpInvalidTargetError,
+        )
+
+        sock = self._ensure_socket()
+        await self._send_nonblocking(sock, bytes(data), (target_host, target_port))
+
+    async def stop(self) -> None:
+        """Close the sender socket and make future ``send()`` calls fail."""
+        if self._closed:
+            return
+        self._assert_owner_loop()
+        self._closed = True
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+
+    async def __aenter__(self) -> AsyncioUdpSender:
+        """Return ``self``; UDP sender is lazy and needs no explicit start."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Close the sender's socket unconditionally."""
+        await self.stop()
+
+    def _ensure_socket(self) -> socket.socket:
+        """Create, configure, and cache the UDP socket on first use."""
+        if self._socket is not None:
+            return self._socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        try:
+            sock.setblocking(False)
+            configure_listener_bind_socket(sock, allow_address_reuse=False)
+            if self._settings.enable_broadcast:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.bind((self._settings.local_host, self._settings.local_port))
+        except OSError:
+            with contextlib.suppress(OSError):
+                sock.close()
+            raise
+        self._refresh_connection_identity_from_socket(sock)
+        self._socket = sock
+        return sock
+
+    def _refresh_connection_identity_from_socket(self, sock: socket.socket) -> None:
+        """Refresh sender identity from the actual bound socket address when available."""
+        try:
+            sockname = sock.getsockname()
+        except OSError:
+            return
+
+        if not (isinstance(sockname, tuple) and len(sockname) >= 2):
+            return
+
+        self._connection_id = udp_sender_component_id(str(sockname[0]), int(sockname[1]))
+        self._logger.extra = {
+            "component": "udp_sender",
+            "connection_id": self._connection_id,
+        }
+
+    def _sendto_fallback_limiter_key(self, sock: socket.socket) -> str:
+        """Build a limiter key from the actual bound socket identity when available."""
+        try:
+            sockname = sock.getsockname()
+        except OSError:
+            return f"{self._connection_id}:sendto-fallback"
+
+        if isinstance(sockname, tuple) and len(sockname) >= 2:
+            return f"{udp_sender_component_id(str(sockname[0]), int(sockname[1]))}:sendto-fallback"
+
+        return f"{self._connection_id}:sendto-fallback"
+
+    async def _send_nonblocking(
+        self, sock: socket.socket, payload: bytes, target: tuple[str, int]
+    ) -> None:
+        """
+        Send one datagram using loop-native send support or a polling fallback.
+
+        Args:
+            sock: Bound UDP socket used for the send.
+            payload: Concrete payload bytes to transmit.
+            target: Resolved target host and port.
+        """
+        loop = asyncio.get_running_loop()
+        runtime_sock_sendto = getattr(loop, "sock_sendto", None)
+        if callable(runtime_sock_sendto):
+            await runtime_sock_sendto(sock, payload, target)
+            return
+
+        if not self._sendto_fallback_warning_emitted:
+            limiter_key = self._sendto_fallback_limiter_key(sock)
+            if _send_fallback_warning_limiter.should_log(limiter_key):
+                self._logger.warning(
+                    "AsyncioUdpSender is using sendto() fallback polling because "
+                    "the event loop does not expose sock_sendto(). On Windows this "
+                    "typically means the ProactorEventLoop is active; see "
+                    "docs/platform_notes.md for latency implications and "
+                    "mitigation via SelectorEventLoop.",
+                )
+            self._sendto_fallback_warning_emitted = True
+
+        backoff_delay_seconds = self._WOULD_BLOCK_INITIAL_DELAY_SECONDS
+        while True:
+            try:
+                sock.sendto(payload, target)
+                return
+            except (BlockingIOError, InterruptedError):
+                await asyncio.sleep(backoff_delay_seconds)
+                backoff_delay_seconds = min(
+                    self._WOULD_BLOCK_MAX_DELAY_SECONDS,
+                    backoff_delay_seconds * 2,
+                )

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -1,0 +1,522 @@
+"""
+Shared asyncio event dispatcher for transport lifecycle/event delivery.
+
+The dispatcher provides per-component event handling with configurable inline
+or background execution and explicit backpressure/failure policies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+from collections import deque
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    WarningRateLimiter,
+    validate_async_event_handler,
+)
+
+_stop_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
+_backpressure_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
+_inline_dispatcher_context: contextvars.ContextVar[frozenset[int]] = contextvars.ContextVar(
+    "aionetx_inline_dispatcher_context", default=frozenset()
+)
+
+
+class _HandlerCancelledError(RuntimeError):
+    """Exception wrapper used when a handler raises CancelledError itself."""
+
+
+@dataclass(frozen=True, slots=True)
+class DispatcherRuntimeStats:
+    """
+    Point-in-time operational counters for one dispatcher instance.
+
+    Attributes:
+        emit_calls_total: Total number of ``emit()`` calls observed.
+        enqueued_total: Events accepted into the background queue.
+        handler_dispatch_attempts_total: Attempts to invoke the event handler.
+        handler_failures_total: Handler invocations that raised.
+        inline_fallback_total: Background-mode emits delivered inline because no worker existed yet.
+        dropped_backpressure_oldest_total: Events evicted by ``DROP_OLDEST`` backpressure.
+        dropped_backpressure_newest_total: Events rejected by ``DROP_NEWEST`` backpressure.
+        dropped_stop_phase_total: Background-mode emits ignored after shutdown started.
+        queue_depth: Current queued event count.
+        queue_peak: Highest queue depth observed so far.
+    """
+
+    emit_calls_total: int
+    enqueued_total: int
+    handler_dispatch_attempts_total: int
+    handler_failures_total: int
+    inline_fallback_total: int
+    dropped_backpressure_oldest_total: int
+    dropped_backpressure_newest_total: int
+    dropped_stop_phase_total: int
+    queue_depth: int
+    queue_peak: int
+
+
+@dataclass(frozen=True, slots=True)
+class DispatcherStopPolicy:
+    """
+    Callback policy used by ``STOP_COMPONENT`` handler-failure behavior.
+
+    Attributes:
+        enabled: Whether handler failures may request component shutdown.
+        callback: Awaitable shutdown callback invoked when the policy is active.
+    """
+
+    enabled: bool
+    callback: Callable[[], Awaitable[None]] | None = None
+
+    @classmethod
+    def disabled(cls) -> DispatcherStopPolicy:
+        """Build a policy that never requests component shutdown."""
+        return cls(enabled=False, callback=None)
+
+    @classmethod
+    def stop_component(cls, callback: Callable[[], Awaitable[None]]) -> DispatcherStopPolicy:
+        """
+        Build a policy that stops the owning component on handler failure.
+
+        Args:
+            callback: Awaitable shutdown callback owned by the component.
+
+        Returns:
+            DispatcherStopPolicy: Enabled stop policy bound to ``callback``.
+        """
+        return cls(enabled=True, callback=callback)
+
+    def validate(self) -> None:
+        """
+        Validate the internal consistency of the configured stop policy.
+
+        Raises:
+            ValueError: If ``enabled`` and ``callback`` disagree about whether
+                shutdown is supported.
+        """
+        if self.enabled and self.callback is None:
+            raise ValueError("DispatcherStopPolicy with enabled=True requires a callback.")
+        if not self.enabled and self.callback is not None:
+            raise ValueError("DispatcherStopPolicy with enabled=False must not provide a callback.")
+
+
+class AsyncioEventDispatcher:
+    """
+    Async event dispatcher with optional background delivery.
+
+    BACKGROUND-mode contract:
+    - Before ``start()`` creates the worker task, ``emit()`` falls back to
+      inline delivery in the caller task.
+    - After ``start()``, ``emit()`` enqueues to the worker task.
+    - Once ``stop()`` begins, new BACKGROUND-mode emits are intentionally
+      ignored so blocked producers can exit promptly and shutdown can complete.
+
+    Flow overview:
+        emit()
+          |
+          +-- INLINE ------------------------------> _emit_now()
+          |
+          +-- BACKGROUND, worker missing ----------> inline fallback
+          |
+          +-- BACKGROUND, worker running ----------> _enqueue() -> _run() -> _emit_now()
+          |
+          +-- BACKGROUND, stop in progress --------> drop and log rate-limited warning
+    """
+
+    def __init__(
+        self,
+        event_handler: NetworkEventHandlerProtocol,
+        delivery: EventDeliverySettings,
+        logger: logging.Logger | logging.LoggerAdapter[logging.Logger],
+        *,
+        error_source: str | None = None,
+        stop_policy: DispatcherStopPolicy | None = None,
+        stop_component_callback: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        validate_async_event_handler(event_handler)
+        if stop_policy is not None and stop_component_callback is not None:
+            raise ValueError("Provide either stop_policy or stop_component_callback, not both.")
+        if stop_policy is None:
+            if stop_component_callback is None:
+                stop_policy = DispatcherStopPolicy.disabled()
+            else:
+                stop_policy = DispatcherStopPolicy.stop_component(stop_component_callback)
+        stop_policy.validate()
+        self._event_handler = event_handler
+        self._delivery = delivery
+        self._logger = logger
+        self._error_source = error_source
+        self._stop_policy_enabled = stop_policy.enabled
+        self._stop_component_callback = stop_policy.callback
+        self._worker_task: asyncio.Task[None] | None = None
+        self._queue: deque[NetworkEvent] = deque()
+        self._queue_not_empty = asyncio.Condition()
+        self._queue_not_full = asyncio.Condition()
+        self._stopping = False
+        self._emit_calls_total = 0
+        self._enqueued_total = 0
+        self._handler_dispatch_attempts_total = 0
+        self._handler_failures_total = 0
+        self._inline_fallback_total = 0
+        self._dropped_backpressure_oldest_total = 0
+        self._dropped_backpressure_newest_total = 0
+        self._dropped_stop_phase_total = 0
+        self._queue_peak = 0
+
+    def _has_background_worker(self) -> bool:
+        return self._worker_task is not None
+
+    def _accepting_background_events(self) -> bool:
+        return not self._stopping
+
+    @property
+    def stop_policy(self) -> DispatcherStopPolicy:
+        """Explicit stop policy configured for handler-failure shutdown."""
+        callback = self._stop_component_callback
+        enabled = self._stop_policy_enabled or callback is not None
+        return DispatcherStopPolicy(enabled=enabled, callback=callback)
+
+    @property
+    def is_running(self) -> bool:
+        """
+        Whether the background worker task currently exists.
+
+        Note: this does not imply the dispatcher is still accepting new events;
+        once shutdown begins (``_stopping=True``), BACKGROUND emits are ignored
+        even if the worker has not exited yet.
+        """
+        return self._has_background_worker()
+
+    @property
+    def is_stopping(self) -> bool:
+        """
+        Whether dispatcher shutdown has been initiated.
+
+        Set to ``True`` at the start of ``stop()``.  Once ``True``, BACKGROUND
+        emits are ignored and blocked producers are released.  The background
+        worker may still be draining its queue when this flag becomes ``True``.
+        """
+        return self._stopping
+
+    @property
+    def runtime_stats(self) -> DispatcherRuntimeStats:
+        """Point-in-time dispatcher operational diagnostics snapshot."""
+        return DispatcherRuntimeStats(
+            emit_calls_total=self._emit_calls_total,
+            enqueued_total=self._enqueued_total,
+            handler_dispatch_attempts_total=self._handler_dispatch_attempts_total,
+            handler_failures_total=self._handler_failures_total,
+            inline_fallback_total=self._inline_fallback_total,
+            dropped_backpressure_oldest_total=self._dropped_backpressure_oldest_total,
+            dropped_backpressure_newest_total=self._dropped_backpressure_newest_total,
+            dropped_stop_phase_total=self._dropped_stop_phase_total,
+            queue_depth=len(self._queue),
+            queue_peak=self._queue_peak,
+        )
+
+    async def start(self) -> None:
+        """Start background dispatch worker when configured for BACKGROUND mode."""
+        if self._delivery.dispatch_mode != EventDispatchMode.BACKGROUND:
+            return
+        if self._has_background_worker():
+            return
+        self._stopping = False
+        self._worker_task = asyncio.create_task(self._run(), name="event-dispatcher")
+
+    async def stop(self) -> None:
+        """
+        Stop background dispatch and release blocked producers.
+
+        Queued events are drained by the worker before it exits. Emits arriving
+        after stop has started (or completed) are ignored in BACKGROUND mode.
+        """
+        self._stopping = True
+        worker_task = self._worker_task
+        if worker_task is None:
+            return
+        current_task = asyncio.current_task()
+        async with self._queue_not_empty:
+            self._queue_not_empty.notify_all()
+        async with self._queue_not_full:
+            self._queue_not_full.notify_all()
+        # In background mode, handlers run on the worker task. If a handler
+        # triggers component shutdown, stop() may execute on that same task, so
+        # it must not await the worker it is currently unwinding.
+        if current_task is worker_task:
+            self._dropped_stop_phase_total += len(self._queue)
+            self._queue.clear()
+            return
+        await worker_task
+
+    async def emit(self, event: NetworkEvent) -> None:
+        """
+        Emit an event according to configured dispatch mode.
+
+        BACKGROUND-mode edge semantics are intentional and part of the
+        dispatcher contract:
+        - before worker start: deliver inline in the caller task;
+        - steady-state (worker running): enqueue for worker delivery;
+        - after stop begins: ignore new emits.
+
+        Arguments:
+            event (NetworkEvent): Event instance to deliver according to the
+                configured dispatch mode.
+        """
+        self._emit_calls_total += 1
+        if self._delivery.dispatch_mode == EventDispatchMode.INLINE:
+            await self._emit_now(event)
+            return
+        if self._is_in_inline_dispatch_context():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        if not self._accepting_background_events():
+            self._record_stop_phase_drop(event)
+            return
+        if self.current_task_is_worker():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        if not self._has_background_worker():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        await self._enqueue(event)
+
+    async def _enqueue(self, event: NetworkEvent) -> None:
+        """
+        Queue one event for background delivery under backpressure rules.
+
+        The method keeps shutdown predictable: once stop begins, blocked
+        producers are released and no additional background work is accepted.
+        """
+        while True:
+            async with self._queue_not_full:
+                if not self._accepting_background_events():
+                    self._record_stop_phase_drop(event)
+                    return
+                if len(self._queue) < self._delivery.max_pending_events:
+                    self._queue.append(event)
+                    self._enqueued_total += 1
+                    self._queue_peak = max(self._queue_peak, len(self._queue))
+                    break
+                policy = self._delivery.backpressure_policy
+                if policy == EventBackpressurePolicy.BLOCK:
+                    await self._queue_not_full.wait()
+                    continue
+                if policy == EventBackpressurePolicy.DROP_OLDEST:
+                    self._queue.popleft()
+                    self._queue.append(event)
+                    self._dropped_backpressure_oldest_total += 1
+                    self._enqueued_total += 1
+                    self._queue_peak = max(self._queue_peak, len(self._queue))
+                    self._warn_backpressure_drop(policy=policy)
+                    break
+                self._dropped_backpressure_newest_total += 1
+                self._warn_backpressure_drop(policy=policy)
+                return
+
+        async with self._queue_not_empty:
+            self._queue_not_empty.notify()
+
+    def _record_stop_phase_drop(self, event: NetworkEvent) -> None:
+        """Track and rate-limit warnings for emits ignored during shutdown."""
+        self._dropped_stop_phase_total += 1
+        limiter_key = f"{self._error_source or 'event-dispatcher'}:stop-phase-drop"
+        if _stop_drop_warning_limiter.should_log(limiter_key):
+            self._logger.warning(
+                "Dropping %s because dispatcher stop is in progress.",
+                type(event).__name__,
+            )
+
+    def current_task_is_worker(self) -> bool:
+        """
+        Return whether the caller currently runs on the dispatcher worker task.
+
+        This is an internal runtime hook for components that need self-await-safe
+        shutdown behavior without reaching into dispatcher private state.
+        """
+        current_task = asyncio.current_task()
+        return current_task is not None and current_task is self._worker_task
+
+    def _is_in_inline_dispatch_context(self) -> bool:
+        """
+        Return whether this dispatcher is already invoking user handler code.
+
+        Background handlers may initiate shutdown paths that create helper tasks
+        before publishing terminal events. Context variables are inherited by
+        those tasks, so this lets terminal internal events avoid re-entering the
+        same background queue that the initiating handler is currently blocking.
+        """
+        return id(self) in _inline_dispatcher_context.get()
+
+    @contextmanager
+    def inline_delivery_context(self) -> Iterator[None]:
+        """
+        Temporarily deliver this dispatcher's background emits inline.
+
+        This is an internal escape hatch for handler-originated shutdown paths
+        that create helper tasks before publishing terminal events. It must not
+        be enabled around arbitrary user-handler execution, because that would
+        leak into user-created tasks through context variable inheritance and
+        break normal BACKGROUND queue semantics.
+        """
+        active_dispatchers = _inline_dispatcher_context.get()
+        reset_token = _inline_dispatcher_context.set(active_dispatchers | {id(self)})
+        try:
+            yield
+        finally:
+            _inline_dispatcher_context.reset(reset_token)
+
+    def _warn_backpressure_drop(self, *, policy: EventBackpressurePolicy) -> None:
+        """Emit a rate-limited warning for overload drops."""
+        limiter_key = f"{self._error_source or 'event-dispatcher'}:{policy.value}"
+        if not _backpressure_drop_warning_limiter.should_log(limiter_key):
+            return
+        drop_count = (
+            self._dropped_backpressure_oldest_total
+            if policy == EventBackpressurePolicy.DROP_OLDEST
+            else self._dropped_backpressure_newest_total
+        )
+        self._logger.warning(
+            "Dropped events due to backpressure (%s, total=%s).",
+            policy.value,
+            drop_count,
+        )
+
+    async def _run(self) -> None:
+        """Drain the background queue until shutdown begins and queued work is exhausted."""
+        current_task = asyncio.current_task()
+        try:
+            while True:
+                event: NetworkEvent | None = None
+                async with self._queue_not_empty:
+                    while not self._queue and not self._stopping:
+                        await self._queue_not_empty.wait()
+                    if self._stopping and not self._queue:
+                        return
+                    if self._queue:
+                        event = self._queue.popleft()
+                async with self._queue_not_full:
+                    self._queue_not_full.notify()
+                if event is not None:
+                    await self._emit_now(event)
+        finally:
+            if self._worker_task is current_task:
+                self._worker_task = None
+
+    async def _emit_now(self, event: NetworkEvent) -> None:
+        """Deliver one event to the handler and route failures through policy handling."""
+        self._handler_dispatch_attempts_total += 1
+        try:
+            await self._event_handler.on_event(event)
+        except asyncio.CancelledError as error:
+            current_task = asyncio.current_task()
+            task_cancelling = getattr(current_task, "cancelling", None)
+            if task_cancelling is not None and task_cancelling():
+                raise
+            wrapped_error = _HandlerCancelledError(
+                "Network event handler raised asyncio.CancelledError without "
+                "cancelling the dispatcher task."
+            )
+            wrapped_error.__cause__ = error
+            await self._record_handler_failure(error=wrapped_error, triggering_event=event)
+        except Exception as error:
+            await self._record_handler_failure(error=error, triggering_event=event)
+
+    async def _record_handler_failure(
+        self, *, error: Exception, triggering_event: NetworkEvent
+    ) -> None:
+        """Record and route one user handler failure."""
+        self._handler_failures_total += 1
+        self._logger.exception(
+            "Network event handler raised while processing %s.", type(triggering_event).__name__
+        )
+        await self._handle_handler_failure(error=error, triggering_event=triggering_event)
+
+    async def _handle_handler_failure(
+        self, *, error: Exception, triggering_event: NetworkEvent
+    ) -> None:
+        """
+        Apply the configured failure policy after a handler exception.
+
+        Args:
+            error: Exception raised by the handler.
+            triggering_event: Event whose delivery triggered the failure.
+
+        Raises:
+            Exception: Re-raises ``error`` when inline mode uses
+                ``RAISE_IN_INLINE_MODE``.
+        """
+        policy = self._delivery.handler_failure_policy
+        if policy == EventHandlerFailurePolicy.LOG_ONLY:
+            return
+        if policy == EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE:
+            if self._delivery.dispatch_mode == EventDispatchMode.INLINE:
+                raise error
+            return
+        if policy == EventHandlerFailurePolicy.EMIT_ERROR_EVENT:
+            if isinstance(triggering_event, NetworkErrorEvent):
+                return
+            source = self._error_source or "event-dispatcher"
+            await self._emit_handler_failure_control_event(
+                NetworkErrorEvent(resource_id=source, error=error)
+            )
+            return
+        if policy == EventHandlerFailurePolicy.STOP_COMPONENT:
+            stop_policy = self.stop_policy
+            stop_callback = stop_policy.callback
+            if not stop_policy.enabled or stop_callback is None:
+                self._logger.warning(
+                    "handler_failure_policy=stop_component is configured but dispatcher stop_policy does not provide a callback."
+                )
+                return
+            if isinstance(triggering_event, HandlerFailurePolicyStopEvent):
+                return
+            source = self._error_source or "event-dispatcher"
+            await self._emit_handler_failure_control_event(
+                HandlerFailurePolicyStopEvent(
+                    resource_id=source,
+                    triggering_event_name=type(triggering_event).__name__,
+                    error=error,
+                    policy=policy,
+                    dispatch_mode=self._delivery.dispatch_mode,
+                )
+            )
+            with self.inline_delivery_context():
+                await stop_callback()
+            return
+        raise RuntimeError(f"Unhandled EventHandlerFailurePolicy: {policy!r}")
+
+    async def _emit_handler_failure_control_event(self, event: NetworkEvent) -> None:
+        """
+        Deliver a failure-path control event without deadlocking the worker queue.
+
+        When the background worker itself is handling a failing event, re-entering
+        ``emit()`` under ``BLOCK`` backpressure can wait forever on queue space
+        that only the same worker could free. Deliver control events inline on
+        the worker to keep failure handling progress-safe.
+        """
+        if (
+            self._delivery.dispatch_mode == EventDispatchMode.BACKGROUND
+            and self.current_task_is_worker()
+        ):
+            await self._emit_now(event)
+            return
+        await self.emit(event)

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -14,6 +14,7 @@ from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import cast
 
 from aionetx.api.event_delivery_settings import (
     EventBackpressurePolicy,
@@ -262,7 +263,7 @@ class AsyncioEventDispatcher:
             self._dropped_stop_phase_total += len(self._queue)
             self._queue.clear()
             return
-        await worker_task
+        _ = await cast(Awaitable[object], worker_task)
 
     async def emit(self, event: NetworkEvent) -> None:
         """

--- a/src/aionetx/implementations/asyncio_impl/identifier_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/identifier_utils.py
@@ -1,0 +1,57 @@
+"""
+Canonical component/connection ID builders for asyncio implementations.
+
+Keep all ID format strings here to avoid drift across components while
+enforcing one normalized identifier schema.
+"""
+
+from __future__ import annotations
+
+
+def tcp_client_connection_id(default_host: str, default_port: int, peer_info: object) -> str:
+    """Build the canonical connection ID for a TCP client session."""
+    host, port = _host_port_or_default(peer_info, default_host, default_port)
+    return f"tcp/client/{host}/{port}/connection"
+
+
+def tcp_client_component_id(host: str, port: int) -> str:
+    """Build the canonical component ID for a TCP client transport."""
+    return f"tcp/client/{host}/{port}"
+
+
+def tcp_server_connection_id(peer_info: object, sequence: int) -> str:
+    """Build the canonical connection ID for one accepted TCP server session."""
+    if isinstance(peer_info, tuple) and len(peer_info) >= 2:
+        return f"tcp/server/{peer_info[0]}/{peer_info[1]}/connection/{sequence}"
+    return f"tcp/server/unknown/unknown/connection/{sequence}"
+
+
+def tcp_server_component_id(host: str, port: int) -> str:
+    """Build the canonical component ID for a TCP server transport."""
+    return f"tcp/server/{host}/{port}"
+
+
+def udp_receiver_component_id(host: str, port: int) -> str:
+    """Build the canonical component ID for a UDP receiver transport."""
+    return f"udp/receiver/{host}/{port}"
+
+
+def udp_sender_component_id(local_host: str, local_port: int) -> str:
+    """Build the canonical component ID for a UDP sender transport."""
+    return f"udp/sender/{local_host}/{local_port}"
+
+
+def multicast_receiver_component_id(group_ip: str, port: int) -> str:
+    """Build the canonical component ID for a multicast receiver transport."""
+    return f"udp/multicast/{group_ip}/{port}"
+
+
+def _host_port_or_default(
+    peer_info: object,
+    default_host: str,
+    default_port: int,
+) -> tuple[object, object]:
+    """Return ``peer_info`` host/port when present, otherwise the supplied defaults."""
+    if isinstance(peer_info, tuple) and len(peer_info) >= 2:
+        return peer_info[0], peer_info[1]
+    return default_host, default_port

--- a/src/aionetx/implementations/asyncio_impl/lifecycle_internal.py
+++ b/src/aionetx/implementations/asyncio_impl/lifecycle_internal.py
@@ -1,0 +1,157 @@
+"""Shared helpers for managed component lifecycle transition publication."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import Enum
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+
+
+class LifecycleRole(str, Enum):
+    """Managed component role used to resolve transition policy."""
+
+    TCP_CLIENT = "tcp_client"
+    TCP_SERVER = "tcp_server"
+    UDP_RECEIVER = "udp_receiver"
+    MULTICAST_RECEIVER = "multicast_receiver"
+
+
+_BASE_TRANSITIONS = {
+    ComponentLifecycleState.STOPPED: {ComponentLifecycleState.STARTING},
+    ComponentLifecycleState.STARTING: {
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    },
+    ComponentLifecycleState.RUNNING: {ComponentLifecycleState.STOPPING},
+    ComponentLifecycleState.STOPPING: {ComponentLifecycleState.STOPPED},
+}
+
+_ROLES_USING_BASE_POLICY = frozenset(LifecycleRole)
+
+
+def assert_legal_lifecycle_transition(
+    *,
+    component_name: str,
+    role: LifecycleRole,
+    previous: ComponentLifecycleState,
+    target: ComponentLifecycleState,
+) -> None:
+    """Validate lifecycle transition against the policy for ``role``."""
+    if previous == target:
+        return
+    if role not in _ROLES_USING_BASE_POLICY:
+        raise RuntimeError(f"Unsupported lifecycle role for {component_name}: {role!r}.")
+    allowed = _BASE_TRANSITIONS.get(previous, set())
+    if target not in allowed:
+        raise RuntimeError(
+            f"Illegal lifecycle transition for {component_name} ({role.value}): "
+            f"{previous.value} -> {target.value}."
+        )
+
+
+class LifecycleTransitionPublisher:
+    """
+    Internal helper for managed lifecycle transition publication.
+
+    This centralizes shared ``apply transition -> emit lifecycle event`` plumbing
+    while keeping transition timing at call sites explicit and role-specific.
+    """
+
+    def __init__(
+        self,
+        *,
+        component_name: str,
+        resource_id: str,
+        role: LifecycleRole,
+        get_state: Callable[[], ComponentLifecycleState],
+        set_state: Callable[[ComponentLifecycleState], None],
+        on_state_applied: Callable[[ComponentLifecycleState], None] | None = None,
+    ) -> None:
+        self._component_name = component_name
+        self._resource_id = resource_id
+        self._role = role
+        self._get_state = get_state
+        self._set_state = set_state
+        self._on_state_applied = on_state_applied
+
+    def apply(self, target: ComponentLifecycleState) -> ComponentLifecycleChangedEvent | None:
+        """
+        Apply a validated lifecycle transition and build publishable event.
+
+        Arguments:
+            target (ComponentLifecycleState): Requested lifecycle state.
+
+        Returns:
+            ComponentLifecycleChangedEvent | None: Transition event ready for
+            emission, or ``None`` when state is unchanged.
+
+        Raises:
+            RuntimeError: If the role-specific transition is illegal.
+        """
+        previous = self._get_state()
+        if previous == target:
+            return None
+        assert_legal_lifecycle_transition(
+            component_name=self._component_name,
+            role=self._role,
+            previous=previous,
+            target=target,
+        )
+        self._set_state(target)
+        if self._on_state_applied is not None:
+            self._on_state_applied(target)
+        return ComponentLifecycleChangedEvent(
+            resource_id=self._resource_id,
+            previous=previous,
+            current=target,
+        )
+
+
+async def emit_lifecycle_event(
+    *,
+    dispatcher: AsyncioEventDispatcher,
+    event: ComponentLifecycleChangedEvent | None,
+) -> None:
+    """Emit lifecycle transition event when one is available."""
+    if event is None:
+        return
+    await dispatcher.emit(event)
+
+
+def apply_stopping_transition_if_active(
+    *,
+    get_state: Callable[[], ComponentLifecycleState],
+    apply_transition: Callable[[ComponentLifecycleState], ComponentLifecycleChangedEvent | None],
+) -> ComponentLifecycleChangedEvent | None:
+    """Apply ``STOPPING`` when component is currently active."""
+    state = get_state()
+    if state not in (ComponentLifecycleState.RUNNING, ComponentLifecycleState.STARTING):
+        return None
+    event = apply_transition(ComponentLifecycleState.STOPPING)
+    if event is None:
+        raise RuntimeError(
+            "Lifecycle transition helper expected STOPPING transition event, "
+            f"but got None while current state was {state.value}."
+        )
+    return event
+
+
+def apply_stopped_transition_if_stopping(
+    *,
+    get_state: Callable[[], ComponentLifecycleState],
+    apply_transition: Callable[[ComponentLifecycleState], ComponentLifecycleChangedEvent | None],
+) -> ComponentLifecycleChangedEvent | None:
+    """Apply ``STOPPED`` only from ``STOPPING``."""
+    if get_state() != ComponentLifecycleState.STOPPING:
+        return None
+    event = apply_transition(ComponentLifecycleState.STOPPED)
+    if event is None:
+        raise RuntimeError(
+            "Lifecycle transition helper expected STOPPED transition event, "
+            "but got None while current state was stopping."
+        )
+    return event

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -1,0 +1,212 @@
+"""
+Shared runtime helpers for asyncio implementations.
+
+This module groups small utilities that are reused across transports, such as
+warning rate limiting, reconnect backoff, event-handler validation, and
+single-owner-loop enforcement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import random
+import socket
+import sys
+import time
+
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.errors import HeartbeatConfigurationError
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.api.reconnect_jitter import ReconnectJitter
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+
+_HEARTBEAT_PROVIDER_REQUIRED_MESSAGE = (
+    "Heartbeat is enabled but no heartbeat_provider was supplied."
+)
+
+
+class WarningRateLimiter:
+    """
+    Simple in-memory warning limiter keyed by event name.
+
+    Caps memory use via eviction: once the number of tracked keys reaches
+    ``max_keys``, the oldest entry (by insertion/last-update order) is removed
+    *before* the new key is inserted, so the dict never exceeds ``max_keys``
+    entries.  Suitable for long-running servers with many transient connection
+    IDs used as keys.
+
+    Not thread-safe; safe for single-threaded asyncio use (no ``await`` inside
+    :meth:`should_log`, so coroutines cannot interleave within it).
+    """
+
+    def __init__(self, interval_seconds: float, max_keys: int = 1000) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be > 0.")
+        if max_keys < 1:
+            raise ValueError("max_keys must be >= 1.")
+        self._interval_seconds = interval_seconds
+        self._max_keys = max_keys
+        self._last_logged_at: dict[str, float] = {}
+
+    def should_log(self, key: str) -> bool:
+        """
+        Return whether a warning for ``key`` should be emitted right now.
+
+        Args:
+            key: Logical warning bucket to rate-limit.
+
+        Returns:
+            ``True`` when enough time has elapsed since the last emission for
+            ``key``; otherwise ``False``.
+        """
+        now = time.monotonic()
+        previous = self._last_logged_at.get(key)
+        if previous is None or (now - previous) >= self._interval_seconds:
+            if key not in self._last_logged_at and len(self._last_logged_at) >= self._max_keys:
+                # Evict the least-recently-inserted-or-updated entry (Python 3.7+ dict order).
+                oldest_key = next(iter(self._last_logged_at))
+                del self._last_logged_at[oldest_key]
+            self._last_logged_at[key] = now
+            return True
+        return False
+
+
+class ReconnectBackoff:
+    """Stateful exponential backoff helper for reconnect attempts."""
+
+    def __init__(self, settings: TcpReconnectSettings) -> None:
+        settings.validate()
+        self._settings = settings
+        self._current_delay = settings.initial_delay_seconds
+
+    def reset(self) -> None:
+        """Reset delay progression to the configured initial value."""
+        self._current_delay = self._settings.initial_delay_seconds
+
+    def next_delay(self) -> float:
+        """Return current delay and advance to next backoff step."""
+        delay = self._apply_jitter(self._current_delay)
+        self._current_delay = min(
+            self._current_delay * self._settings.backoff_factor,
+            self._settings.max_delay_seconds,
+        )
+        return delay
+
+    def _apply_jitter(self, delay: float) -> float:
+        jitter = self._settings.jitter
+        if jitter == ReconnectJitter.NONE:
+            return delay
+        if jitter == ReconnectJitter.FULL:
+            return random.uniform(0.0, delay)
+        if jitter == ReconnectJitter.EQUAL:
+            return (delay / 2.0) + random.uniform(0.0, delay / 2.0)
+        return delay
+
+
+def assert_running_on_owner_loop(
+    *,
+    class_name: str,
+    owner_loop: asyncio.AbstractEventLoop | None,
+) -> asyncio.AbstractEventLoop:
+    """
+    Raise ``RuntimeError`` if the caller is not on the component's owner loop.
+
+    This guard enforces the asyncio single-event-loop contract for all
+    managed transport methods.  A component's owner loop is the event loop
+    that called ``start()`` first.  Calling any public method from a
+    different loop (or from a thread with no running loop) is a programming
+    error and raises immediately with a descriptive message.
+
+    Returns the current running loop so callers can pin it on first use:
+    ``self._owner_loop = assert_running_on_owner_loop(...)``.  Storing the
+    loop via the return value (rather than a separate ``get_running_loop()``
+    call in the transport module) ensures the identity is always drawn from
+    this module's ``asyncio`` import — not from a potentially test-patched
+    module-level import in the transport.
+
+    Performance: ``asyncio.get_running_loop()`` is a C-level O(1) call; the
+    guard adds no measurable overhead on the hot path.
+    """
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        raise RuntimeError(
+            f"{class_name} methods must be called from within the asyncio "
+            "event loop. No running loop detected in the calling thread."
+        ) from None
+    if owner_loop is not None and current_loop is not owner_loop:
+        raise RuntimeError(
+            f"{class_name} was started on a different event loop than the "
+            "calling thread's current loop. Cross-loop use is not supported. "
+            "Use loop.call_soon_threadsafe() to schedule from another thread."
+        )
+    return current_loop
+
+
+def validate_async_event_handler(event_handler: NetworkEventHandlerProtocol) -> None:
+    """
+    Validate the runtime contract for ``NetworkEventHandlerProtocol``.
+
+    We enforce this at construction boundaries so factory and direct concrete
+    constructors fail the same way for invalid handlers.
+    """
+    on_event = getattr(event_handler, "on_event", None)
+    if on_event is None or not callable(on_event):
+        raise TypeError("event_handler must define a callable async on_event(event) method.")
+    on_event_call = getattr(on_event, "__call__", None)
+    if not (inspect.iscoroutinefunction(on_event) or inspect.iscoroutinefunction(on_event_call)):
+        raise TypeError("event_handler.on_event must be an async function.")
+
+
+def validate_heartbeat_provider(
+    *,
+    heartbeat_settings: TcpHeartbeatSettings,
+    heartbeat_provider: HeartbeatProviderProtocol | None,
+) -> None:
+    """
+    Validate that heartbeat configuration and provider presence agree.
+
+    Raises:
+        HeartbeatConfigurationError: If heartbeat is enabled but no provider
+            was supplied.
+    """
+    if heartbeat_settings.enabled and heartbeat_provider is None:
+        raise HeartbeatConfigurationError(_HEARTBEAT_PROVIDER_REQUIRED_MESSAGE)
+    if heartbeat_provider is None:
+        return
+
+    create_heartbeat = getattr(heartbeat_provider, "create_heartbeat", None)
+    if create_heartbeat is None or not callable(create_heartbeat):
+        raise TypeError(
+            "heartbeat_provider must define a callable async create_heartbeat(request) method."
+        )
+    create_heartbeat_call = getattr(create_heartbeat, "__call__", None)
+    if not (
+        inspect.iscoroutinefunction(create_heartbeat)
+        or inspect.iscoroutinefunction(create_heartbeat_call)
+    ):
+        raise TypeError("heartbeat_provider.create_heartbeat must be an async function.")
+
+
+def configure_listener_bind_socket(
+    sock: socket.socket,
+    *,
+    allow_address_reuse: bool,
+) -> None:
+    """
+    Configure bind semantics for server/receiver sockets with safer Windows defaults.
+
+    On Windows we prefer ``SO_EXCLUSIVEADDRUSE`` for ordinary listeners so a
+    second process cannot bind the same local address. Multicast receivers can
+    opt into ``allow_address_reuse=True`` because group membership requires the
+    traditional reuse semantics there.
+    """
+    if sys.platform == "win32" and not allow_address_reuse:
+        exclusive_addr_use = getattr(socket, "SO_EXCLUSIVEADDRUSE", None)
+        if exclusive_addr_use is not None:
+            sock.setsockopt(socket.SOL_SOCKET, exclusive_addr_use, 1)
+            return
+    if allow_address_reuse:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
+++ b/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
@@ -1,0 +1,334 @@
+"""
+Connect/reconnect supervision for the managed asyncio TCP client.
+
+This module keeps retry policy, failure publication, and terminal lifecycle
+cleanup in one place so the transport-facing client object can stay focused on
+public API state and resource ownership.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+from aionetx.implementations.asyncio_impl.lifecycle_internal import (
+    apply_stopped_transition_if_stopping,
+    apply_stopping_transition_if_active,
+)
+
+if TYPE_CHECKING:
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+
+@dataclass(frozen=True)
+class _ReconnectPlan:
+    """
+    Internal reconnect decision produced after a disconnect or failure.
+
+    Attributes:
+        should_reconnect: Whether supervision should attempt another connect cycle.
+        delay_seconds: Delay before the next attempt when reconnect is enabled.
+    """
+
+    should_reconnect: bool
+    delay_seconds: float | None
+
+    def __post_init__(self) -> None:
+        if self.should_reconnect and self.delay_seconds is None:
+            raise ValueError("Reconnect plan delay must be set when reconnect is scheduled.")
+
+    @classmethod
+    def disabled(cls) -> "_ReconnectPlan":
+        """Return a plan that terminates supervision without another retry."""
+        return cls(should_reconnect=False, delay_seconds=None)
+
+    @classmethod
+    def scheduled(cls, delay_seconds: float) -> "_ReconnectPlan":
+        """
+        Return a plan that schedules another connect attempt after ``delay_seconds``.
+
+        Args:
+            delay_seconds: Backoff delay before the next attempt.
+
+        Returns:
+            _ReconnectPlan: Retry plan carrying the requested delay.
+        """
+        return cls(should_reconnect=True, delay_seconds=delay_seconds)
+
+
+@dataclass(frozen=True)
+class _FailureOutcome:
+    """Failure-handling decision pairing error policy with reconnect behavior."""
+
+    policy: ErrorPolicy
+    reconnect: _ReconnectPlan
+
+
+class TcpClientConnectionSupervisor:
+    """
+    Coordinates connect/reconnect supervision in explicit, ordered phases.
+
+    Flow overview:
+        connect attempt
+            |
+            +-- success ------------------> wait for connection termination
+            |                                  |
+            |                                  +-- running + reconnect --> sleep -> next attempt
+            |                                  |
+            |                                  +-- stop / reconnect off --> finalize
+            |
+            +-- failure ------------------> publish failure events
+                                               |
+                                               +-- fail-fast / stopped ----> finalize
+                                               |
+                                               +-- retry enabled -----------> sleep -> next attempt
+    """
+
+    def __init__(self, client: "AsyncioTcpClient") -> None:
+        self._client = client
+
+    async def run(self) -> None:
+        """Run connect/reconnect supervision until stop or terminal failure."""
+        client = self._client
+        try:
+            while client._running:
+                try:
+                    should_continue = await self._run_connect_cycle()
+                    if not should_continue:
+                        break
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    should_continue = await self._handle_connect_cycle_failure(error)
+                    if not should_continue:
+                        break
+        finally:
+            await self._finalize_supervision()
+
+    async def _run_connect_cycle(self) -> bool:
+        """Run one connect-to-disconnect cycle and decide whether supervision continues."""
+        await self._start_connect_attempt()
+        await self._await_connection_termination()
+        return await self._schedule_reconnect_after_disconnect()
+
+    async def _handle_connect_cycle_failure(self, error: Exception) -> bool:
+        """
+        Publish failure state, tear down resources, and decide whether to retry.
+
+        Args:
+            error: Exception raised while creating or supervising a connection.
+
+        Returns:
+            bool: ``True`` when supervision should keep retrying.
+        """
+        outcome = self._determine_failure_outcome(error)
+        await self._publish_connect_failure(
+            error=error,
+            policy=outcome.policy,
+            next_delay_seconds=outcome.reconnect.delay_seconds,
+        )
+        await self._teardown_after_failure()
+        if self._should_stop_after_failure(policy=outcome.policy):
+            return False
+        return await self._sleep_until_next_reconnect(reconnect=outcome.reconnect)
+
+    def _determine_failure_outcome(self, error: Exception) -> _FailureOutcome:
+        """Resolve error policy and reconnect timing for one failed connect cycle."""
+        policy = self._capture_failure_state(error)
+        return _FailureOutcome(policy=policy, reconnect=self._plan_reconnect())
+
+    async def _start_connect_attempt(self) -> None:
+        """Advance attempt counters, publish start notification, and open one connection."""
+        client = self._client
+        client._last_connect_error = None
+        client._attempt_counter += 1
+        client._notify_status_changed()
+        await client._event_dispatcher.emit(
+            ReconnectAttemptStartedEvent(
+                resource_id=client._component_id,
+                attempt=client._attempt_counter,
+            )
+        )
+        await client._connect_once()
+        client._backoff.reset()
+        client._logger.debug("TCP client connected.")
+
+    async def _await_connection_termination(self) -> None:
+        """Wait until the current connection disappears or reaches ``CLOSED``."""
+        client = self._client
+        while client._running:
+            await client._connection_closed_event.wait()
+            client._connection_closed_event.clear()
+            if client._connection is None or client._connection.state == ConnectionState.CLOSED:
+                return
+
+    async def _schedule_reconnect_after_disconnect(self) -> bool:
+        """Plan and wait for the next reconnect after a clean disconnect."""
+        return await self._sleep_until_next_reconnect(reconnect=self._plan_reconnect())
+
+    def _capture_failure_state(self, error: Exception) -> ErrorPolicy:
+        """Persist failure state on the client and return the active error policy."""
+        client = self._client
+        client._logger.warning("TCP client supervision error: %s", error)
+        client._last_connect_error = error
+        client._notify_status_changed()
+        return client._resolve_error_policy()
+
+    def _plan_reconnect(self) -> _ReconnectPlan:
+        """Return the reconnect decision implied by client state and settings."""
+        client = self._client
+        if not client._running or not client._settings.reconnect.enabled:
+            return _ReconnectPlan.disabled()
+        return _ReconnectPlan.scheduled(delay_seconds=client._backoff.next_delay())
+
+    async def _emit_failure_events(
+        self,
+        error: Exception,
+        policy: ErrorPolicy,
+        next_delay_seconds: float | None,
+    ) -> None:
+        """Emit error and reconnect-failure events for one failed attempt."""
+        client = self._client
+        if policy != ErrorPolicy.IGNORE:
+            await client._event_dispatcher.emit(
+                NetworkErrorEvent(resource_id=client._component_id, error=error)
+            )
+        await client._event_dispatcher.emit(
+            ReconnectAttemptFailedEvent(
+                resource_id=client._component_id,
+                attempt=client._attempt_counter,
+                error=error,
+                next_delay_seconds=next_delay_seconds,
+            )
+        )
+
+    async def _publish_connect_failure(
+        self,
+        *,
+        error: Exception,
+        policy: ErrorPolicy,
+        next_delay_seconds: float | None,
+    ) -> None:
+        """Publish the externally visible events for a failed connect cycle."""
+        await self._emit_failure_events(
+            error=error,
+            policy=policy,
+            next_delay_seconds=next_delay_seconds,
+        )
+
+    async def _teardown_after_failure(self) -> None:
+        """Stop heartbeats and close any partially active connection after failure."""
+        client = self._client
+        await client._stop_heartbeat_sender()
+        await client._close_current_connection()
+
+    def _should_stop_after_failure(self, *, policy: ErrorPolicy) -> bool:
+        """Return whether supervision should stop instead of sleeping for a retry."""
+        client = self._client
+        return (
+            policy == ErrorPolicy.FAIL_FAST
+            or not client._running
+            or not client._settings.reconnect.enabled
+        )
+
+    async def _sleep_until_next_reconnect(self, *, reconnect: _ReconnectPlan) -> bool:
+        """
+        Wait for the next reconnect delay unless stop state changes first.
+
+        Returns:
+            bool: ``True`` when another connect cycle should start immediately after the wait.
+        """
+        if not reconnect.should_reconnect:
+            return False
+        client = self._client
+        if not client._running or not client._settings.reconnect.enabled:
+            return False
+        delay_seconds = reconnect.delay_seconds
+        if delay_seconds is None:
+            raise RuntimeError(
+                "Reconnect plan is marked as scheduled but does not provide delay_seconds."
+            )
+        await self._emit_reconnect_scheduled(next_delay_seconds=delay_seconds)
+        if not client._running or not client._settings.reconnect.enabled:
+            return False
+        client._logger.debug("TCP client reconnect scheduled in %.3f seconds.", delay_seconds)
+        return await self._wait_for_reconnect_delay_or_stop(delay_seconds=delay_seconds)
+
+    async def _wait_for_reconnect_delay_or_stop(self, *, delay_seconds: float) -> bool:
+        """Sleep for the reconnect delay, but wake early if status changes or stop begins."""
+        client = self._client
+        observed_version = client._status_version
+        client._status_changed.clear()
+        if client._status_version != observed_version:
+            return client._running and client._settings.reconnect.enabled
+        try:
+            await asyncio.wait_for(client._status_changed.wait(), timeout=delay_seconds)
+        except asyncio.TimeoutError:
+            return client._running and client._settings.reconnect.enabled
+        return client._running and client._settings.reconnect.enabled
+
+    async def _emit_reconnect_scheduled(self, next_delay_seconds: float) -> None:
+        """Emit the next scheduled reconnect delay to observers."""
+        client = self._client
+        await client._event_dispatcher.emit(
+            ReconnectScheduledEvent(
+                resource_id=client._component_id,
+                attempt=client._attempt_counter + 1,
+                delay_seconds=next_delay_seconds,
+            )
+        )
+
+    async def _finalize_supervision(self) -> None:
+        """Leave the client in a fully stopped state after supervision exits."""
+        try:
+            await self._shutdown_active_resources()
+            await self._publish_terminal_lifecycle_transitions()
+        finally:
+            await self._stop_dispatcher()
+
+    async def _shutdown_active_resources(self) -> None:
+        """Stop heartbeat before connection close to preserve teardown order."""
+        client = self._client
+        await client._stop_heartbeat_sender()
+        await client._close_current_connection()
+
+    async def _publish_terminal_lifecycle_transitions(self) -> None:
+        """Emit any remaining STOPPING/STOPPED lifecycle events in order."""
+        transition_events = await self._collect_terminal_lifecycle_events()
+        for event in transition_events:
+            await self._client._emit_lifecycle_event(event)
+
+    async def _stop_dispatcher(self) -> None:
+        # Supervision can reach a terminal state on its own, for example after a
+        # non-retrying connect failure. The dispatcher is still stopped here so
+        # background delivery never outlives the final STOPPED transition.
+        await self._client._event_dispatcher.stop()
+
+    async def _collect_terminal_lifecycle_events(self) -> list[ComponentLifecycleChangedEvent]:
+        """Apply final lifecycle transitions under lock and return them for emission."""
+        client = self._client
+        transition_events: list[ComponentLifecycleChangedEvent] = []
+        async with client._state_lock:
+            stopping_event = apply_stopping_transition_if_active(
+                get_state=lambda: client._lifecycle_state,
+                apply_transition=client._apply_lifecycle_state,
+            )
+            if stopping_event is not None:
+                transition_events.append(stopping_event)
+            stopped_event = apply_stopped_transition_if_stopping(
+                get_state=lambda: client._lifecycle_state,
+                apply_transition=client._apply_lifecycle_state,
+            )
+            if stopped_event is not None:
+                transition_events.append(stopped_event)
+        return transition_events

--- a/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
+++ b/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
@@ -9,10 +9,12 @@ public API state and resource ownership.
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Protocol
 
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_lifecycle import ConnectionState
 from aionetx.api.error_policy import ErrorPolicy
 from aionetx.api.network_error_event import NetworkErrorEvent
@@ -21,13 +23,59 @@ from aionetx.api.reconnect_events import (
     ReconnectAttemptStartedEvent,
     ReconnectScheduledEvent,
 )
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.lifecycle_internal import (
     apply_stopped_transition_if_stopping,
     apply_stopping_transition_if_active,
 )
+from aionetx.implementations.asyncio_impl.runtime_utils import ReconnectBackoff
 
-if TYPE_CHECKING:
-    from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+class _TcpClientForSupervision(Protocol):
+    """Structural view of the private client hooks used by supervision."""
+
+    _attempt_counter: int
+    _backoff: ReconnectBackoff
+    _component_id: str
+    _connection: AsyncioTcpConnection | None
+    _event_dispatcher: AsyncioEventDispatcher
+    _last_connect_error: Exception | None
+    _lifecycle_state: ComponentLifecycleState
+    _logger: logging.LoggerAdapter[logging.Logger]
+    _running: bool
+    _settings: TcpClientSettings
+    _state_lock: asyncio.Lock
+    _status_changed: asyncio.Event
+    _status_version: int
+
+    @property
+    def _connection_closed_event(self) -> asyncio.Event:
+        raise NotImplementedError
+
+    def _apply_lifecycle_state(
+        self, target: ComponentLifecycleState
+    ) -> ComponentLifecycleChangedEvent | None:
+        raise NotImplementedError
+
+    async def _close_current_connection(self) -> None:
+        raise NotImplementedError
+
+    async def _connect_once(self) -> None:
+        raise NotImplementedError
+
+    async def _emit_lifecycle_event(self, event: ComponentLifecycleChangedEvent | None) -> None:
+        raise NotImplementedError
+
+    def _notify_status_changed(self) -> None:
+        raise NotImplementedError
+
+    def _resolve_error_policy(self) -> ErrorPolicy:
+        raise NotImplementedError
+
+    async def _stop_heartbeat_sender(self) -> None:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)
@@ -94,7 +142,7 @@ class TcpClientConnectionSupervisor:
                                                +-- retry enabled -----------> sleep -> next attempt
     """
 
-    def __init__(self, client: "AsyncioTcpClient") -> None:
+    def __init__(self, client: _TcpClientForSupervision) -> None:
         self._client = client
 
     async def run(self) -> None:

--- a/src/aionetx/testing/__init__.py
+++ b/src/aionetx/testing/__init__.py
@@ -1,0 +1,115 @@
+"""
+Testing helpers for capturing and waiting on emitted network events.
+
+This module exposes in-memory recording handlers plus a small async polling
+helper that tests and examples can reuse without reimplementing bookkeeping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Callable
+
+from aionetx.api._event_registry import NETWORK_EVENT_RECORDING_BUCKETS
+from aionetx.api.events import (
+    BytesReceivedEvent,
+    ComponentLifecycleChangedEvent,
+    ConnectionClosedEvent,
+    ConnectionOpenedEvent,
+    ConnectionRejectedEvent,
+    HandlerFailurePolicyStopEvent,
+    NetworkErrorEvent,
+    NetworkEvent,
+)
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+
+class RecordingEventHandler:
+    """In-memory event collector for tests and examples."""
+
+    def __init__(self) -> None:
+        self.events: list[NetworkEvent] = []
+        self.opened_events: list[ConnectionOpenedEvent] = []
+        self.rejected_events: list[ConnectionRejectedEvent] = []
+        self.closed_events: list[ConnectionClosedEvent] = []
+        self.received_events: list[BytesReceivedEvent] = []
+        self.error_events: list[NetworkErrorEvent] = []
+        self.lifecycle_events: list[ComponentLifecycleChangedEvent] = []
+        self.handler_failure_policy_stop_events: list[HandlerFailurePolicyStopEvent] = []
+        self.reconnect_attempt_started_events: list[ReconnectAttemptStartedEvent] = []
+        self.reconnect_attempt_failed_events: list[ReconnectAttemptFailedEvent] = []
+        self.reconnect_scheduled_events: list[ReconnectScheduledEvent] = []
+        self.received_by_connection: dict[str, list[bytes]] = defaultdict(list)
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        """
+        Record an emitted event into the aggregate and typed event buckets.
+
+        Args:
+            event: Event instance emitted by a component under test.
+        """
+        self.events.append(event)
+        for event_type, bucket_name in NETWORK_EVENT_RECORDING_BUCKETS.items():
+            if isinstance(event, event_type):
+                bucket = getattr(self, bucket_name)
+                bucket.append(event)
+                break
+
+        if isinstance(event, BytesReceivedEvent):
+            self.received_by_connection[event.resource_id].append(event.data)
+
+
+class AwaitableRecordingEventHandler(RecordingEventHandler):
+    """Recording handler with event milestones for deterministic async tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.connection_opened = asyncio.Event()
+        self.bytes_received = asyncio.Event()
+        self.error_observed = asyncio.Event()
+        self.connection_closed = asyncio.Event()
+        self.lifecycle_changed = asyncio.Event()
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        """
+        Record an event and update milestone flags for common event categories.
+
+        Args:
+            event: Event instance emitted by a component under test.
+        """
+        await super().on_event(event)
+        if isinstance(event, ConnectionOpenedEvent):
+            self.connection_opened.set()
+        elif isinstance(event, BytesReceivedEvent):
+            self.bytes_received.set()
+        elif isinstance(event, NetworkErrorEvent):
+            self.error_observed.set()
+        elif isinstance(event, ConnectionClosedEvent):
+            self.connection_closed.set()
+        elif isinstance(event, ComponentLifecycleChangedEvent):
+            self.lifecycle_changed.set()
+
+
+async def wait_for_condition(
+    condition: Callable[[], bool],
+    timeout_seconds: float = 2.0,
+    interval_seconds: float = 0.01,
+) -> None:
+    """Poll ``condition`` until it is true or timeout is exceeded."""
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while not condition():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError("Timed out waiting for test condition.")
+        await asyncio.sleep(interval_seconds)
+
+
+__all__ = (
+    "AwaitableRecordingEventHandler",
+    "RecordingEventHandler",
+    "wait_for_condition",
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from inspect import iscoroutinefunction
+import socket
+
+import pytest
+
+from aionetx.testing import AwaitableRecordingEventHandler, RecordingEventHandler
+
+
+@pytest.fixture
+def recording_event_handler() -> RecordingEventHandler:
+    return RecordingEventHandler()
+
+
+@pytest.fixture
+def awaitable_recording_event_handler() -> AwaitableRecordingEventHandler:
+    return AwaitableRecordingEventHandler()
+
+
+@pytest.fixture
+def unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _is_async_test(item: pytest.Item) -> bool:
+    test_function = getattr(item, "obj", None)
+    return item.get_closest_marker("asyncio") is not None or (
+        test_function is not None and iscoroutinefunction(test_function)
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if config.pluginmanager.has_plugin("asyncio"):
+        return
+
+    async_tests = [item for item in items if _is_async_test(item)]
+    if not async_tests:
+        return
+
+    raise pytest.UsageError(
+        "Cannot run a complete test suite: pytest-asyncio is not installed, "
+        f"and {len(async_tests)} async tests were collected. "
+        "Pytest stops here to avoid a false green run with async coverage missing. "
+        "Fix: install dev dependencies (`pip install -e .[dev]`) and re-run `pytest`."
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,3 @@
+from aionetx.testing import wait_for_condition
+
+__all__ = ["wait_for_condition"]

--- a/tests/integration/test_client_reconnect.py
+++ b/tests/integration/test_client_reconnect.py
@@ -1,0 +1,735 @@
+"""
+Integration tests for TCP client reconnect behavior.
+
+These scenarios verify the user-visible reconnect contract: retries begin only
+after start(), waiters unblock deterministically, stop() interrupts in-flight
+connect or heartbeat work promptly, and error-policy choices change emitted
+events without corrupting lifecycle state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+
+import pytest
+
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from tests.helpers import wait_for_condition
+
+pytestmark = pytest.mark.integration_confidence
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _HeartbeatProvider(HeartbeatProviderProtocol):
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload=f"HB:{request.connection_id}".encode())
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_smoke
+@pytest.mark.integration_semantic
+async def test_tcp_client_reconnects_after_server_appears(recording_event_handler) -> None:
+    server: asyncio.AbstractServer | None = None
+    port = get_unused_tcp_port()
+
+    async def start_server() -> asyncio.AbstractServer:
+        async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            try:
+                while await reader.read(4096):
+                    continue
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+        return await asyncio.start_server(handle, "127.0.0.1", port)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.1,
+                backoff_factor=2.0,
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+    delayed_server_task: asyncio.Task[None] | None = None
+    try:
+        await client.start()
+
+        async def delayed_server_start() -> None:
+            nonlocal server
+            await wait_for_condition(
+                lambda: bool(recording_event_handler.reconnect_attempt_started_events),
+                timeout_seconds=1.5,
+            )
+            server = await start_server()
+
+        delayed_server_task = asyncio.create_task(delayed_server_start())
+        await wait_for_condition(
+            lambda: client.connection is not None and client.connection.is_connected,
+            timeout_seconds=3.0,
+        )
+        connection = client.connection
+        assert connection is not None
+        assert connection.is_connected
+        # The wait_for_condition above confirmed at least one attempt started and
+        # at least one was scheduled; verify the lists are non-empty with an
+        # explicit count lower-bound instead of bare truthiness.
+        assert len(recording_event_handler.reconnect_attempt_started_events) >= 1
+        assert len(recording_event_handler.reconnect_scheduled_events) >= 1
+        assert all(
+            event.resource_id == f"tcp/client/127.0.0.1/{port}"
+            for event in recording_event_handler.reconnect_attempt_started_events
+        )
+        assert all(
+            event.resource_id == f"tcp/client/127.0.0.1/{port}"
+            for event in recording_event_handler.reconnect_scheduled_events
+        )
+        event_types = [type(event).__name__ for event in recording_event_handler.events]
+        assert event_types.index("ReconnectAttemptStartedEvent") < event_types.index(
+            "ReconnectAttemptFailedEvent"
+        )
+        assert event_types.index("ReconnectAttemptFailedEvent") < event_types.index(
+            "ReconnectScheduledEvent"
+        )
+        assert event_types.index("ReconnectScheduledEvent") < event_types.index(
+            "ConnectionOpenedEvent"
+        )
+        assert recording_event_handler.reconnect_attempt_started_events[0].attempt == 1
+        assert recording_event_handler.reconnect_scheduled_events[0].attempt == 2
+    finally:
+        if delayed_server_task is not None:
+            delayed_server_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await delayed_server_task
+        await client.stop()
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_smoke
+@pytest.mark.behavior_critical
+async def test_client_stop_during_reconnect_sleep_is_prompt(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=5.0,
+                max_delay_seconds=5.0,
+                backoff_factor=1.0,
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+
+    await wait_for_condition(
+        lambda: len(recording_event_handler.reconnect_scheduled_events) >= 1,
+        timeout_seconds=1.5,
+    )
+    scheduled_event = recording_event_handler.reconnect_scheduled_events[0]
+    assert scheduled_event.delay_seconds == pytest.approx(5.0)
+    assert scheduled_event.attempt == 2
+
+    await asyncio.wait_for(client.stop(), timeout=1.0)
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+    assert len(recording_event_handler.reconnect_attempt_started_events) == 1
+    client_component_id = f"tcp/client/127.0.0.1/{port}"
+    lifecycle_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == client_component_id
+    ]
+    lifecycle_states = [event.current for event in lifecycle_events]
+    assert lifecycle_states.count(ComponentLifecycleState.STOPPING) == 1
+    assert lifecycle_states.count(ComponentLifecycleState.STOPPED) == 1
+    assert lifecycle_states.index(ComponentLifecycleState.STOPPING) < lifecycle_states.index(
+        ComponentLifecycleState.STOPPED
+    )
+    event_types = [type(event).__name__ for event in recording_event_handler.events]
+    assert event_types.count("ReconnectScheduledEvent") == 1
+    reconnect_index = event_types.index("ReconnectScheduledEvent")
+    stopping_index = next(
+        index
+        for index, event in enumerate(recording_event_handler.events)
+        if (
+            type(event).__name__ == "ComponentLifecycleChangedEvent"
+            and getattr(event, "current", None) == ComponentLifecycleState.STOPPING
+        )
+    )
+    assert reconnect_index < stopping_index
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.behavior_critical
+async def test_client_stop_during_inflight_heartbeat_send_is_prompt(
+    recording_event_handler,
+) -> None:
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    port = get_unused_tcp_port()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", port)
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+            ),
+            event_handler=recording_event_handler,
+            heartbeat_provider=_HeartbeatProvider(),
+        )
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=2.0)
+        original_send = connection.send
+
+        async def blocked_send(payload: bytes | bytearray | memoryview) -> None:
+            if bytes(payload).startswith(b"HB:"):
+                send_started.set()
+                await release_send.wait()
+            await original_send(payload)
+
+        connection.send = blocked_send  # type: ignore[method-assign]
+        await asyncio.wait_for(send_started.wait(), timeout=1.0)
+        await asyncio.wait_for(client.stop(), timeout=1.0)
+        release_send.set()
+
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert client.connection is None
+        opened_events = [
+            event
+            for event in recording_event_handler.events
+            if isinstance(event, ConnectionOpenedEvent)
+        ]
+        assert len(opened_events) == 1
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_wait_until_connected_rejects_non_positive_poll_interval(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(host="127.0.0.1", port=port),
+        event_handler=recording_event_handler,
+    )
+
+    with pytest.raises(ValueError, match="poll_interval_seconds"):
+        await client.wait_until_connected(poll_interval_seconds=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_wait_until_connected_fails_when_server_never_available(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await client.start()
+    try:
+        with pytest.raises((asyncio.TimeoutError, ConnectionError)):
+            await client.wait_until_connected(
+                timeout_seconds=0.15,
+                poll_interval_seconds=0.02,
+            )
+    finally:
+        await client.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_wait_until_connected_does_not_fail_immediately_before_start(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while await reader.read(4096):
+                continue
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", unused_tcp_port)
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    try:
+        waiter_task = asyncio.create_task(
+            client.wait_until_connected(timeout_seconds=2.0, poll_interval_seconds=0.02)
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(waiter_task), timeout=0.05)
+        assert waiter_task.done() is False
+        await client.start()
+        connection = await waiter_task
+        assert connection.is_connected
+    finally:
+        await client.stop()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_wait_until_connected_waiters_unblock_when_client_stops(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.1
+            ),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+
+    waiters = [
+        asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0)) for _ in range(4)
+    ]
+    await wait_for_condition(
+        lambda: all(waiter.done() is False for waiter in waiters),
+        timeout_seconds=0.5,
+    )
+    await client.stop()
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert all(isinstance(result, ConnectionError) for result in results)
+    assert all(waiter.done() for waiter in waiters)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.behavior_critical
+async def test_client_stop_while_connect_attempt_is_pending(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def slow_opener(
+        *, host: str, port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        assert host == "127.0.0.1"
+        assert port == unused_tcp_port
+        connect_started.set()
+        await release_connect.wait()
+        raise OSError("connect-cancelled-for-test")
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.1, max_delay_seconds=0.1
+            ),
+        ),
+        event_handler=recording_event_handler,
+        connection_opener=slow_opener,
+    )
+    await client.start()
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+
+    stop_task = asyncio.create_task(client.stop())
+    await asyncio.wait_for(stop_task, timeout=1.0)
+    release_connect.set()
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client._supervisor_task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_restart_clears_cached_connect_error(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            # Must be < 0.5s so the connect fails and the supervisor transitions
+            # to STOPPED before wait_until_connected(timeout_seconds=0.5) fires.
+            connect_timeout_seconds=0.3,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    # First run with no server: should fail and cache a connect error.
+    await client.start()
+    try:
+        with pytest.raises(ConnectionError):
+            await client.wait_until_connected(timeout_seconds=0.5, poll_interval_seconds=0.02)
+    finally:
+        await client.stop()
+
+    # Second run with server available must not raise stale first-run error.
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while await reader.read(4096):
+                continue
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", port)
+    try:
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=2.0)
+        assert connection.is_connected
+    finally:
+        await client.stop()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_fail_fast_policy_stops_supervision(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=True, initial_delay_seconds=0.05),
+            error_policy=ErrorPolicy.FAIL_FAST,
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await client.start()
+    # Wait for both STOPPED state and event delivery (BACKGROUND dispatcher may
+    # queue events while the event loop is busy with other tasks).
+    await wait_for_condition(
+        lambda: (
+            client.lifecycle_state == ComponentLifecycleState.STOPPED
+            and bool(recording_event_handler.reconnect_attempt_failed_events)
+        ),
+        timeout_seconds=1.0,
+    )
+    # FAIL_FAST policy: exactly 1 attempt is made, then the client stops.
+    assert len(recording_event_handler.reconnect_attempt_failed_events) == 1
+    assert recording_event_handler.reconnect_scheduled_events == []
+    assert recording_event_handler.reconnect_attempt_failed_events[
+        0
+    ].next_delay_seconds == pytest.approx(0.05)
+
+    with pytest.raises(ConnectionError):
+        await client.wait_until_connected(timeout_seconds=0.2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_ignore_policy_suppresses_error_events(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.1,
+                backoff_factor=1.0,
+            ),
+            error_policy=ErrorPolicy.IGNORE,
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+
+    await wait_for_condition(
+        lambda: bool(recording_event_handler.reconnect_attempt_failed_events),
+        timeout_seconds=1.5,
+    )
+    assert recording_event_handler.error_events == []
+    assert len(recording_event_handler.reconnect_attempt_failed_events) >= 1
+    assert client.lifecycle_state in (
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+    )
+
+    await client.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_default_retry_policy_emits_error_then_recovers(
+    recording_event_handler,
+) -> None:
+    server: asyncio.AbstractServer | None = None
+    port = get_unused_tcp_port()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while await reader.read(4096):
+                continue
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.1,
+                backoff_factor=1.0,
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    try:
+        await client.start()
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.error_events), timeout_seconds=1.5
+        )
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.reconnect_attempt_failed_events),
+            timeout_seconds=1.5,
+        )
+
+        server = await asyncio.start_server(handle, "127.0.0.1", port)
+        await wait_for_condition(
+            lambda: client.connection is not None and client.connection.is_connected,
+            timeout_seconds=3.0,
+        )
+
+        assert len(recording_event_handler.error_events) >= 1
+        assert len(recording_event_handler.reconnect_scheduled_events) >= 1
+        assert client.connection is not None
+        assert client.connection.is_connected
+    finally:
+        await client.stop()
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_reconnect_event_sequence_contains_expected_order(
+    awaitable_recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    server: asyncio.AbstractServer | None = None
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.1
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await client.start()
+    await wait_for_condition(
+        lambda: bool(awaitable_recording_event_handler.reconnect_scheduled_events),
+        timeout_seconds=1.5,
+    )
+    server = await asyncio.start_server(lambda _r, _w: None, "127.0.0.1", unused_tcp_port)
+    try:
+        await asyncio.wait_for(
+            awaitable_recording_event_handler.connection_opened.wait(), timeout=2.0
+        )
+        event_types = [type(event).__name__ for event in awaitable_recording_event_handler.events]
+        started_index = event_types.index("ReconnectAttemptStartedEvent")
+        failed_index = event_types.index("ReconnectAttemptFailedEvent")
+        scheduled_index = event_types.index("ReconnectScheduledEvent")
+        opened_index = event_types.index("ConnectionOpenedEvent")
+        assert started_index < failed_index < scheduled_index < opened_index
+    finally:
+        await client.stop()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_cancelling_connect_waiter_does_not_break_subsequent_waiters(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.1
+            ),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    try:
+        cancelled_waiter = asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0))
+        await wait_for_condition(lambda: cancelled_waiter.done() is False, timeout_seconds=0.5)
+        cancelled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        surviving_waiter = asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0))
+        await wait_for_condition(lambda: surviving_waiter.done() is False, timeout_seconds=0.5)
+        await client.stop()
+        result = await asyncio.gather(surviving_waiter, return_exceptions=True)
+        assert len(result) == 1
+        assert isinstance(result[0], ConnectionError)
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    finally:
+        await client.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.behavior_critical
+async def test_supervisor_cancellation_during_connect_attempt_finalizes_without_leaking_tasks(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def slow_opener(
+        *, host: str, port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        assert host == "127.0.0.1"
+        assert port == unused_tcp_port
+        connect_started.set()
+        await release_connect.wait()
+        raise OSError("connect-cancelled-for-test")
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.1, max_delay_seconds=0.1
+            ),
+        ),
+        event_handler=recording_event_handler,
+        connection_opener=slow_opener,
+    )
+    await client.start()
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+
+    supervisor = client._supervisor_task  # type: ignore[attr-defined]
+    assert supervisor is not None
+    supervisor.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await supervisor
+
+    release_connect.set()
+    await asyncio.wait_for(client.stop(), timeout=1.0)
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client._supervisor_task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_reconnect_client_repeated_start_stop_cycles_remain_operationally_stable(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.05,
+                max_delay_seconds=0.05,
+                backoff_factor=1.0,
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    reconnect_counts: list[int] = []
+    for _ in range(3):
+        await client.start()
+        await wait_for_condition(
+            lambda: (
+                len(recording_event_handler.reconnect_scheduled_events)
+                >= (len(reconnect_counts) + 1)
+            ),
+            timeout_seconds=1.5,
+        )
+        reconnect_counts.append(len(recording_event_handler.reconnect_scheduled_events))
+        await asyncio.wait_for(client.stop(), timeout=1.0)
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert client.connection is None
+
+    assert reconnect_counts[0] < reconnect_counts[1] < reconnect_counts[2]
+    assert client.dispatcher_runtime_stats.emit_calls_total > 0

--- a/tests/integration/test_client_reconnect.py
+++ b/tests/integration/test_client_reconnect.py
@@ -123,7 +123,7 @@ async def test_tcp_client_reconnects_after_server_appears(recording_event_handle
         if delayed_server_task is not None:
             delayed_server_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await delayed_server_task
+                _ = await delayed_server_task
         await client.stop()
         if server is not None:
             server.close()
@@ -637,7 +637,7 @@ async def test_cancelling_connect_waiter_does_not_break_subsequent_waiters(
         await wait_for_condition(lambda: cancelled_waiter.done() is False, timeout_seconds=0.5)
         cancelled_waiter.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await cancelled_waiter
+            _ = await cancelled_waiter
 
         surviving_waiter = asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0))
         await wait_for_condition(lambda: surviving_waiter.done() is False, timeout_seconds=0.5)
@@ -687,7 +687,7 @@ async def test_supervisor_cancellation_during_connect_attempt_finalizes_without_
     assert supervisor is not None
     supervisor.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await supervisor
+        _ = await supervisor
 
     release_connect.set()
     await asyncio.wait_for(client.stop(), timeout=1.0)

--- a/tests/integration/test_concurrency_scenarios.py
+++ b/tests/integration/test_concurrency_scenarios.py
@@ -1,0 +1,312 @@
+"""
+Integration tests for concurrency scenarios that are easy to miss.
+
+The module covers concurrent send() on one live connection, UDP receiver
+restartability, and end-to-end STOP_COMPONENT behavior with BACKGROUND
+dispatch. These are coordination-heavy paths where failures usually appear
+only under real scheduling pressure rather than in narrow unit tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings, UdpSenderSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+from tests.helpers import wait_for_condition
+
+
+def _unused_port(kind: socket.SocketKind = socket.SOCK_STREAM) -> int:
+    with socket.socket(socket.AF_INET, kind) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _NoopHandler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Concurrent send() from multiple coroutines
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_send_on_connected_connection() -> None:
+    """
+    Ten coroutines calling send() on the same connection concurrently must all succeed.
+
+    Rationale: asyncio writers are not thread-safe, but they are coroutine-safe
+    when drained properly.  This test exercises the send path under concurrent
+    scheduling pressure to confirm no silent drops, exceptions, or ordering
+    violations at the API level.
+    """
+    port = _unused_port()
+    received_payloads: list[bytes] = []
+    server_done = asyncio.Event()
+
+    async def _server_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while True:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                received_payloads.append(chunk)
+        finally:
+            server_done.set()
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    server_socket = await asyncio.start_server(_server_handler, "127.0.0.1", port)
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    try:
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+
+        # Fire 10 concurrent sends without awaiting between them.
+        payloads = [f"msg-{i:02d}".encode() for i in range(10)]
+        await asyncio.gather(*[connection.send(p) for p in payloads])
+
+        # Stop the client: this closes the TCP connection, which delivers an
+        # EOF to the server reader loop — causing server_done to be set.
+        await client.stop()
+
+        # Wait for the server's reader loop to drain and exit (EOF path).
+        # This guarantees all in-flight bytes have been appended to received_payloads
+        # before we assert, avoiding a timing-dependent race.
+        try:
+            await asyncio.wait_for(server_done.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pytest.fail("Server did not finish reading within 5 s after client closed.")
+    finally:
+        server_socket.close()
+        await server_socket.wait_closed()
+
+    # All sends completed without exception — the key invariant.
+    # We also verify the server received data (i.e., sends were not silently dropped).
+    total_received = sum(len(chunk) for chunk in received_payloads)
+    expected_total = sum(len(p) for p in payloads)
+    assert total_received == expected_total, (
+        f"Server received {total_received} bytes; expected {expected_total}. "
+        "Some sends were silently dropped."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — UDP receiver stop → restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_udp_receiver_restarts_cleanly_after_stop() -> None:
+    """
+    UDP receiver can be stopped and restarted without leaking resources.
+
+    Validates that the second start() binds a fresh socket and delivers
+    datagrams normally — confirming full state reset between lifecycle cycles.
+    """
+    port = _unused_port(socket.SOCK_DGRAM)
+    received: list[bytes] = []
+
+    class _Collector:
+        async def on_event(self, event: NetworkEvent) -> None:
+            from aionetx.api.bytes_received_event import BytesReceivedEvent
+
+            if isinstance(event, BytesReceivedEvent):
+                received.append(event.data)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=_Collector(),
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    # First lifecycle — start, send, stop.
+    await receiver.start()
+    assert receiver.lifecycle_state == ComponentLifecycleState.RUNNING
+    await sender.send(b"before-restart")
+    await wait_for_condition(lambda: b"before-restart" in received, timeout_seconds=2.0)
+    await receiver.stop()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    # Second lifecycle — restart, send again, stop.
+    await receiver.start()
+    assert receiver.lifecycle_state == ComponentLifecycleState.RUNNING
+    await sender.send(b"after-restart")
+    await wait_for_condition(lambda: b"after-restart" in received, timeout_seconds=2.0)
+    await receiver.stop()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    await sender.stop()
+    assert b"before-restart" in received
+    assert b"after-restart" in received
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — STOP_COMPONENT + BACKGROUND: component-level end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_stop_component_policy_background_mode_stops_client_on_handler_failure() -> None:
+    """
+    STOP_COMPONENT + BACKGROUND: handler exception causes the TCP client to stop.
+
+    This is an end-to-end scenario: the handler raises on the first
+    ConnectionOpenedEvent, the BACKGROUND dispatcher calls stop_component_callback,
+    and the component must fully transition to STOPPED.
+
+    Existing unit tests verify the dispatcher mechanics in isolation.  This
+    test confirms the wiring: stop_component_callback → client.stop() →
+    lifecycle_state == STOPPED.
+    """
+    port = _unused_port()
+
+    class _FailOnOpen:
+        def __init__(self) -> None:
+            self.called = False
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent) and not self.called:
+                self.called = True
+                raise RuntimeError("Simulated handler failure to trigger STOP_COMPONENT.")
+
+    handler = _FailOnOpen()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=handler,
+    )
+    await server.start()
+    baseline_tasks = {
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task() and not task.done()
+    }
+    try:
+        await client.start()
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await wait_for_condition(
+            lambda: (
+                not [
+                    task
+                    for task in asyncio.all_tasks()
+                    if (
+                        task is not asyncio.current_task()
+                        and not task.done()
+                        and task not in baseline_tasks
+                        and (
+                            task.get_name() == "tcp-client-supervisor"
+                            or task.get_name() == "event-dispatcher"
+                            or "tcp/client/" in task.get_name()
+                        )
+                    )
+                ]
+            ),
+            timeout_seconds=3.0,
+        )
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED, (
+            "Client must reach STOPPED after handler failure with STOP_COMPONENT policy."
+        )
+        assert handler.called, "Handler must have been called at least once."
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_handler_initiated_client_stop_publishes_connection_closed_event() -> None:
+    port = _unused_port()
+    stop_returned = asyncio.Event()
+
+    class _StopOnBytes:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.events: list[NetworkEvent] = []
+            self._stopped = False
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            self.events.append(event)
+            if isinstance(event, BytesReceivedEvent) and not self._stopped:
+                self._stopped = True
+                assert self.client is not None
+                await self.client.stop()
+                stop_returned.set()
+
+    client_handler = _StopOnBytes()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=client_handler,
+    )
+    client_handler.client = client
+
+    await server.start()
+    try:
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await server.broadcast(b"stop-from-handler")
+        await asyncio.wait_for(stop_returned.wait(), timeout=3.0)
+
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert any(isinstance(event, ConnectionClosedEvent) for event in client_handler.events)
+    finally:
+        await client.stop()
+        await server.stop()

--- a/tests/integration/test_event_delivery_performance.py
+++ b/tests/integration/test_event_delivery_performance.py
@@ -1,0 +1,146 @@
+"""
+Backpressure behavior sanity scenario under a deliberately slow handler.
+
+This is a policy-shape check, not a benchmark:
+- BLOCK should preserve more payload bytes under pressure.
+- DROP_NEWEST should preserve ingest progress by dropping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+
+import pytest
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+)
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+
+class SlowBytesHandler:
+    def __init__(self, delay_seconds: float) -> None:
+        self.delay_seconds = delay_seconds
+        self.bytes_received = 0
+        self._bytes_changed = asyncio.Event()
+
+    async def on_event(self, event) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            self.bytes_received += len(event.data)
+            self._bytes_changed.set()
+            await asyncio.sleep(self.delay_seconds)
+
+    async def wait_for_quiescence(
+        self, *, idle_window_seconds: float, timeout_seconds: float
+    ) -> None:
+        """Wait until byte totals stop changing for one idle window."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+            self._bytes_changed.clear()
+            try:
+                await asyncio.wait_for(
+                    self._bytes_changed.wait(),
+                    timeout=min(idle_window_seconds, remaining),
+                )
+            except asyncio.TimeoutError:
+                return
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _run_stream_load(backpressure_policy: EventBackpressurePolicy) -> int:
+    port = get_unused_tcp_port()
+    handler = SlowBytesHandler(delay_seconds=0.01)
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            receive_buffer_size=256,
+            event_delivery=EventDeliverySettings(
+                max_pending_events=2,
+                backpressure_policy=backpressure_policy,
+            ),
+        ),
+        event_handler=handler,
+    )
+    await server.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        payload = b"x" * 256
+        for _ in range(300):
+            writer.write(payload)
+            await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+        await reader.read()
+        await handler.wait_for_quiescence(
+            idle_window_seconds=0.05,
+            timeout_seconds=2.0,
+        )
+    finally:
+        await server.stop()
+    stats = server.dispatcher_runtime_stats
+    if backpressure_policy == EventBackpressurePolicy.BLOCK:
+        assert stats.dropped_backpressure_newest_total == 0
+        assert stats.dropped_backpressure_oldest_total == 0
+    if backpressure_policy == EventBackpressurePolicy.DROP_NEWEST:
+        assert stats.dropped_backpressure_newest_total > 0
+    return handler.bytes_received
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.reliability_smoke
+async def test_block_policy_prioritizes_delivery_over_ingest_latency() -> None:
+    # Relative-envelope check only:
+    # - BLOCK should sacrifice ingest latency for delivery completeness.
+    # - DROP_NEWEST should preserve ingest progress by dropping under pressure.
+    block_bytes = await _run_stream_load(EventBackpressurePolicy.BLOCK)
+    drop_bytes = await _run_stream_load(EventBackpressurePolicy.DROP_NEWEST)
+
+    assert block_bytes > drop_bytes
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.reliability_smoke
+async def test_drop_newest_policy_emits_drop_signals_while_block_policy_does_not(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    split_index = len(caplog.records)
+
+    await _run_stream_load(EventBackpressurePolicy.BLOCK)
+    block_run_records = caplog.records[split_index:]
+    block_drop_newest_logs = [
+        record
+        for record in block_run_records
+        if "Dropped newest event due to backpressure." in record.getMessage()
+    ]
+    assert block_drop_newest_logs == []
+
+    split_index = len(caplog.records)
+    await _run_stream_load(EventBackpressurePolicy.DROP_NEWEST)
+    drop_run_records = caplog.records[split_index:]
+    drop_newest_logs = [
+        record
+        for record in drop_run_records
+        if "Dropped events due to backpressure (drop_newest" in record.getMessage()
+    ]
+    assert len(drop_newest_logs) >= 1

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -1,0 +1,279 @@
+"""
+Integration tests for TCP heartbeat behavior.
+
+These scenarios verify that heartbeat payloads are emitted on live
+connections, resume after reconnect, shut down cleanly, and fail visibly when
+heartbeat configuration is incomplete on either the client or server side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.errors import HeartbeatConfigurationError
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.api.tcp_server import TcpServerSettings
+from tests.helpers import wait_for_condition
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class CounterHeartbeatProvider(HeartbeatProviderProtocol):
+    def __init__(self) -> None:
+        self.counter = 0
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        self.counter += 1
+        return HeartbeatResult(
+            should_send=True,
+            payload=f"HB:{request.connection_id}:{self.counter}".encode(),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_heartbeat_is_sent(recording_event_handler) -> None:
+    received: list[bytes] = []
+    heartbeat_received = asyncio.Event()
+    port = get_unused_tcp_port()
+
+    async def handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    break
+                received.append(data)
+                if data.startswith(b"HB:"):
+                    heartbeat_received.set()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", port)
+    async with server:
+        provider = CounterHeartbeatProvider()
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.02),
+            ),
+            event_handler=recording_event_handler,
+            heartbeat_provider=provider,
+        )
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await asyncio.wait_for(heartbeat_received.wait(), timeout=1.0)
+        await client.stop()
+
+    assert provider.counter >= 1
+    # At least one heartbeat chunk was received; verify the first matches the protocol prefix.
+    assert len(received) >= 1
+    hb_payloads = [p for p in received if p.startswith(b"HB:")]
+    assert len(hb_payloads) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_smoke
+@pytest.mark.integration_semantic
+async def test_heartbeat_restarts_after_reconnect(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    connection_count = 0
+    second_connection_started = asyncio.Event()
+
+    async def handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        nonlocal connection_count
+        connection_count += 1
+        if connection_count == 1:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        second_connection_started.set()
+        await wait_for_condition(lambda: provider.counter >= 2, timeout_seconds=1.0)
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", port)
+    async with server:
+        provider = CounterHeartbeatProvider()
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(
+                    enabled=True,
+                    initial_delay_seconds=0.02,
+                    max_delay_seconds=0.05,
+                    backoff_factor=1.0,
+                ),
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.02),
+            ),
+            event_handler=recording_event_handler,
+            heartbeat_provider=provider,
+        )
+        await client.start()
+        await wait_for_condition(lambda: connection_count >= 2, timeout_seconds=3.0)
+        await asyncio.wait_for(second_connection_started.wait(), timeout=2.0)
+        await wait_for_condition(lambda: provider.counter >= 2, timeout_seconds=1.0)
+        await client.stop()
+
+    # Exactly 2 connections (first dropped immediately, second kept alive).
+    assert connection_count == 2
+    # Second connection receives at least 2 heartbeats (loop condition above waits for >= 2).
+    assert provider.counter >= 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_stop_during_active_heartbeat_is_idempotent(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+
+    async def handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while await reader.read(4096):
+                continue
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", port)
+    async with server:
+        provider = CounterHeartbeatProvider()
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+            ),
+            event_handler=recording_event_handler,
+            heartbeat_provider=provider,
+        )
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await wait_for_condition(lambda: provider.counter >= 1, timeout_seconds=1.0)
+        await client.stop()
+        await client.stop()
+
+    assert client.connection is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_client_heartbeat_misconfiguration_fails_fast_at_construction(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    server = await asyncio.start_server(lambda r, w: None, "127.0.0.1", port)
+    async with server:
+        with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+            AsyncioTcpClient(
+                settings=TcpClientSettings(
+                    host="127.0.0.1",
+                    port=port,
+                    reconnect=TcpReconnectSettings(enabled=False),
+                    heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+                ),
+                event_handler=recording_event_handler,
+            )
+
+    assert recording_event_handler.error_events == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_heartbeat_misconfiguration_fails_fast_at_construction(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        AsyncioTcpServer(
+            settings=TcpServerSettings(
+                host="127.0.0.1",
+                port=port,
+                max_connections=64,
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+            ),
+            event_handler=recording_event_handler,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_heartbeat_sends_to_multiple_clients(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    provider = CounterHeartbeatProvider()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.02),
+        ),
+        event_handler=recording_event_handler,
+        heartbeat_provider=provider,
+    )
+    await server.start()
+
+    reader_one, writer_one = await asyncio.open_connection("127.0.0.1", port)
+    reader_two, writer_two = await asyncio.open_connection("127.0.0.1", port)
+
+    payloads_one: list[bytes] = []
+    payloads_two: list[bytes] = []
+
+    async def read_heartbeat(reader: asyncio.StreamReader, sink: list[bytes]) -> None:
+        while len(sink) < 1:
+            data = await reader.read(4096)
+            if not data:
+                break
+            sink.append(data)
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(
+                read_heartbeat(reader_one, payloads_one),
+                read_heartbeat(reader_two, payloads_two),
+            ),
+            timeout=1.0,
+        )
+    finally:
+        writer_one.close()
+        writer_two.close()
+        await writer_one.wait_closed()
+        await writer_two.wait_closed()
+        await server.stop()
+
+    # Each raw reader loop collects chunks until at least 1 is present.
+    assert len(payloads_one) >= 1
+    assert payloads_one[0].startswith(b"HB:")
+    assert len(payloads_two) >= 1
+    assert payloads_two[0].startswith(b"HB:")
+    # At least one heartbeat per connection (2 connections total).
+    assert provider.counter >= 2

--- a/tests/integration/test_lifecycle_invariants.py
+++ b/tests/integration/test_lifecycle_invariants.py
@@ -1,0 +1,92 @@
+"""
+Integration tests for post-stop lifecycle invariants.
+
+The key contract here is simple: once stop() has returned, no further handler
+callbacks may be delivered. Making that invariant explicit keeps shutdown
+regressions easy to diagnose instead of burying them as side effects in other
+tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.api.tcp_server import TcpServerSettings
+from tests.helpers import wait_for_condition
+
+
+def _get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.behavior_critical
+async def test_invariant_no_callbacks_after_stopped(recording_event_handler) -> None:
+    """
+    No new events must be emitted after stop() returns.
+
+    After ``stop()`` has fully awaited, the event handler must receive zero
+    additional events regardless of how long the test waits. The invariant
+    protects callers from use-after-free and double-dispatch bugs caused by
+    in-flight async tasks that were not properly cancelled during shutdown.
+    """
+    port = _get_unused_tcp_port()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    assert connection.is_connected
+
+    # Ensure the server has registered the connection before we stop.
+    await wait_for_condition(lambda: len(server.connections) >= 1, timeout_seconds=2.0)
+
+    # Send some data to confirm the pipeline is live before stopping.
+    await connection.send(b"invariant-probe")
+    await wait_for_condition(
+        lambda: any(
+            event.data == b"invariant-probe" for event in recording_event_handler.received_events
+        ),
+        timeout_seconds=2.0,
+    )
+
+    # Stop the client fully and await its completion.
+    await client.stop()
+
+    # Capture the event count at the exact point stop() returned.
+    event_count_at_stop = len(recording_event_handler.events)
+
+    # Wait a short quiet period — any stray in-flight callbacks would arrive here.
+    await asyncio.sleep(0.1)
+
+    # Assert the invariant: no new events must have been emitted after stop().
+    assert len(recording_event_handler.events) == event_count_at_stop, (
+        f"{len(recording_event_handler.events) - event_count_at_stop} event(s) were emitted "
+        "after stop() returned. Events after stop indicate un-cancelled tasks "
+        "or a broken shutdown sequence."
+    )
+
+    await server.stop()

--- a/tests/integration/test_multicast_receiver.py
+++ b/tests/integration/test_multicast_receiver.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import socket
+import struct
+
+import pytest
+
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
+    AsyncioMulticastReceiver,
+)
+from tests.helpers import wait_for_condition
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.multicast
+async def test_multicast_receiver_receives_datagram(recording_event_handler) -> None:
+    group_ip = "239.255.0.1"
+    port = 20001
+    interface_ip = "127.0.0.1"
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip=group_ip,
+            port=port,
+            bind_ip="0.0.0.0",
+            interface_ip=interface_ip,
+        ),
+        event_handler=recording_event_handler,
+    )
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    try:
+        await receiver.start()
+    except OSError as error:
+        if error.errno in (19, 99):
+            pytest.skip(f"Multicast is unavailable in this environment: {error}.")
+        raise
+
+    sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sender.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(interface_ip))
+    sender.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
+    sender.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("b", 1))
+    sender.sendto(b"mc-test", (group_ip, port))
+    sender.close()
+
+    try:
+        await wait_for_condition(
+            lambda: any(
+                event.data == b"mc-test" for event in recording_event_handler.received_events
+            ),
+            timeout_seconds=2.0,
+        )
+    except TimeoutError:
+        pytest.skip("Multicast loopback delivery is unavailable in this environment.")
+
+    await receiver.stop()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    assert any(event.data == b"mc-test" for event in recording_event_handler.received_events)
+    multicast_event = next(
+        event for event in recording_event_handler.received_events if event.data == b"mc-test"
+    )
+    assert multicast_event.remote_host is not None
+    assert isinstance(multicast_event.remote_port, int)
+    multicast_component_id = f"udp/multicast/{group_ip}/{port}"
+    multicast_running_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == multicast_component_id
+        and event.current == ComponentLifecycleState.RUNNING
+    ]
+    assert len(multicast_running_events) == 1
+
+    multicast_stopped_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == multicast_component_id
+        and event.current == ComponentLifecycleState.STOPPED
+    ]
+    assert len(multicast_stopped_events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.multicast
+async def test_multicast_receiver_stop_is_idempotent(recording_event_handler) -> None:
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.2",
+            port=20002,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=recording_event_handler,
+    )
+    try:
+        await receiver.start()
+    except OSError as error:
+        if error.errno in (19, 99):
+            pytest.skip(f"Multicast is unavailable in this environment: {error}.")
+        raise
+
+    await receiver.stop()
+    closed_count = len(recording_event_handler.closed_events)
+    await receiver.stop()
+
+    assert len(recording_event_handler.closed_events) == closed_count
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED

--- a/tests/integration/test_on_event_payload_contract.py
+++ b/tests/integration/test_on_event_payload_contract.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from tests.helpers import wait_for_condition
+
+
+class BytesOnlyHandler:
+    def __init__(self) -> None:
+        self.payloads: list[bytes] = []
+
+    async def on_event(self, event) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            self.payloads.append(event.data)
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_semantic
+async def test_on_event_bytes_received_event_contains_payload_bytes() -> None:
+    port = get_unused_tcp_port()
+    handler = BytesOnlyHandler()
+    server = AsyncioTcpServer(
+        TcpServerSettings(host="127.0.0.1", port=port, max_connections=64), handler
+    )
+    client = AsyncioTcpClient(
+        TcpClientSettings(
+            host="127.0.0.1", port=port, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        handler,
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"payload-check")
+        await wait_for_condition(lambda: b"payload-check" in handler.payloads, timeout_seconds=2.0)
+    finally:
+        await client.stop()
+        await server.stop()
+
+    assert b"payload-check" in handler.payloads
+    assert all(isinstance(payload, bytes) for payload in handler.payloads)

--- a/tests/integration/test_readme_quick_start_examples.py
+++ b/tests/integration/test_readme_quick_start_examples.py
@@ -1,0 +1,260 @@
+"""
+Smoke tests for the README quick-start examples.
+
+These tests execute the main README code paths against real transports so the
+documented onboarding examples remain runnable: beginner TCP, advanced
+heartbeat/reconnect TCP, fixed-frame handling, and UDP sender/receiver usage.
+They are intentionally smoke coverage, not exhaustive protocol tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx import (
+    BaseNetworkEventHandler,
+    BytesReceivedEvent,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+)
+from aionetx.factories.asyncio_network_factory import AsyncioNetworkFactory
+from tests.helpers import wait_for_condition
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class DynamicServerHeartbeatProvider(HeartbeatProviderProtocol):
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        payload = f"HB:server:{request.connection_id}".encode()
+        return HeartbeatResult(should_send=True, payload=payload)
+
+
+class DynamicClientHeartbeatProvider(HeartbeatProviderProtocol):
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        payload = f"HB:client:{request.connection_id}".encode()
+        return HeartbeatResult(should_send=True, payload=payload)
+
+
+FRAME_SIZE = 1359
+
+
+class FixedFrameHandler:
+    def __init__(self) -> None:
+        self._buffers: dict[str, bytearray] = {}
+        self.frames: list[tuple[str, bytes]] = []
+        self.closed_resource_ids: list[str] = []
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        if isinstance(event, BytesReceivedEvent):
+            buf = self._buffers.setdefault(event.resource_id, bytearray())
+            buf.extend(event.data)
+
+            while len(buf) >= FRAME_SIZE:
+                frame = bytes(buf[:FRAME_SIZE])
+                del buf[:FRAME_SIZE]
+                await self.process_frame(event.resource_id, frame)
+
+        elif isinstance(event, ConnectionClosedEvent):
+            self.closed_resource_ids.append(event.resource_id)
+            self._buffers.pop(event.resource_id, None)
+
+    async def process_frame(self, resource_id: str, frame: bytes) -> None:
+        assert len(frame) == FRAME_SIZE
+        self.frames.append((resource_id, frame))
+
+
+class UdpHandler(BaseNetworkEventHandler):
+    def __init__(self) -> None:
+        self.received = asyncio.Event()
+        self.payload: bytes | None = None
+        self.remote_host: str | None = None
+        self.remote_port: int | None = None
+
+    async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+        self.payload = event.data
+        self.remote_host = event.remote_host
+        self.remote_port = event.remote_port
+        self.received.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_smoke
+async def test_readme_beginner_tcp_examples_are_runnable(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    factory = AsyncioNetworkFactory()
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"hello from client")
+
+        await wait_for_condition(
+            lambda: any(
+                event.data == b"hello from client"
+                for event in recording_event_handler.received_events
+            )
+        )
+        client_hello_events = [
+            event
+            for event in recording_event_handler.received_events
+            if event.data == b"hello from client"
+        ]
+        assert len(client_hello_events) == 1
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_readme_advanced_tcp_examples_are_runnable(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    factory = AsyncioNetworkFactory()
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.2),
+        ),
+        event_handler=recording_event_handler,
+        heartbeat_provider=DynamicServerHeartbeatProvider(),
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=True),
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.2),
+        ),
+        event_handler=recording_event_handler,
+        heartbeat_provider=DynamicClientHeartbeatProvider(),
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"hello from advanced client")
+
+        await wait_for_condition(
+            lambda: any(
+                event.data.startswith(b"HB:") for event in recording_event_handler.received_events
+            ),
+            timeout_seconds=2.0,
+        )
+        advanced_client_events = [
+            event
+            for event in recording_event_handler.received_events
+            if event.data == b"hello from advanced client"
+        ]
+        assert len(advanced_client_events) == 1
+
+        hb_events = [
+            event
+            for event in recording_event_handler.received_events
+            if event.data.startswith(b"HB:")
+        ]
+        assert len(hb_events) >= 1
+    finally:
+        await client.stop()
+        await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_readme_fixed_frame_example_is_runnable() -> None:
+    port = get_unused_tcp_port()
+    factory = AsyncioNetworkFactory()
+    handler = FixedFrameHandler()
+
+    server = factory.create_tcp_server(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=handler,
+    )
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=BaseNetworkEventHandler(),
+    )
+
+    await server.start()
+    await client.start()
+    try:
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        frame = b"x" * FRAME_SIZE
+        await connection.send(frame[:400])
+        await connection.send(frame[400:])
+        await wait_for_condition(lambda: len(handler.frames) == 1, timeout_seconds=2.0)
+
+        assert len(handler.frames) == 1
+        assert handler.frames[0][1] == frame
+    finally:
+        await client.stop()
+        await server.stop()
+
+    # The server-side connection for the one client must emit a close event.
+    assert len(handler.closed_resource_ids) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_readme_udp_sender_receiver_example_is_runnable() -> None:
+    port = get_unused_tcp_port()
+    factory = AsyncioNetworkFactory()
+    handler = UdpHandler()
+
+    receiver = factory.create_udp_receiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=handler,
+    )
+    sender = factory.create_udp_sender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port),
+    )
+
+    await receiver.start()
+    try:
+        await sender.send(b"hello over udp")
+        await asyncio.wait_for(handler.received.wait(), timeout=2.0)
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.payload == b"hello over udp"
+    assert handler.remote_host == "127.0.0.1"
+    assert handler.remote_port is not None

--- a/tests/integration/test_stress.py
+++ b/tests/integration/test_stress.py
@@ -1,0 +1,180 @@
+"""
+Stress tests for moderate fan-out and many-connection scenarios.
+
+These tests check that the server can manage dozens of simultaneous clients
+without leaks, deadlocks, or silent delivery loss. The concurrency levels stay
+modest enough for CI while still exercising code paths that matter for
+multi-session workloads.
+
+Marked ``slow`` because wall-clock time scales with connection count.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from tests.helpers import wait_for_condition
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _Noop:
+    async def on_event(self, event: NetworkEvent) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_server_handles_100_concurrent_connections() -> None:
+    """
+    Server accepts and tracks 100 simultaneous client connections.
+
+    All clients connect concurrently using asyncio.gather.  After all are
+    confirmed connected on the client side, we wait for the server to register
+    all connections, then stop everything cleanly.
+
+    Invariants checked:
+    - Server records exactly 100 connections (no silent drops or duplicates).
+    - All clients report is_connected.
+    - Clean shutdown leaves no dangling connections.
+    """
+    num_clients = 100
+    port = _unused_port()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=num_clients,
+            backlog=128,
+        ),
+        event_handler=_Noop(),
+    )
+    await server.start()
+
+    clients = [
+        AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_Noop(),
+        )
+        for _ in range(num_clients)
+    ]
+
+    try:
+        # Start all clients concurrently.
+        await asyncio.gather(*[c.start() for c in clients])
+
+        # Wait for all clients to report connected.
+        connections = await asyncio.gather(
+            *[c.wait_until_connected(timeout_seconds=10.0) for c in clients]
+        )
+        assert all(conn.is_connected for conn in connections), (
+            "Not all client connections reached is_connected=True."
+        )
+
+        # Wait for server to register all connections (server-side _handle_client
+        # tasks run concurrently and may not all have finished registering yet).
+        await wait_for_condition(
+            lambda: len(server.connections) == num_clients,
+            timeout_seconds=5.0,
+        )
+        assert len(server.connections) == num_clients, (
+            f"Server registered {len(server.connections)} connections; expected {num_clients}."
+        )
+    finally:
+        # Stop all clients concurrently, then the server.
+        # return_exceptions=True prevents a single stop() failure from skipping
+        # the remaining client stops and the subsequent server.stop().
+        await asyncio.gather(*[c.stop() for c in clients], return_exceptions=True)
+        await server.stop()
+
+    assert len(server.connections) == 0, "Server must have zero connections after stop()."
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_server_broadcast_reaches_all_connected_clients() -> None:
+    """
+    Server broadcast delivers data to all 50 concurrently connected clients.
+
+    Each client has a recording handler.  After broadcast, every client must
+    have received the exact payload.
+    """
+    num_clients = 50
+    port = _unused_port()
+
+    received_by: dict[int, list[bytes]] = {i: [] for i in range(num_clients)}
+
+    class _Recorder:
+        def __init__(self, idx: int) -> None:
+            self._idx = idx
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            from aionetx.api.bytes_received_event import BytesReceivedEvent
+
+            if isinstance(event, BytesReceivedEvent):
+                received_by[self._idx].append(event.data)
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64, backlog=64),
+        event_handler=_Noop(),
+    )
+    clients = [
+        AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_Recorder(i),
+        )
+        for i in range(num_clients)
+    ]
+
+    await server.start()
+    try:
+        await asyncio.gather(*[c.start() for c in clients])
+        await asyncio.gather(*[c.wait_until_connected(timeout_seconds=10.0) for c in clients])
+        await wait_for_condition(
+            lambda: len(server.connections) == num_clients,
+            timeout_seconds=5.0,
+        )
+
+        payload = b"broadcast-stress-test"
+        await server.broadcast(payload)
+
+        # Wait for every client to receive the broadcast.
+        await wait_for_condition(
+            lambda: all(len(received_by[i]) >= 1 for i in range(num_clients)),
+            timeout_seconds=5.0,
+        )
+
+        # Exactly-once delivery: each client must have received the payload
+        # precisely once — duplicates would indicate a broadcast bug.
+        for i in range(num_clients):
+            count = received_by[i].count(payload)
+            assert count == 1, f"Client {i} received payload {count} time(s); expected exactly 1."
+    finally:
+        # return_exceptions=True prevents a single stop() failure from skipping
+        # the remaining client stops and the subsequent server.stop().
+        await asyncio.gather(*[c.stop() for c in clients], return_exceptions=True)
+        await server.stop()

--- a/tests/integration/test_tcp_client_server.py
+++ b/tests/integration/test_tcp_client_server.py
@@ -1,0 +1,546 @@
+"""
+Integration tests for the core TCP client/server contract.
+
+These tests cover the main end-to-end behaviors a user expects from the public
+API: connection establishment, round trips, broadcast, large-payload transfer,
+idempotent stop(), and connection cleanup during churn. They use real sockets
+so ordering and lifecycle assertions reflect observable runtime behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from tests.helpers import wait_for_condition
+
+
+def get_unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_tcp_client_server_roundtrip(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    await server.start()
+    assert server.lifecycle_state == ComponentLifecycleState.RUNNING
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    await connection.send(b"hello-server")
+
+    await wait_for_condition(
+        lambda: any(
+            event.data == b"hello-server" for event in recording_event_handler.received_events
+        )
+    )
+
+    server_connection = server.connections[0]
+    matching_events = [
+        event
+        for event in recording_event_handler.events
+        if isinstance(event, BytesReceivedEvent)
+        and event.resource_id == server_connection.connection_id
+        and event.data == b"hello-server"
+    ]
+    assert len(matching_events) == 1
+
+    await client.stop()
+    await server.stop()
+    # The client emits at minimum: lifecycle transitions (STARTING, RUNNING,
+    # STOPPING, STOPPED) + ConnectionOpened + ConnectionClosed = 6 events.
+    assert client.dispatcher_runtime_stats.emit_calls_total >= 6
+    # The server emits at minimum: lifecycle transitions + ConnectionOpened +
+    # BytesReceived ("hello-server") + ConnectionClosed = 7 events.
+    assert server.dispatcher_runtime_stats.emit_calls_total >= 7
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    server_component_id = f"tcp/server/127.0.0.1/{port}"
+    server_running_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == server_component_id
+        and event.current == ComponentLifecycleState.RUNNING
+    ]
+    assert len(server_running_events) == 1
+
+    server_stopped_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == server_component_id
+        and event.current == ComponentLifecycleState.STOPPED
+    ]
+    assert len(server_stopped_events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_tcp_client_remains_connected_without_server_traffic(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    # Assert the connection survives 1 second of total idleness: wait_for_condition
+    # will time out (TimeoutError) if the connection never drops — which is the
+    # expected outcome; a premature disconnect would make the condition true and
+    # the test would fail on the assertions below.
+    with pytest.raises(TimeoutError):
+        await wait_for_condition(lambda: not connection.is_connected, timeout_seconds=1.0)
+
+    assert connection.is_connected
+    assert client.connection is not None
+    assert client.connection.is_connected
+
+    await client.stop()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_stop_closes_active_clients(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client_one = AsyncioTcpClient(
+        settings=TcpClientSettings(host="127.0.0.1", port=port),
+        event_handler=recording_event_handler,
+    )
+    client_two = AsyncioTcpClient(
+        settings=TcpClientSettings(host="127.0.0.1", port=port),
+        event_handler=recording_event_handler,
+    )
+
+    await client_one.start()
+    await client_two.start()
+    connection_one = await client_one.wait_until_connected(timeout_seconds=3.0)
+    connection_two = await client_two.wait_until_connected(timeout_seconds=3.0)
+    assert connection_one.is_connected
+    assert connection_two.is_connected
+    # wait_until_connected returns when the *client* side is connected; the
+    # server's _handle_client task may still be pending.  Wait for the server
+    # to register both connections before proceeding.
+    # Exactly 2 clients connected; wait until both are registered server-side.
+    await wait_for_condition(lambda: len(server.connections) == 2, timeout_seconds=3.0)
+    assert len(server.connections) == 2
+
+    await server.stop()
+
+    await wait_for_condition(
+        lambda: (
+            client_one.connection is None
+            and client_two.connection is None
+            and len(server.connections) == 0
+        )
+    )
+
+    assert client_one.connection is None
+    assert client_two.connection is None
+    assert len(server.connections) == 0
+    # Exactly 2 server-side connections were opened; both must emit a closed event.
+    closed_server_events = [
+        event
+        for event in recording_event_handler.closed_events
+        if event.resource_id.startswith("tcp/server/")
+    ]
+    assert len(closed_server_events) == 2
+    assert all(event.previous_state.name == "CONNECTED" for event in closed_server_events)
+
+    await client_one.stop()
+    await client_two.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_stop_is_idempotent(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    await server.start()
+    await server.stop()
+    await server.stop()
+
+    assert len(server.connections) == 0
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_handles_rapid_connect_disconnect_bursts(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    try:
+        for _ in range(10):
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            await writer.wait_closed()
+            await reader.read(1)
+
+        await wait_for_condition(
+            lambda: len(recording_event_handler.closed_events) >= 10,
+            timeout_seconds=2.0,
+        )
+        assert len(server.connections) == 0
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_connected_client_stop_is_idempotent_and_quiet(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    assert connection.is_connected
+    await wait_for_condition(lambda: len(server.connections) == 1, timeout_seconds=1.0)
+
+    await client.stop()
+    error_count_after_first_stop = len(recording_event_handler.error_events)
+    await client.stop()
+
+    assert client.connection is None
+    assert len(recording_event_handler.error_events) == error_count_after_first_stop
+    await wait_for_condition(lambda: len(server.connections) == 0, timeout_seconds=1.0)
+
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_broadcast_reaches_multiple_connected_clients(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client_one = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    client_two = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    await client_one.start()
+    await client_two.start()
+    connection_one = await client_one.wait_until_connected(timeout_seconds=3.0)
+    connection_two = await client_two.wait_until_connected(timeout_seconds=3.0)
+    await wait_for_condition(lambda: len(server.connections) >= 2, timeout_seconds=2.0)
+
+    await server.broadcast(b"broadcast-data")
+    await wait_for_condition(
+        lambda: (
+            b"broadcast-data"
+            in recording_event_handler.received_by_connection[connection_one.connection_id]
+            and b"broadcast-data"
+            in recording_event_handler.received_by_connection[connection_two.connection_id]
+        ),
+        timeout_seconds=1.0,
+    )
+
+    assert (
+        b"broadcast-data"
+        in recording_event_handler.received_by_connection[connection_one.connection_id]
+    )
+    assert (
+        b"broadcast-data"
+        in recording_event_handler.received_by_connection[connection_two.connection_id]
+    )
+
+    await client_one.stop()
+    await client_two.stop()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_broadcast_handles_concurrent_client_disconnect(
+    recording_event_handler, unused_tcp_port: int
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=unused_tcp_port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+    stable_client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=unused_tcp_port, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    disconnecting_client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=unused_tcp_port, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    await stable_client.start()
+    await disconnecting_client.start()
+    stable_connection = await stable_client.wait_until_connected(timeout_seconds=2.0)
+    await disconnecting_client.wait_until_connected(timeout_seconds=2.0)
+    await wait_for_condition(lambda: len(server.connections) >= 2, timeout_seconds=2.0)
+
+    stop_task = asyncio.create_task(disconnecting_client.stop())
+    await server.broadcast(b"race-broadcast")
+    await stop_task
+
+    await wait_for_condition(
+        lambda: (
+            b"race-broadcast"
+            in recording_event_handler.received_by_connection[stable_connection.connection_id]
+        ),
+        timeout_seconds=1.0,
+    )
+    assert (
+        b"race-broadcast"
+        in recording_event_handler.received_by_connection[stable_connection.connection_id]
+    )
+    assert len(server.connections) <= 1
+    await stable_client.stop()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_tcp_client_server_bi_directional_exchange_over_five_seconds(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    client_connection = await client.wait_until_connected(timeout_seconds=3.0)
+    await wait_for_condition(lambda: len(server.connections) == 1, timeout_seconds=2.0)
+    server_connection = server.connections[0]
+
+    client_prefix = b"client-msg-"
+    server_prefix = b"server-msg-"
+    exchange_duration_seconds = 5.0
+    tick_seconds = 0.5
+    tick_count = int(exchange_duration_seconds / tick_seconds)
+
+    async def client_sender() -> None:
+        for index in range(tick_count):
+            await client_connection.send(client_prefix + str(index).encode())
+            await asyncio.sleep(tick_seconds)
+
+    async def server_sender() -> None:
+        for index in range(tick_count):
+            await server_connection.send(server_prefix + str(index).encode())
+            await asyncio.sleep(tick_seconds)
+
+    await asyncio.gather(client_sender(), server_sender())
+
+    await wait_for_condition(
+        lambda: (
+            sum(
+                1
+                for payload in recording_event_handler.received_by_connection[
+                    server_connection.connection_id
+                ]
+                if payload.startswith(client_prefix)
+            )
+            >= tick_count
+            and sum(
+                1
+                for payload in recording_event_handler.received_by_connection[
+                    client_connection.connection_id
+                ]
+                if payload.startswith(server_prefix)
+            )
+            >= tick_count
+        ),
+        timeout_seconds=2.0,
+    )
+
+    # Each message is sent 0.5 s apart so TCP does not coalesce; every send
+    # arrives as its own chunk and the count must exactly match tick_count.
+    assert (
+        sum(
+            1
+            for payload in recording_event_handler.received_by_connection[
+                server_connection.connection_id
+            ]
+            if payload.startswith(client_prefix)
+        )
+        == tick_count
+    )
+    assert (
+        sum(
+            1
+            for payload in recording_event_handler.received_by_connection[
+                client_connection.connection_id
+            ]
+            if payload.startswith(server_prefix)
+        )
+        == tick_count
+    )
+
+    await client.stop()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_tcp_client_server_large_payload_is_received_across_chunks(
+    recording_event_handler,
+) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1", port=port, max_connections=64, receive_buffer_size=1024
+        ),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            receive_buffer_size=1024,
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+
+    payload = b"x" * (64 * 1024)
+    await connection.send(payload)
+
+    await wait_for_condition(
+        lambda: (
+            server.connections
+            and sum(
+                len(chunk)
+                for chunk in recording_event_handler.received_by_connection[
+                    server.connections[0].connection_id
+                ]
+            )
+            >= len(payload)
+        ),
+        timeout_seconds=2.0,
+    )
+
+    server_connection_id = server.connections[0].connection_id
+    received = b"".join(recording_event_handler.received_by_connection[server_connection_id])
+    assert received.startswith(payload[:1024])
+    assert len(received) >= len(payload)
+
+    await client.stop()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_server_connection_ids_are_unique_across_reconnects(recording_event_handler) -> None:
+    port = get_unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+    try:
+        ids: set[str] = set()
+        for _ in range(3):
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            await wait_for_condition(lambda: len(server.connections) == 1, timeout_seconds=1.0)
+            ids.add(server.connections[0].connection_id)
+            writer.close()
+            await writer.wait_closed()
+            await reader.read(1)
+            await wait_for_condition(lambda: len(server.connections) == 0, timeout_seconds=1.0)
+
+        assert len(ids) == 3
+        assert all(connection_id.startswith("tcp/server/127.0.0.1/") for connection_id in ids)
+    finally:
+        await server.stop()

--- a/tests/integration/test_tcp_client_server.py
+++ b/tests/integration/test_tcp_client_server.py
@@ -357,7 +357,7 @@ async def test_server_broadcast_handles_concurrent_client_disconnect(
 
     stop_task = asyncio.create_task(disconnecting_client.stop())
     await server.broadcast(b"race-broadcast")
-    await stop_task
+    _ = await stop_task
 
     await wait_for_condition(
         lambda: (

--- a/tests/integration/test_udp_transport.py
+++ b/tests/integration/test_udp_transport.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.api.udp import UdpSenderSettings
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+from tests.helpers import wait_for_condition
+
+
+def get_unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_udp_sender_receiver_roundtrip(recording_event_handler) -> None:
+    port = get_unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=recording_event_handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+
+    await receiver.start()
+    try:
+        await sender.send(b"udp-test")
+        await wait_for_condition(
+            lambda: any(
+                event.data == b"udp-test" for event in recording_event_handler.received_events
+            ),
+            timeout_seconds=2.0,
+        )
+        event = next(
+            event for event in recording_event_handler.received_events if event.data == b"udp-test"
+        )
+        assert event.remote_host in ("127.0.0.1", "::ffff:127.0.0.1")
+        assert isinstance(event.remote_port, int)
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_udp_receiver_repeated_sends_and_stop_idempotence(recording_event_handler) -> None:
+    port = get_unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=recording_event_handler,
+    )
+    sender = AsyncioUdpSender(settings=UdpSenderSettings())
+
+    await receiver.start()
+    try:
+        for payload in (b"one", b"two", b"three"):
+            await sender.send(payload, host="127.0.0.1", port=port)
+
+        await wait_for_condition(
+            lambda: (
+                sum(
+                    1
+                    for e in recording_event_handler.received_events
+                    if e.data in {b"one", b"two", b"three"}
+                )
+                >= 3
+            ),
+            timeout_seconds=2.0,
+        )
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    closed_count = len(recording_event_handler.closed_events)
+    assert recording_event_handler.closed_events[-1].previous_state == ConnectionState.CONNECTED
+    assert recording_event_handler.closed_events[-1].metadata is not None
+    await receiver.stop()
+    assert len(recording_event_handler.closed_events) == closed_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_udp_broadcast_send_and_receive(recording_event_handler) -> None:
+    port = get_unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="0.0.0.0", port=port, enable_broadcast=True),
+        event_handler=recording_event_handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="255.255.255.255", default_port=port, enable_broadcast=True
+        )
+    )
+
+    await receiver.start()
+    try:
+        try:
+            await sender.send(b"broadcast-test")
+        except OSError as error:
+            if error.errno in (101, 13):
+                pytest.skip(f"Broadcast send is unavailable in this environment: {error}.")
+            raise
+        try:
+            await wait_for_condition(
+                lambda: any(
+                    event.data == b"broadcast-test"
+                    for event in recording_event_handler.received_events
+                ),
+                timeout_seconds=1.5,
+            )
+        except TimeoutError:
+            pytest.skip("Broadcast loopback delivery is unavailable in this environment.")
+    finally:
+        await sender.stop()
+        await receiver.stop()

--- a/tests/internal_asyncio_impl_refs.py
+++ b/tests/internal_asyncio_impl_refs.py
@@ -1,0 +1,41 @@
+"""
+Test-local indirection for unstable asyncio implementation symbols.
+
+This keeps brittle internal import paths centralized in one test utility module.
+"""
+
+from aionetx.implementations.asyncio_impl.identifier_utils import (
+    multicast_receiver_component_id,
+    tcp_client_component_id,
+    tcp_client_connection_id,
+    tcp_server_component_id,
+    tcp_server_connection_id,
+    udp_receiver_component_id,
+)
+from aionetx.implementations.asyncio_impl.lifecycle_internal import (
+    LifecycleRole,
+    apply_stopped_transition_if_stopping,
+    apply_stopping_transition_if_active,
+    assert_legal_lifecycle_transition,
+)
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    ReconnectBackoff,
+    WarningRateLimiter,
+    validate_heartbeat_provider,
+)
+
+__all__ = (
+    "LifecycleRole",
+    "ReconnectBackoff",
+    "WarningRateLimiter",
+    "apply_stopped_transition_if_stopping",
+    "apply_stopping_transition_if_active",
+    "assert_legal_lifecycle_transition",
+    "multicast_receiver_component_id",
+    "tcp_client_component_id",
+    "tcp_client_connection_id",
+    "tcp_server_component_id",
+    "tcp_server_connection_id",
+    "udp_receiver_component_id",
+    "validate_heartbeat_provider",
+)

--- a/tests/unit/test_api_symbol_sources.py
+++ b/tests/unit/test_api_symbol_sources.py
@@ -1,0 +1,88 @@
+"""
+Curated API symbol-source checks for the merge-blocking symbol gate.
+
+These tests stay intentionally small. They verify that the curated root and
+``aionetx.api`` surfaces are sourced from their dedicated grouping modules
+instead of encouraging deep-module imports.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aionetx
+import aionetx.api as api
+
+
+def test_api_symbol_root_public_api_matches_dunder_all() -> None:
+    assert aionetx.PUBLIC_API == aionetx.__all__
+
+
+def test_api_symbol_api_public_api_matches_dunder_all() -> None:
+    assert api.PUBLIC_API == api.__all__
+
+
+def test_api_symbol_root_curated_exports_come_from_grouping_modules() -> None:
+    grouped_sources = {
+        "AsyncioNetworkFactory": "aionetx.factories",
+        "BaseNetworkEventHandler": "aionetx.api",
+        "BytesReceivedEvent": "aionetx.api",
+        "ComponentLifecycleState": "aionetx.api",
+        "EventDeliverySettings": "aionetx.api",
+        "HeartbeatConfigurationError": "aionetx.api",
+        "HeartbeatProviderProtocol": "aionetx.api",
+        "MulticastReceiverSettings": "aionetx.api",
+        "NetworkEvent": "aionetx.api",
+        "TcpHeartbeatSettings": "aionetx.api",
+        "TcpReconnectSettings": "aionetx.api",
+        "TcpClientSettings": "aionetx.api",
+        "TcpServerSettings": "aionetx.api",
+        "UdpReceiverSettings": "aionetx.api",
+        "UdpSenderSettings": "aionetx.api",
+    }
+
+    for symbol_name, expected_module in grouped_sources.items():
+        grouped_module = importlib.import_module(expected_module)
+        assert getattr(aionetx, symbol_name) is getattr(grouped_module, symbol_name), symbol_name
+
+
+def test_api_symbol_api_curated_exports_come_from_grouping_modules() -> None:
+    grouped_sources = {
+        "BaseNetworkEventHandler": "aionetx.api.events",
+        "BytesReceivedEvent": "aionetx.api.events",
+        "ComponentLifecycleChangedEvent": "aionetx.api.events",
+        "ConnectionClosedError": "aionetx.api.errors",
+        "ConnectionClosedEvent": "aionetx.api.events",
+        "ConnectionMetadata": "aionetx.api.lifecycle",
+        "ConnectionOpenedEvent": "aionetx.api.events",
+        "ConnectionProtocol": "aionetx.api.protocols",
+        "ConnectionRole": "aionetx.api.lifecycle",
+        "ConnectionState": "aionetx.api.lifecycle",
+        "ErrorPolicy": "aionetx.api.policies",
+        "EventDeliverySettings": "aionetx.api.policies",
+        "HandlerFailurePolicyStopEvent": "aionetx.api.events",
+        "HeartbeatProviderProtocol": "aionetx.api.protocols",
+        "HeartbeatResult": "aionetx.api.heartbeat",
+        "NetworkConfigurationError": "aionetx.api.errors",
+        "MulticastReceiverProtocol": "aionetx.api.protocols",
+        "MulticastReceiverSettings": "aionetx.api.settings",
+        "NetworkFactory": "aionetx.api.protocols",
+        "NetworkErrorEvent": "aionetx.api.events",
+        "NetworkEvent": "aionetx.api.events",
+        "NetworkLayerError": "aionetx.api.errors",
+        "NetworkRuntimeError": "aionetx.api.errors",
+        "ReconnectScheduledEvent": "aionetx.api.events",
+        "TcpClientProtocol": "aionetx.api.protocols",
+        "TcpClientSettings": "aionetx.api.settings",
+        "TcpServerProtocol": "aionetx.api.protocols",
+        "TcpServerSettings": "aionetx.api.settings",
+        "TypedEventRouter": "aionetx.api.typed_event_router",
+        "UdpReceiverProtocol": "aionetx.api.protocols",
+        "UdpReceiverSettings": "aionetx.api.settings",
+        "UdpSenderProtocol": "aionetx.api.protocols",
+        "UdpSenderSettings": "aionetx.api.settings",
+    }
+
+    for symbol_name, expected_module in grouped_sources.items():
+        grouped_module = importlib.import_module(expected_module)
+        assert getattr(api, symbol_name) is getattr(grouped_module, symbol_name), symbol_name

--- a/tests/unit/test_assert_integration_semantic_shard_script.py
+++ b/tests/unit/test_assert_integration_semantic_shard_script.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "ci" / "assert_integration_semantic_shard.py"
+)
+SCRIPT_GLOBALS = runpy.run_path(str(SCRIPT_PATH))
+
+_load_marked_tests = SCRIPT_GLOBALS["_load_marked_tests"]
+
+
+def test_load_marked_tests_includes_top_level_functions(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_top_level.py"
+    test_file.write_text(
+        """
+import pytest
+
+@pytest.mark.integration_semantic
+def test_top_level():
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    assert _load_marked_tests(test_file) == {"test_top_level"}
+
+
+def test_load_marked_tests_includes_test_class_methods(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_class_method.py"
+    test_file.write_text(
+        """
+import pytest
+
+class TestSemanticShard:
+    @pytest.mark.integration_semantic
+    def test_from_class(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+
+    assert _load_marked_tests(test_file) == {"TestSemanticShard::test_from_class"}
+
+
+def test_load_marked_tests_excludes_nested_function_definitions(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_nested.py"
+    test_file.write_text(
+        """
+import pytest
+
+def test_wrapper():
+    @pytest.mark.integration_semantic
+    def test_nested():
+        pass
+
+@pytest.mark.integration_semantic
+def test_visible():
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    assert _load_marked_tests(test_file) == {"test_visible"}
+
+
+def test_load_marked_tests_distinguishes_same_named_methods_across_classes(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_duplicate_method_names.py"
+    test_file.write_text(
+        """
+import pytest
+
+class TestOne:
+    @pytest.mark.integration_semantic
+    def test_contract(self):
+        pass
+
+class TestTwo:
+    @pytest.mark.integration_semantic
+    def test_contract(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+
+    assert _load_marked_tests(test_file) == {
+        "TestOne::test_contract",
+        "TestTwo::test_contract",
+    }

--- a/tests/unit/test_async_context_manager.py
+++ b/tests/unit/test_async_context_manager.py
@@ -23,6 +23,10 @@ class _NoopHandler:
         return None
 
 
+async def _raise_test_error() -> None:
+    raise ValueError("test-error")
+
+
 def _get_unused_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -72,13 +76,9 @@ async def test_tcp_server_async_context_manager_stops_on_exception() -> None:
         settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
         event_handler=_NoopHandler(),
     )
-    try:
+    with pytest.raises(ValueError, match="test-error"):
         async with server:
-            raise ValueError("test-error")
-    except ValueError as error:
-        assert str(error) == "test-error"
-    else:
-        pytest.fail("async context manager body did not raise")
+            await _raise_test_error()
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
 
 

--- a/tests/unit/test_async_context_manager.py
+++ b/tests/unit/test_async_context_manager.py
@@ -1,0 +1,179 @@
+"""Tests for async context manager (__aenter__ / __aexit__) support on all transports."""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.udp import UdpReceiverSettings, UdpSenderSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+class _NoopHandler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        return None
+
+
+def _get_unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _get_unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+# --- TCP Server ---
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_async_context_manager_is_running_inside_block() -> None:
+    """__aenter__ must call start() and the server is RUNNING inside the block."""
+    port = _get_unused_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    async with server as ctx:
+        assert ctx is server
+        assert server.lifecycle_state == ComponentLifecycleState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_async_context_manager_is_stopped_after_block() -> None:
+    """__aexit__ must call stop(); server is STOPPED after leaving the block."""
+    port = _get_unused_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    async with server:
+        pass
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_async_context_manager_stops_on_exception() -> None:
+    """__aexit__ must call stop() even when the body raises."""
+    port = _get_unused_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    with pytest.raises(ValueError, match="test-error"):
+        async with server:
+            raise ValueError("test-error")
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+# --- TCP Client ---
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_async_context_manager_is_running_inside_block() -> None:
+    port = _get_unused_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    await server.start()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_NoopHandler(),
+        )
+        async with client as ctx:
+            assert ctx is client
+            assert client.lifecycle_state == ComponentLifecycleState.RUNNING
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_async_context_manager_is_stopped_after_block() -> None:
+    port = _get_unused_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    await server.start()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_NoopHandler(),
+        )
+        async with client:
+            pass
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    finally:
+        await server.stop()
+
+
+# --- UDP Receiver ---
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_async_context_manager_is_running_inside_block() -> None:
+    port = _get_unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=_NoopHandler(),
+    )
+    async with receiver as ctx:
+        assert ctx is receiver
+        assert receiver.lifecycle_state == ComponentLifecycleState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_async_context_manager_is_stopped_after_block() -> None:
+    port = _get_unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=_NoopHandler(),
+    )
+    async with receiver:
+        pass
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+# --- UDP Sender ---
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_async_context_manager_returns_self() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=_get_unused_udp_port())
+    )
+    async with sender as ctx:
+        assert ctx is sender
+        assert not sender._closed
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_async_context_manager_closes_after_block() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=_get_unused_udp_port())
+    )
+    async with sender:
+        pass
+    assert sender._closed

--- a/tests/unit/test_async_context_manager.py
+++ b/tests/unit/test_async_context_manager.py
@@ -72,9 +72,13 @@ async def test_tcp_server_async_context_manager_stops_on_exception() -> None:
         settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
         event_handler=_NoopHandler(),
     )
-    with pytest.raises(ValueError, match="test-error"):
+    try:
         async with server:
             raise ValueError("test-error")
+    except ValueError as error:
+        assert str(error) == "test-error"
+    else:
+        pytest.fail("async context manager body did not raise")
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
 
 

--- a/tests/unit/test_asyncio_heartbeat_sender.py
+++ b/tests/unit/test_asyncio_heartbeat_sender.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+import logging
+
+import pytest
+
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api._event_registry import NETWORK_EVENT_TYPES
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import wait_for_condition
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.connection_id = "fake"
+        self.role = ConnectionRole.CLIENT
+        self.state = ConnectionState.CONNECTED
+        self.metadata = ConnectionMetadata(connection_id="fake", role=ConnectionRole.CLIENT)
+        self.sent: list[bytes] = []
+
+    @property
+    def is_connected(self) -> bool:
+        return self.state == ConnectionState.CONNECTED
+
+    async def send(self, data: bytes) -> None:
+        self.sent.append(bytes(data))
+
+    async def close(self) -> None:
+        self.state = ConnectionState.CLOSED
+
+
+class ToggleHeartbeatProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        self.calls += 1
+        if self.calls % 2 == 0:
+            return HeartbeatResult(should_send=False)
+        return HeartbeatResult(
+            should_send=True, payload=f"hb:{request.connection_id}:{self.calls}".encode()
+        )
+
+
+class AlwaysSendHeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload=f"hb:{request.connection_id}".encode())
+
+
+class FailingHeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        raise RuntimeError("failed")
+
+
+class InvalidResultHeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> str:
+        return "not-a-heartbeat-result"
+
+
+class InvalidPayloadHeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload="bad-payload")  # type: ignore[arg-type]
+
+
+class FailingSendConnection(FakeConnection):
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_calls = 0
+
+    async def send(self, data: bytes) -> None:
+        self.send_calls += 1
+        raise RuntimeError("send-failed")
+
+
+def make_dispatcher(handler) -> AsyncioEventDispatcher:
+    return AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_sends_only_when_requested(recording_event_handler) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        ToggleHeartbeatProvider(),
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: len(sender._connection.sent) >= 2, timeout_seconds=1.0)
+    await sender.stop()
+    await dispatcher.stop()
+    assert sender._connection.sent
+    assert recording_event_handler.events == []
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_start_and_stop_are_idempotent(recording_event_handler) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+        ToggleHeartbeatProvider(),
+        dispatcher,
+    )
+
+    await sender.start()
+    first_task = sender._task  # type: ignore[attr-defined]
+    await sender.start()
+
+    assert sender.is_running is True
+    assert sender._task is first_task  # type: ignore[attr-defined]
+
+    await sender.stop()
+    await sender.stop()
+    await dispatcher.stop()
+
+    assert sender.is_running is False
+    assert sender._task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_exits_when_connection_is_no_longer_connected(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = FakeConnection()
+    connection.state = ConnectionState.CLOSED
+    sender = AsyncioHeartbeatSender(
+        connection,
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        ToggleHeartbeatProvider(),
+        dispatcher,
+    )
+
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+
+    assert connection.sent == []
+    assert recording_event_handler.events == []
+
+
+def test_network_event_taxonomy_has_no_heartbeat_activity_events() -> None:
+    heartbeat_named_events = [
+        event_type.__name__
+        for event_type in NETWORK_EVENT_TYPES
+        if "heartbeat" in event_type.__name__.lower()
+    ]
+    assert heartbeat_named_events == []
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_error_when_provider_fails(recording_event_handler) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        FailingHeartbeatProvider(),
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+    assert recording_event_handler.error_events
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_error_for_invalid_result_type(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        InvalidResultHeartbeatProvider(),  # type: ignore[arg-type]
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1], NetworkErrorEvent)
+    assert isinstance(recording_event_handler.error_events[-1].error, TypeError)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_error_for_invalid_payload_type(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        InvalidPayloadHeartbeatProvider(),  # type: ignore[arg-type]
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1].error, TypeError)
+
+
+def test_heartbeat_sender_requires_enabled_settings(recording_event_handler) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    with pytest.raises(ValueError, match="requires TcpHeartbeatSettings.enabled=True"):
+        AsyncioHeartbeatSender(
+            FakeConnection(),
+            TcpHeartbeatSettings(enabled=False, interval_seconds=1.0),
+            ToggleHeartbeatProvider(),
+            dispatcher,
+        )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_error_and_stops_when_connection_send_fails(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = FailingSendConnection()
+    sender = AsyncioHeartbeatSender(
+        connection,
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        AlwaysSendHeartbeatProvider(),
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+
+    assert connection.send_calls == 1
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1].error, RuntimeError)

--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -1,0 +1,330 @@
+"""
+Unit tests for multicast receiver startup rollback and cleanup.
+
+Multicast setup has several OS-dependent failure points, so this file focuses
+on deterministic cleanup when bind, join, receive-loop, or stop paths fail.
+The goal is to keep lifecycle events and socket teardown coherent even when
+the environment refuses multicast operations.
+"""
+
+from __future__ import annotations
+
+import socket
+import asyncio
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
+    AsyncioMulticastReceiver,
+)
+from aionetx.implementations.asyncio_impl import asyncio_multicast_receiver as multicast_module
+
+
+class NoopHandler:
+    async def on_event(self, event) -> None:
+        return None
+
+
+class FailOnOpenedHandler:
+    async def on_event(self, event) -> None:
+        if isinstance(event, ConnectionOpenedEvent):
+            raise RuntimeError("boom-on-opened")
+
+
+@pytest.mark.asyncio
+@pytest.mark.multicast
+@pytest.mark.reliability_smoke
+async def test_multicast_start_failure_cleans_dispatcher_and_state(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failing_bind(self: socket.socket, address: tuple[str, int]) -> None:
+        raise OSError("bind-failed")
+
+    monkeypatch.setattr(socket.socket, "bind", failing_bind)
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.1",
+            port=20001,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    with pytest.raises(OSError, match="bind-failed"):
+        await receiver.start()
+
+    lifecycle_states = [
+        event.current
+        for event in awaitable_recording_event_handler.lifecycle_events
+        if event.resource_id == receiver._connection_id  # type: ignore[attr-defined]
+    ]
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert lifecycle_states == [ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPED]
+    assert awaitable_recording_event_handler.closed_events == []
+    await receiver.stop()
+
+
+@pytest.mark.asyncio
+async def test_multicast_join_failure_cleans_up_state(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_setsockopt = socket.socket.setsockopt
+
+    def failing_setsockopt(self: socket.socket, level: int, optname: int, value) -> None:
+        if level == socket.IPPROTO_IP and optname == socket.IP_ADD_MEMBERSHIP:
+            raise OSError("join-failed")
+        return original_setsockopt(self, level, optname, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", failing_setsockopt)
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.1",
+            port=20002,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    with pytest.raises(OSError, match="join-failed"):
+        await receiver.start()
+
+    lifecycle_states = [
+        event.current
+        for event in awaitable_recording_event_handler.lifecycle_events
+        if event.resource_id == receiver._connection_id  # type: ignore[attr-defined]
+    ]
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert lifecycle_states == [ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPED]
+    assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+async def test_multicast_join_failure_rolls_back_without_closed_event(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_setsockopt = socket.socket.setsockopt
+
+    def failing_setsockopt(self: socket.socket, level: int, optname: int, value) -> None:
+        if level == socket.IPPROTO_IP and optname == socket.IP_ADD_MEMBERSHIP:
+            raise OSError("join-failed")
+        return original_setsockopt(self, level, optname, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", failing_setsockopt)
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.10",
+            port=20102,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    with pytest.raises(OSError, match="join-failed"):
+        await receiver.start()
+
+    lifecycle_states = [
+        event.current
+        for event in awaitable_recording_event_handler.lifecycle_events
+        if event.resource_id == receiver._connection_id  # type: ignore[attr-defined]
+    ]
+    assert lifecycle_states == [ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPED]
+    assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.multicast
+async def test_multicast_opened_handler_failure_rolls_back_runtime_resources() -> None:
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.11",
+            port=20111,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=FailOnOpenedHandler(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom-on-opened"):
+        await receiver.start()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_multicast_drop_membership_failure_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original_setsockopt = socket.socket.setsockopt
+
+    def failing_drop_membership(self: socket.socket, level: int, optname: int, value) -> None:
+        if level == socket.IPPROTO_IP and optname == socket.IP_DROP_MEMBERSHIP:
+            raise OSError("drop-failed")
+        return original_setsockopt(self, level, optname, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", failing_drop_membership)
+    caplog.set_level("WARNING")
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.1",
+            port=20003,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=NoopHandler(),
+    )
+
+    await receiver.start()
+    await receiver.stop()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert any("IP_DROP_MEMBERSHIP failure" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_multicast_start_failure_logs_socket_close_cleanup_error(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original_socket_cls = socket.socket
+
+    class _FailingCloseSocket(original_socket_cls):  # type: ignore[misc]
+        def bind(self, address: tuple[str, int]) -> None:
+            raise OSError("bind-failed")
+
+        def close(self) -> None:
+            raise OSError("close-failed")
+
+    monkeypatch.setattr(multicast_module.socket, "socket", _FailingCloseSocket)
+    caplog.set_level("WARNING")
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.20",
+            port=20120,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    with pytest.raises(OSError, match="bind-failed"):
+        await receiver.start()
+
+    assert any(
+        "startup cleanup could not close socket cleanly" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_multicast_receive_loop_runtime_failure_emits_error_and_stops(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingLoop:
+        async def sock_recvfrom(self, _sock: socket.socket, _size: int):
+            raise RuntimeError("recv-failed")
+
+    monkeypatch.setattr(multicast_module.asyncio, "get_running_loop", lambda: _FailingLoop())
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.2",
+            port=20004,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await receiver.start()
+    await asyncio.wait_for(awaitable_recording_event_handler.error_observed.wait(), timeout=1.0)
+    await asyncio.wait_for(awaitable_recording_event_handler.connection_closed.wait(), timeout=1.0)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert len(awaitable_recording_event_handler.closed_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_multicast_receiver_stop_from_starting_state_does_not_emit_closed_event(
+    awaitable_recording_event_handler,
+) -> None:
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.3",
+            port=20005,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+    receiver._runtime.lifecycle_state = ComponentLifecycleState.STARTING  # type: ignore[attr-defined]
+    receiver._runtime.connection_state = ConnectionState.CREATED  # type: ignore[attr-defined]
+
+    await receiver.stop()
+
+    assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+async def test_multicast_receiver_overlapping_stop_calls_publish_one_stop_sequence(
+    awaitable_recording_event_handler,
+) -> None:
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.4",
+            port=20006,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await receiver.start()
+
+    await asyncio.gather(receiver.stop(), receiver.stop())
+
+    stop_relevant_events = [
+        event
+        for event in awaitable_recording_event_handler.events
+        if (
+            isinstance(event, ConnectionClosedEvent)
+            or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            )
+        )
+    ]
+    assert [type(event).__name__ for event in stop_relevant_events] == [
+        "ComponentLifecycleChangedEvent",
+        "ConnectionClosedEvent",
+        "ComponentLifecycleChangedEvent",
+    ]

--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -24,10 +24,13 @@ from aionetx.api.event_delivery_settings import (
     EventHandlerFailurePolicy,
 )
 from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.implementations.asyncio_impl import (
+    _asyncio_datagram_receiver_base as datagram_base_module,
+)
+from aionetx.implementations.asyncio_impl import asyncio_multicast_receiver as multicast_module
 from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
     AsyncioMulticastReceiver,
 )
-from aionetx.implementations.asyncio_impl import asyncio_multicast_receiver as multicast_module
 
 
 class NoopHandler:
@@ -253,7 +256,7 @@ async def test_multicast_receive_loop_runtime_failure_emits_error_and_stops(
         async def sock_recvfrom(self, _sock: socket.socket, _size: int):
             raise RuntimeError("recv-failed")
 
-    monkeypatch.setattr(multicast_module.asyncio, "get_running_loop", lambda: _FailingLoop())
+    monkeypatch.setattr(datagram_base_module.asyncio, "get_running_loop", lambda: _FailingLoop())
 
     receiver = AsyncioMulticastReceiver(
         settings=MulticastReceiverSettings(

--- a/tests/unit/test_asyncio_network_factory.py
+++ b/tests/unit/test_asyncio_network_factory.py
@@ -1,0 +1,339 @@
+"""
+Unit tests for AsyncioNetworkFactory validation and return types.
+
+These tests pin the factory-first onboarding contract: valid settings produce
+the expected transport implementations, invalid settings fail fast, and
+handler or heartbeat-provider requirements are enforced consistently between
+the factory and the direct constructors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.event_delivery_settings import EventDeliverySettings
+from aionetx.api.errors import HeartbeatConfigurationError, InvalidNetworkConfigurationError
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.network_factory import NetworkFactory
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.api.udp import UdpSenderSettings
+from aionetx.factories.asyncio_network_factory import AsyncioNetworkFactory
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import AsyncioMulticastReceiver
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+class _AsyncHandler:
+    async def on_event(self, event) -> None:
+        return None
+
+
+class _SyncHandler:
+    def on_event(self, event) -> None:
+        return None
+
+
+class _AsyncCallableOnEvent:
+    async def __call__(self, event) -> None:
+        return None
+
+
+class _HandlerWithAsyncCallableAttribute:
+    def __init__(self) -> None:
+        self.on_event = _AsyncCallableOnEvent()
+
+
+class _HeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload=b"hb")
+
+
+class _SyncHeartbeatProvider:
+    def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send=True, payload=b"hb")
+
+
+def test_factory_returns_expected_concrete_types() -> None:
+    factory = AsyncioNetworkFactory()
+    handler = _AsyncHandler()
+
+    client = factory.create_tcp_client(
+        TcpClientSettings(
+            host="127.0.0.1", port=12345, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        handler,
+    )
+    server = factory.create_tcp_server(
+        TcpServerSettings(host="127.0.0.1", port=12346, max_connections=64), handler
+    )
+    receiver = factory.create_multicast_receiver(
+        MulticastReceiverSettings(group_ip="239.1.1.1", port=12347),
+        handler,
+    )
+    udp_receiver = factory.create_udp_receiver(
+        UdpReceiverSettings(host="127.0.0.1", port=12348),
+        handler,
+    )
+    udp_sender = factory.create_udp_sender(UdpSenderSettings())
+
+    assert isinstance(client, AsyncioTcpClient)
+    assert isinstance(server, AsyncioTcpServer)
+    assert isinstance(receiver, AsyncioMulticastReceiver)
+    assert isinstance(udp_receiver, AsyncioUdpReceiver)
+    assert isinstance(udp_sender, AsyncioUdpSender)
+
+
+def test_factory_conforms_to_explicit_network_factory_protocol() -> None:
+    factory = AsyncioNetworkFactory()
+
+    assert isinstance(factory, NetworkFactory)
+
+
+def test_factory_requires_heartbeat_provider_when_client_heartbeat_enabled() -> None:
+    factory = AsyncioNetworkFactory()
+    settings = TcpClientSettings(
+        host="127.0.0.1",
+        port=12345,
+        reconnect=TcpReconnectSettings(enabled=False),
+        heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+        event_delivery=EventDeliverySettings(),
+    )
+
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        factory.create_tcp_client(settings=settings, event_handler=_AsyncHandler())
+
+
+def test_factory_requires_heartbeat_provider_when_server_heartbeat_enabled() -> None:
+    factory = AsyncioNetworkFactory()
+    settings = TcpServerSettings(
+        host="127.0.0.1",
+        port=12345,
+        max_connections=64,
+        heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+    )
+
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        factory.create_tcp_server(settings=settings, event_handler=_AsyncHandler())
+
+
+def test_direct_server_constructor_requires_heartbeat_provider_when_server_heartbeat_enabled() -> (
+    None
+):
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        AsyncioTcpServer(
+            settings=TcpServerSettings(
+                host="127.0.0.1",
+                port=12345,
+                max_connections=64,
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+            ),
+            event_handler=_AsyncHandler(),
+        )
+
+
+def test_factory_rejects_non_async_heartbeat_provider() -> None:
+    factory = AsyncioNetworkFactory()
+    with pytest.raises(TypeError, match="create_heartbeat"):
+        factory.create_tcp_server(
+            settings=TcpServerSettings(
+                host="127.0.0.1",
+                port=12345,
+                max_connections=64,
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+            ),
+            event_handler=_AsyncHandler(),
+            heartbeat_provider=_SyncHeartbeatProvider(),  # type: ignore[arg-type]
+        )
+
+
+def test_direct_client_constructor_rejects_non_async_heartbeat_provider() -> None:
+    with pytest.raises(TypeError, match="create_heartbeat"):
+        AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=12345,
+                reconnect=TcpReconnectSettings(enabled=False),
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+            ),
+            event_handler=_AsyncHandler(),
+            heartbeat_provider=_SyncHeartbeatProvider(),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "factory_method,kwargs",
+    [
+        (
+            "create_tcp_client",
+            {
+                "settings": TcpClientSettings(
+                    host="127.0.0.1", port=12345, reconnect=TcpReconnectSettings(enabled=False)
+                ),
+                "heartbeat_provider": None,
+            },
+        ),
+        (
+            "create_tcp_server",
+            {
+                "settings": TcpServerSettings(host="127.0.0.1", port=12345, max_connections=64),
+                "heartbeat_provider": None,
+            },
+        ),
+        (
+            "create_multicast_receiver",
+            {"settings": MulticastReceiverSettings(group_ip="239.1.1.1", port=12345)},
+        ),
+        (
+            "create_udp_receiver",
+            {"settings": UdpReceiverSettings(host="127.0.0.1", port=12345)},
+        ),
+    ],
+)
+def test_factory_rejects_non_async_event_handler(
+    factory_method: str, kwargs: dict[str, object]
+) -> None:
+    factory = AsyncioNetworkFactory()
+    method = getattr(factory, factory_method)
+
+    with pytest.raises(TypeError, match="on_event"):
+        method(event_handler=_SyncHandler(), **kwargs)
+
+
+def test_factory_accepts_heartbeat_provider_when_required() -> None:
+    factory = AsyncioNetworkFactory()
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+            reconnect=TcpReconnectSettings(enabled=False),
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+        ),
+        event_handler=_AsyncHandler(),
+        heartbeat_provider=_HeartbeatProvider(),
+    )
+    assert isinstance(client, AsyncioTcpClient)
+
+
+def test_factory_accepts_async_callable_object_for_on_event() -> None:
+    factory = AsyncioNetworkFactory()
+    client = factory.create_tcp_client(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_HandlerWithAsyncCallableAttribute(),  # type: ignore[arg-type]
+    )
+    assert isinstance(client, AsyncioTcpClient)
+
+
+@pytest.mark.parametrize(
+    "constructor,kwargs",
+    [
+        (
+            AsyncioTcpClient,
+            {
+                "settings": TcpClientSettings(
+                    host="127.0.0.1", port=12345, reconnect=TcpReconnectSettings(enabled=False)
+                ),
+            },
+        ),
+        (
+            AsyncioTcpServer,
+            {
+                "settings": TcpServerSettings(host="127.0.0.1", port=12345, max_connections=64),
+            },
+        ),
+        (
+            AsyncioMulticastReceiver,
+            {
+                "settings": MulticastReceiverSettings(group_ip="239.1.1.1", port=12345),
+            },
+        ),
+        (
+            AsyncioUdpReceiver,
+            {
+                "settings": UdpReceiverSettings(host="127.0.0.1", port=12345),
+            },
+        ),
+    ],
+)
+def test_direct_constructor_matches_factory_event_handler_validation(
+    constructor: object,
+    kwargs: dict[str, object],
+) -> None:
+    factory = AsyncioNetworkFactory()
+
+    with pytest.raises(TypeError, match="on_event"):
+        constructor(event_handler=_SyncHandler(), **kwargs)  # type: ignore[misc]
+
+    factory_method_by_constructor = {
+        AsyncioTcpClient: factory.create_tcp_client,
+        AsyncioTcpServer: factory.create_tcp_server,
+        AsyncioMulticastReceiver: factory.create_multicast_receiver,
+        AsyncioUdpReceiver: factory.create_udp_receiver,
+    }
+    method = factory_method_by_constructor[constructor]  # type: ignore[index]
+    with pytest.raises(TypeError, match="on_event"):
+        method(event_handler=_SyncHandler(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("factory_method", "kwargs_factory", "match"),
+    [
+        (
+            "create_tcp_client",
+            lambda: {
+                "settings": TcpClientSettings(host="", port=1234),
+                "event_handler": _AsyncHandler(),
+            },
+            "host",
+        ),
+        (
+            "create_tcp_server",
+            lambda: {
+                "settings": TcpServerSettings(host="127.0.0.1", port=0, max_connections=64),
+                "event_handler": _AsyncHandler(),
+            },
+            "port",
+        ),
+        (
+            "create_multicast_receiver",
+            lambda: {
+                "settings": MulticastReceiverSettings(group_ip="", port=5000),
+                "event_handler": _AsyncHandler(),
+            },
+            "group_ip",
+        ),
+        (
+            "create_udp_receiver",
+            lambda: {
+                "settings": UdpReceiverSettings(host="", port=5000),
+                "event_handler": _AsyncHandler(),
+            },
+            "host",
+        ),
+        (
+            "create_udp_sender",
+            lambda: {
+                "settings": UdpSenderSettings(default_port=70000),
+            },
+            "default_port",
+        ),
+    ],
+)
+def test_factory_validates_settings_at_creation_time(
+    factory_method: str, kwargs_factory, match: str
+) -> None:
+    factory = AsyncioNetworkFactory()
+    method = getattr(factory, factory_method)
+    with pytest.raises(InvalidNetworkConfigurationError, match=match):
+        method(**kwargs_factory())

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -1,0 +1,1027 @@
+"""
+Internal-contract tests for AsyncioTcpClient supervision.
+
+These tests cover the coordination code that turns low-level asyncio failures
+into stable client behavior: runtime-state ownership, reconnect planning,
+keepalive warnings, ordered teardown, and emitted-event sequencing. They reach
+into private helpers on purpose because regressions in this layer quickly turn
+into user-visible reconnect bugs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.reconnect_events import ReconnectScheduledEvent
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.implementations.asyncio_impl import asyncio_tcp_client as tcp_client_module
+from aionetx.implementations.asyncio_impl import (
+    tcp_client_supervision as tcp_client_supervision_module,
+)
+from aionetx.implementations.asyncio_impl import _tcp_client_connect as tcp_client_connect_module
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from tests.internal_asyncio_impl_refs import WarningRateLimiter
+
+
+class _SocketThatFailsKeepalive:
+    """Socket double that always fails keepalive configuration."""
+
+    def setsockopt(self, level: int, optname: int, value: int) -> None:
+        raise OSError("keepalive-not-supported")
+
+
+class _WriterWithPeerInfo:
+    """Writer stub that exposes peer info and a failing socket object."""
+
+    def __init__(self, peer_info: object) -> None:
+        self._peer_info = peer_info
+
+    def get_extra_info(self, key: str):
+        if key == "peername":
+            return self._peer_info
+        if key == "socket":
+            return _SocketThatFailsKeepalive()
+        return None
+
+
+class _WriterProxy:
+    """Wrap a real writer while overriding metadata used by client internals."""
+
+    def __init__(
+        self, writer: asyncio.StreamWriter, *, peer_info: object, socket_obj: object
+    ) -> None:
+        self._writer = writer
+        self._peer_info = peer_info
+        self._socket_obj = socket_obj
+
+    def get_extra_info(self, key: str, default=None):
+        if key == "peername":
+            return self._peer_info
+        if key == "socket":
+            return self._socket_obj
+        return self._writer.get_extra_info(key, default)
+
+    def __getattr__(self, name: str):
+        return getattr(self._writer, name)
+
+
+def _track_emitted_event_order(recording_event_handler, call_order: list[str]) -> None:
+    """Record emitted event types while preserving the original handler behavior."""
+
+    original_on_event = recording_event_handler.on_event
+
+    async def _on_event(event) -> None:
+        call_order.append(type(event).__name__)
+        await original_on_event(event)
+
+    recording_event_handler.on_event = _on_event  # type: ignore[method-assign]
+
+
+class _FailOnClientLifecycleState:
+    def __init__(self, state: ComponentLifecycleState) -> None:
+        self._state = state
+
+    async def on_event(self, event) -> None:
+        if isinstance(event, ComponentLifecycleChangedEvent) and event.current == self._state:
+            raise RuntimeError(f"client-{self._state.value}-publication-failed")
+
+
+# Runtime-state ownership and basic supervision wiring.
+@pytest.mark.asyncio
+async def test_client_runtime_state_groups_mutable_supervision_fields(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45678, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    assert client._runtime.running is False  # type: ignore[attr-defined]
+    assert client._runtime.connection is None  # type: ignore[attr-defined]
+    assert client._runtime.attempt_counter == 0  # type: ignore[attr-defined]
+
+    client._running = True  # type: ignore[attr-defined]
+    client._attempt_counter = 4  # type: ignore[attr-defined]
+    client._notify_status_changed()  # type: ignore[attr-defined]
+
+    assert client._runtime.running is True  # type: ignore[attr-defined]
+    assert client._runtime.attempt_counter == 4  # type: ignore[attr-defined]
+    assert client._runtime.status_version == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_client_connection_closed_event_is_owned_by_session_runtime_state(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45688, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    assert client._connection_closed_event is client._runtime.connection_closed_event  # type: ignore[attr-defined]
+    assert client._connection_closed_event.is_set() is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_client_connection_uses_fallback_id_when_peer_info_invalid_and_missing_socket(
+    recording_event_handler,
+) -> None:
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await reader.read(1)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+
+        async def _open_connection(*, host: str, port: int):
+            reader, writer = await asyncio.open_connection(host, port)
+            return reader, _WriterProxy(writer, peer_info="invalid-peer-info", socket_obj=None)
+
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1", port=port, reconnect=TcpReconnectSettings(enabled=False)
+            ),
+            event_handler=recording_event_handler,
+            connection_opener=_open_connection,
+        )
+        await client.start()
+        try:
+            connection = await client.wait_until_connected(timeout_seconds=2.0)
+            assert connection.connection_id == f"tcp/client/127.0.0.1/{port}/connection"
+        finally:
+            await client.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failing_state", [ComponentLifecycleState.STARTING, ComponentLifecycleState.RUNNING]
+)
+async def test_client_start_lifecycle_publication_failure_rolls_back_supervision(
+    failing_state: ComponentLifecycleState,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45693,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=_FailOnClientLifecycleState(failing_state),
+    )
+
+    with pytest.raises(RuntimeError, match=f"client-{failing_state.value}-publication-failed"):
+        await client.start()
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client._supervisor_task is None  # type: ignore[attr-defined]
+    assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    await client.stop()
+
+
+# Keepalive warnings and active-resource teardown helpers.
+@pytest.mark.asyncio
+async def test_client_keepalive_warning_is_rate_limited(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Exercise the keepalive helper directly so warning-rate behavior stays
+    # pinned even if the surrounding supervisor wiring changes.
+    writer = _WriterWithPeerInfo(("127.0.0.1", 1111))
+
+    monkeypatch.setattr(
+        tcp_client_connect_module, "_warning_limiter", WarningRateLimiter(interval_seconds=60.0)
+    )
+
+    import logging as _logging
+
+    _logger = _logging.getLogger("test_keepalive")
+    with caplog.at_level(logging.WARNING):
+        tcp_client_connect_module._apply_tcp_keepalive(
+            writer=writer,  # type: ignore[arg-type]
+            component_id="tcp/client/127.0.0.1/34567",
+            logger=_logger,
+        )
+        tcp_client_connect_module._apply_tcp_keepalive(
+            writer=writer,  # type: ignore[arg-type]
+            component_id="tcp/client/127.0.0.1/34567",
+            logger=_logger,
+        )
+
+    warning_messages = [
+        message
+        for message in caplog.messages
+        if "Failed to enable TCP keepalive on client socket." in message
+    ]
+    assert len(warning_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_client_stop_heartbeat_is_idempotent_for_same_sender(recording_event_handler) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45679, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    class _Sender:
+        def __init__(self) -> None:
+            self.stop_calls = 0
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+
+    sender = _Sender()
+    client._heartbeat_sender = sender  # type: ignore[attr-defined]
+
+    await client._stop_heartbeat_sender()  # type: ignore[attr-defined]
+    await client._stop_heartbeat_sender()  # type: ignore[attr-defined]
+
+    assert sender.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_supervisor_shutdown_resources_stops_heartbeat_before_connection_close(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45680, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    call_order: list[str] = []
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+
+    await client._connection_supervisor._shutdown_active_resources()  # type: ignore[attr-defined]
+
+    assert call_order == ["heartbeat-stop", "connection-close"]
+
+
+@pytest.mark.asyncio
+async def test_client_connect_attempt_clears_cached_last_connect_error_before_new_attempt(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45691,
+            reconnect=TcpReconnectSettings(enabled=True, initial_delay_seconds=0.05),
+        ),
+        event_handler=recording_event_handler,
+    )
+    observed_cached_error: list[object] = []
+    client._last_connect_error = RuntimeError("stale-connect-error")  # type: ignore[attr-defined]
+
+    async def fake_connect_once() -> None:
+        observed_cached_error.append(client._last_connect_error)  # type: ignore[attr-defined]
+
+    client._connect_once = fake_connect_once  # type: ignore[attr-defined,method-assign]
+
+    await client._connection_supervisor._start_connect_attempt()  # type: ignore[attr-defined]
+
+    assert observed_cached_error == [None]
+    assert client._last_connect_error is None  # type: ignore[attr-defined]
+
+
+# Supervisor finalization and lifecycle publication ordering.
+@pytest.mark.asyncio
+async def test_client_supervisor_finalize_emits_terminal_lifecycle_transitions_in_order(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45683, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    call_order: list[str] = []
+    lifecycle_emits: list[str] = []
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    async def fake_emit_lifecycle_event(event) -> None:
+        if event is not None:
+            lifecycle_emits.append(event.current.value)
+
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._emit_lifecycle_event = fake_emit_lifecycle_event  # type: ignore[attr-defined,method-assign]
+
+    await client._connection_supervisor._finalize_supervision()  # type: ignore[attr-defined]
+
+    assert call_order == ["heartbeat-stop", "connection-close"]
+    assert lifecycle_emits == ["stopping", "stopped"]
+
+
+@pytest.mark.asyncio
+async def test_client_supervisor_finalize_stops_dispatcher_when_terminal_publish_fails(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45682,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        return None
+
+    async def fake_close_connection() -> None:
+        return None
+
+    async def fail_terminal_publication(event) -> None:
+        raise RuntimeError("terminal-publish-failed")
+
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._emit_lifecycle_event = fail_terminal_publication  # type: ignore[attr-defined,method-assign]
+
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+    with pytest.raises(RuntimeError, match="terminal-publish-failed"):
+        await client._connection_supervisor._finalize_supervision()  # type: ignore[attr-defined]
+
+    assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_client_supervisor_collect_terminal_events_is_idempotent_under_concurrency(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45694, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+
+    results = await asyncio.gather(
+        client._connection_supervisor._collect_terminal_lifecycle_events(),  # type: ignore[attr-defined]
+        client._connection_supervisor._collect_terminal_lifecycle_events(),  # type: ignore[attr-defined]
+    )
+    emitted_states = [event.current for batch in results for event in batch]
+
+    assert client.lifecycle_state == tcp_client_module.ComponentLifecycleState.STOPPED
+    assert emitted_states.count(tcp_client_module.ComponentLifecycleState.STOPPING) == 1
+    assert emitted_states.count(tcp_client_module.ComponentLifecycleState.STOPPED) == 1
+
+
+@pytest.mark.asyncio
+async def test_client_supervisor_run_cancellation_finalizes_teardown_and_lifecycle_order(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45684, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    call_order: list[str] = []
+    lifecycle_emits: list[str] = []
+
+    async def fake_run_connect_cycle() -> bool:
+        raise asyncio.CancelledError
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    async def fake_emit_lifecycle_event(event) -> None:
+        if event is not None:
+            lifecycle_emits.append(event.current.value)
+
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._connection_supervisor._run_connect_cycle = fake_run_connect_cycle  # type: ignore[attr-defined,method-assign]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._emit_lifecycle_event = fake_emit_lifecycle_event  # type: ignore[attr-defined,method-assign]
+
+    with pytest.raises(asyncio.CancelledError):
+        await client._connection_supervisor.run()  # type: ignore[attr-defined]
+
+    assert call_order == ["heartbeat-stop", "connection-close"]
+    assert lifecycle_emits == ["stopping", "stopped"]
+
+
+# Failure-path ordering, teardown, and reconnect signaling.
+@pytest.mark.asyncio
+async def test_client_supervision_failure_orders_events_before_teardown_and_reschedule(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry failures should publish teardown and reschedule events in a stable order."""
+    call_order: list[str] = []
+    _track_emitted_event_order(recording_event_handler, call_order)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45681,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.05
+            ),
+            error_policy=ErrorPolicy.RETRY,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    async def fake_wait_for_reconnect_delay_or_stop(*, delay_seconds: float) -> bool:
+        call_order.append(f"wait:{delay_seconds}")
+        return True
+
+    client._attempt_counter = 3  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._connection_supervisor._wait_for_reconnect_delay_or_stop = (  # type: ignore[attr-defined,method-assign]
+        fake_wait_for_reconnect_delay_or_stop
+    )
+
+    should_continue = await client._connection_supervisor._handle_connect_cycle_failure(  # type: ignore[attr-defined]
+        RuntimeError("connect-failed")
+    )
+
+    assert should_continue is True
+    assert call_order == [
+        "NetworkErrorEvent",
+        "ReconnectAttemptFailedEvent",
+        "heartbeat-stop",
+        "connection-close",
+        "ReconnectScheduledEvent",
+        "wait:0.05",
+    ]
+    assert call_order.index("ReconnectScheduledEvent") < call_order.index("wait:0.05")
+
+
+@pytest.mark.asyncio
+async def test_client_supervision_failure_cancellation_during_sleep_keeps_prior_ordering(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during backoff must not reorder already-emitted retry signals."""
+    call_order: list[str] = []
+    _track_emitted_event_order(recording_event_handler, call_order)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45682,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.05
+            ),
+            error_policy=ErrorPolicy.RETRY,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    async def fake_wait_for_reconnect_delay_or_stop(*, delay_seconds: float) -> bool:
+        call_order.append(f"wait-cancel:{delay_seconds}")
+        raise asyncio.CancelledError
+
+    client._attempt_counter = 7  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._connection_supervisor._wait_for_reconnect_delay_or_stop = (  # type: ignore[attr-defined,method-assign]
+        fake_wait_for_reconnect_delay_or_stop
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await client._connection_supervisor._handle_connect_cycle_failure(
+            RuntimeError("connect-failed")
+        )  # type: ignore[attr-defined]
+
+    assert call_order == [
+        "NetworkErrorEvent",
+        "ReconnectAttemptFailedEvent",
+        "heartbeat-stop",
+        "connection-close",
+        "ReconnectScheduledEvent",
+        "wait-cancel:0.05",
+    ]
+    assert call_order.index("ReconnectScheduledEvent") < call_order.index("wait-cancel:0.05")
+
+
+@pytest.mark.asyncio
+async def test_client_supervision_failure_with_reconnect_disabled_does_not_reschedule(
+    recording_event_handler,
+) -> None:
+    call_order: list[str] = []
+    _track_emitted_event_order(recording_event_handler, call_order)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45685,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    client._attempt_counter = 5  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+
+    should_continue = await client._connection_supervisor._handle_connect_cycle_failure(
+        RuntimeError("connect-failed")
+    )  # type: ignore[attr-defined]
+
+    assert should_continue is False
+    assert call_order == [
+        "NetworkErrorEvent",
+        "ReconnectAttemptFailedEvent",
+        "heartbeat-stop",
+        "connection-close",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_supervision_failure_ignore_policy_skips_network_error_event(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IGNORE suppresses NetworkErrorEvent but still publishes retry lifecycle signals."""
+    call_order: list[str] = []
+    _track_emitted_event_order(recording_event_handler, call_order)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45686,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.05
+            ),
+            error_policy=ErrorPolicy.IGNORE,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    async def fake_wait_for_reconnect_delay_or_stop(*, delay_seconds: float) -> bool:
+        call_order.append(f"wait:{delay_seconds}")
+        return True
+
+    client._attempt_counter = 9  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    client._connection_supervisor._wait_for_reconnect_delay_or_stop = (  # type: ignore[attr-defined,method-assign]
+        fake_wait_for_reconnect_delay_or_stop
+    )
+
+    should_continue = await client._connection_supervisor._handle_connect_cycle_failure(
+        RuntimeError("connect-failed")
+    )  # type: ignore[attr-defined]
+
+    assert should_continue is True
+    assert call_order == [
+        "ReconnectAttemptFailedEvent",
+        "heartbeat-stop",
+        "connection-close",
+        "ReconnectScheduledEvent",
+        "wait:0.05",
+    ]
+    assert call_order.index("ReconnectScheduledEvent") < call_order.index("wait:0.05")
+
+
+# Reconnect-plan validation and wait coordination.
+@pytest.mark.asyncio
+async def test_reconnect_plan_requires_delay_when_reconnect_enabled() -> None:
+    with pytest.raises(ValueError, match="Reconnect plan delay must be set"):
+        tcp_client_supervision_module._ReconnectPlan(should_reconnect=True, delay_seconds=None)
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_without_reconnect_does_not_schedule_sleep(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45687,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    client._running = True  # type: ignore[attr-defined]
+
+    should_continue = await client._connection_supervisor._schedule_reconnect_after_disconnect()  # type: ignore[attr-defined]
+
+    assert should_continue is False
+
+
+@pytest.mark.asyncio
+async def test_client_supervision_failure_stop_during_reconnect_scheduled_skips_sleep(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_order: list[str] = []
+    _track_emitted_event_order(recording_event_handler, call_order)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45688,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.05
+            ),
+            error_policy=ErrorPolicy.RETRY,
+        ),
+        event_handler=recording_event_handler,
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    original_on_event = recording_event_handler.on_event
+
+    async def stop_on_reconnect_scheduled(event) -> None:
+        await original_on_event(event)
+        if isinstance(event, ReconnectScheduledEvent):
+            client._running = False  # type: ignore[attr-defined]
+
+    client._attempt_counter = 11  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    recording_event_handler.on_event = stop_on_reconnect_scheduled  # type: ignore[method-assign]
+
+    should_continue = await client._connection_supervisor._handle_connect_cycle_failure(  # type: ignore[attr-defined]
+        RuntimeError("connect-failed")
+    )
+
+    assert should_continue is False
+    assert call_order == [
+        "NetworkErrorEvent",
+        "ReconnectAttemptFailedEvent",
+        "heartbeat-stop",
+        "connection-close",
+        "ReconnectScheduledEvent",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_reconnect_wait_returns_early_when_stop_changes_status(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45689,
+            reconnect=TcpReconnectSettings(
+                enabled=True, initial_delay_seconds=0.05, max_delay_seconds=0.05
+            ),
+        ),
+        event_handler=recording_event_handler,
+    )
+    client._running = True  # type: ignore[attr-defined]
+
+    async def stop_soon() -> None:
+        await asyncio.sleep(0)
+        client._running = False  # type: ignore[attr-defined]
+        client._notify_status_changed()  # type: ignore[attr-defined]
+
+    stop_task = asyncio.create_task(stop_soon())
+    should_continue = await client._connection_supervisor._wait_for_reconnect_delay_or_stop(  # type: ignore[attr-defined]
+        delay_seconds=10.0
+    )
+    await stop_task
+
+    assert should_continue is False
+
+
+# STOP_COMPONENT ordering when handler failures trigger client shutdown.
+@pytest.mark.asyncio
+async def test_stop_component_policy_stops_heartbeat_before_connection_close() -> None:
+    call_order: list[str] = []
+    observed_events: list[object] = []
+
+    class _RecordingHandler:
+        async def on_event(self, event) -> None:
+            observed_events.append(event)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45690,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=_RecordingHandler(),
+    )
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+        client._connection = None  # type: ignore[attr-defined]
+        client._connection_closed_event.set()  # type: ignore[attr-defined]
+        client._notify_status_changed()  # type: ignore[attr-defined]
+
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+    await client._event_dispatcher._handle_handler_failure(  # type: ignore[attr-defined]
+        error=RuntimeError("stop-component-failure"),
+        triggering_event=ConnectionOpenedEvent(
+            resource_id="tcp/client/127.0.0.1/45690/connection",
+            metadata=ConnectionMetadata(
+                connection_id="tcp/client/127.0.0.1/45690/connection",
+                role=ConnectionRole.CLIENT,
+            ),
+        ),
+    )
+
+    assert call_order[:2] == ["heartbeat-stop", "connection-close"]
+    assert client.lifecycle_state == tcp_client_module.ComponentLifecycleState.STOPPED
+    assert any(type(event).__name__ == "HandlerFailurePolicyStopEvent" for event in observed_events)
+
+
+@pytest.mark.asyncio
+async def test_stop_component_policy_from_worker_with_full_queue_stops_client() -> None:
+    first_started = asyncio.Event()
+    release_failure = asyncio.Event()
+    stopped = asyncio.Event()
+    observed_events: list[object] = []
+
+    class _FailFirstThenRecord:
+        async def on_event(self, event) -> None:
+            observed_events.append(event)
+            if isinstance(event, ConnectionOpenedEvent):
+                if event.metadata.connection_id.endswith("/first"):
+                    first_started.set()
+                    await release_failure.wait()
+                    raise RuntimeError("boom")
+                if event.metadata.connection_id.endswith("/queued"):
+                    pytest.fail("queued user event was delivered after worker-originated stop")
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45691,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+                backpressure_policy=EventBackpressurePolicy.BLOCK,
+                max_pending_events=1,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=_FailFirstThenRecord(),
+    )
+    client._lifecycle_state = tcp_client_module.ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._running = True  # type: ignore[attr-defined]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+
+    await client._event_dispatcher.emit(  # type: ignore[attr-defined]
+        ConnectionOpenedEvent(
+            resource_id="tcp/client/127.0.0.1/45691/first",
+            metadata=ConnectionMetadata(
+                connection_id="tcp/client/127.0.0.1/45691/first",
+                role=ConnectionRole.CLIENT,
+            ),
+        )
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await client._event_dispatcher.emit(  # type: ignore[attr-defined]
+        ConnectionOpenedEvent(
+            resource_id="tcp/client/127.0.0.1/45691/queued",
+            metadata=ConnectionMetadata(
+                connection_id="tcp/client/127.0.0.1/45691/queued",
+                role=ConnectionRole.CLIENT,
+            ),
+        )
+    )
+
+    release_failure.set()
+
+    async def _wait_until_stopped() -> None:
+        while client.lifecycle_state != tcp_client_module.ComponentLifecycleState.STOPPED:
+            await asyncio.sleep(0)
+        stopped.set()
+
+    await asyncio.wait_for(_wait_until_stopped(), timeout=1.0)
+    await asyncio.wait_for(client._event_dispatcher.stop(), timeout=1.0)  # type: ignore[attr-defined]
+
+    lifecycle_states = [
+        event.current
+        for event in observed_events
+        if isinstance(event, ComponentLifecycleChangedEvent)
+    ]
+    assert tcp_client_module.ComponentLifecycleState.STOPPING in lifecycle_states
+    assert tcp_client_module.ComponentLifecycleState.STOPPED in lifecycle_states
+    assert any(type(event).__name__ == "HandlerFailurePolicyStopEvent" for event in observed_events)
+    assert stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_client_open_event_failure_closes_partially_started_connection_without_read_loop_leak() -> (
+    None
+):
+    server_connection_opened = asyncio.Event()
+    release_server_connection = asyncio.Event()
+
+    async def _handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        server_connection_opened.set()
+        try:
+            await release_server_connection.wait()
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(_handle_client, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        await asyncio.wait_for(server.start_serving(), timeout=1.0)
+
+        class _FailOnOpenedEvent:
+            async def on_event(self, event) -> None:
+                if isinstance(event, ConnectionOpenedEvent):
+                    raise RuntimeError("boom-on-opened")
+
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                event_delivery=EventDeliverySettings(
+                    dispatch_mode=EventDispatchMode.INLINE,
+                    handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+                ),
+            ),
+            event_handler=_FailOnOpenedEvent(),
+        )
+
+        await client.start()
+        await asyncio.wait_for(server_connection_opened.wait(), timeout=1.0)
+
+        async def _wait_until_stopped() -> None:
+            while client.lifecycle_state != tcp_client_module.ComponentLifecycleState.STOPPED:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(_wait_until_stopped(), timeout=1.0)
+        await client.stop()
+        await asyncio.sleep(0)
+
+        leaked_read_loops = [
+            task.get_name()
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+            and task.get_name().endswith("-read-loop")
+            and task.get_name().startswith(f"tcp/client/127.0.0.1/{port}/connection")
+            and not task.done()
+        ]
+        assert leaked_read_loops == []
+
+        release_server_connection.set()
+
+
+@pytest.mark.asyncio
+async def test_client_supervisor_cancellation_during_connection_start_closes_partial_connection() -> (
+    None
+):
+    server_connection_opened = asyncio.Event()
+    release_server_connection = asyncio.Event()
+
+    async def _handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        server_connection_opened.set()
+        try:
+            await release_server_connection.wait()
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(_handle_client, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        await asyncio.wait_for(server.start_serving(), timeout=1.0)
+
+        class _CancelTaskOnOpenedEvent:
+            async def on_event(self, event) -> None:
+                if isinstance(event, ConnectionOpenedEvent):
+                    task = asyncio.current_task()
+                    assert task is not None
+                    task.cancel()
+                    await asyncio.sleep(0)
+
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                event_delivery=EventDeliverySettings(
+                    dispatch_mode=EventDispatchMode.INLINE,
+                    handler_failure_policy=EventHandlerFailurePolicy.LOG_ONLY,
+                ),
+            ),
+            event_handler=_CancelTaskOnOpenedEvent(),
+        )
+
+        await client.start()
+        await asyncio.wait_for(server_connection_opened.wait(), timeout=1.0)
+
+        async def _wait_until_stopped() -> None:
+            while client.lifecycle_state != tcp_client_module.ComponentLifecycleState.STOPPED:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(_wait_until_stopped(), timeout=1.0)
+        await client.stop()
+        await asyncio.sleep(0)
+
+        leaked_read_loops = [
+            task.get_name()
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+            and task.get_name().endswith("-read-loop")
+            and task.get_name().startswith(f"tcp/client/127.0.0.1/{port}/connection")
+            and not task.done()
+        ]
+        assert leaked_read_loops == []
+
+        release_server_connection.set()

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -36,6 +36,7 @@ from aionetx.implementations.asyncio_impl import (
 )
 from aionetx.implementations.asyncio_impl import _tcp_client_connect as tcp_client_connect_module
 from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
 from tests.internal_asyncio_impl_refs import WarningRateLimiter
 
 
@@ -962,17 +963,18 @@ async def test_client_open_event_failure_closes_partially_started_connection_wit
 
 
 @pytest.mark.asyncio
-async def test_client_supervisor_cancellation_during_connection_start_closes_partial_connection() -> (
-    None
-):
+async def test_client_supervisor_cancellation_during_connection_start_closes_partial_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     server_connection_opened = asyncio.Event()
-    release_server_connection = asyncio.Event()
+    server_saw_eof = asyncio.Event()
+    connection_start_called = asyncio.Event()
 
     async def _handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         server_connection_opened.set()
         try:
-            await release_server_connection.wait()
-            await reader.read()
+            if await reader.read() == b"":
+                server_saw_eof.set()
         finally:
             writer.close()
             await writer.wait_closed()
@@ -982,13 +984,15 @@ async def test_client_supervisor_cancellation_during_connection_start_closes_par
         port = server.sockets[0].getsockname()[1]
         await asyncio.wait_for(server.start_serving(), timeout=1.0)
 
-        class _CancelTaskOnOpenedEvent:
+        async def _cancel_connection_start(self: AsyncioTcpConnection) -> None:
+            connection_start_called.set()
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(AsyncioTcpConnection, "start", _cancel_connection_start)
+
+        class _NoopHandler:
             async def on_event(self, event) -> None:
-                if isinstance(event, ConnectionOpenedEvent):
-                    task = asyncio.current_task()
-                    assert task is not None
-                    task.cancel()
-                    await asyncio.sleep(0)
+                return None
 
         client = AsyncioTcpClient(
             settings=TcpClientSettings(
@@ -1000,11 +1004,13 @@ async def test_client_supervisor_cancellation_during_connection_start_closes_par
                     handler_failure_policy=EventHandlerFailurePolicy.LOG_ONLY,
                 ),
             ),
-            event_handler=_CancelTaskOnOpenedEvent(),
+            event_handler=_NoopHandler(),
         )
 
         await client.start()
+        await asyncio.wait_for(connection_start_called.wait(), timeout=1.0)
         await asyncio.wait_for(server_connection_opened.wait(), timeout=1.0)
+        await asyncio.wait_for(server_saw_eof.wait(), timeout=1.0)
 
         async def _wait_until_stopped() -> None:
             while client.lifecycle_state != tcp_client_module.ComponentLifecycleState.STOPPED:
@@ -1023,5 +1029,3 @@ async def test_client_supervisor_cancellation_during_connection_start_closes_par
             and not task.done()
         ]
         assert leaked_read_loops == []
-
-        release_server_connection.set()

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -764,7 +764,7 @@ async def test_client_reconnect_wait_returns_early_when_stop_changes_status(
     should_continue = await client._connection_supervisor._wait_for_reconnect_delay_or_stop(  # type: ignore[attr-defined]
         delay_seconds=10.0
     )
-    await stop_task
+    _ = await stop_task
 
     assert should_continue is False
 

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -1,0 +1,1119 @@
+"""
+Contract tests for AsyncioTcpConnection.
+
+This module focuses on the per-connection behavior beneath the TCP client and
+server transports: opened/received ordering, send and close semantics,
+metadata exposure, and teardown idempotency under cancellation or concurrency.
+Regressions here would surface in every TCP role, so the close-path edge cases
+are covered in detail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from aionetx.api.errors import ConnectionClosedError
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import wait_for_condition
+
+
+def make_dispatcher(handler) -> AsyncioEventDispatcher:
+    """Construct the default dispatcher used by connection-focused tests."""
+
+    return AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(),
+        logger=logging.getLogger("test"),
+    )
+
+
+async def _no_op_server_handler(
+    _reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    """Accept a connection and close it immediately."""
+
+    writer.close()
+    await writer.wait_closed()
+
+
+# Startup, receive ordering, and basic send behavior.
+@pytest.mark.asyncio
+async def test_tcp_connection_receives_and_closes(recording_event_handler) -> None:
+    received_data: list[bytes] = []
+
+    async def server_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(b"hello")
+        await writer.drain()
+        received_data.append(await reader.read(4096))
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test", ConnectionRole.CLIENT, reader, writer, dispatcher, 4096
+        )
+        await connection.start()
+        await connection.send(b"ping")
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.received_events and received_data),
+            timeout_seconds=1.0,
+        )
+        await connection.close()
+        await dispatcher.stop()
+
+    assert received_data == [b"ping"]
+    assert recording_event_handler.opened_events
+    assert recording_event_handler.received_events
+    assert connection.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_invariant_connection_opened_precedes_bytes_received(
+    recording_event_handler,
+) -> None:
+    async def server_handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(b"hello")
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:ordering", ConnectionRole.CLIENT, reader, writer, dispatcher, 4096
+        )
+        await connection.start()
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.received_events), timeout_seconds=1.0
+        )
+        await connection.close()
+        await dispatcher.stop()
+
+    event_names = [
+        type(event).__name__
+        for event in recording_event_handler.events
+        if isinstance(event, (ConnectionOpenedEvent, BytesReceivedEvent))
+    ]
+    assert event_names[:2] == ["ConnectionOpenedEvent", "BytesReceivedEvent"]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_start_enters_connecting_before_connected(
+    recording_event_handler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen_state_at_task_creation: list[ConnectionState] = []
+
+    original_create_task = asyncio.create_task
+
+    def tracking_create_task(coro, *args, **kwargs):
+        coro_name = getattr(getattr(coro, "cr_code", None), "co_name", "")
+        if coro_name == "_read_loop":
+            seen_state_at_task_creation.append(connection.state)
+        return original_create_task(coro, *args, **kwargs)
+
+    class DummyWriter:
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = AsyncioTcpConnection(
+        "client:test-connecting",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    monkeypatch.setattr(asyncio, "create_task", tracking_create_task)
+
+    await connection.start()
+    await connection.close()
+    await dispatcher.stop()
+
+    assert seen_state_at_task_creation
+    assert seen_state_at_task_creation[0] == ConnectionState.CONNECTING
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_send_on_closed_connection_raises(recording_event_handler) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test", ConnectionRole.CLIENT, reader, writer, dispatcher, 4096
+        )
+        await connection.start()
+        await connection.close()
+        await dispatcher.stop()
+        with pytest.raises(ConnectionClosedError):
+            await connection.send(b"test")
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_send_rejects_non_bytes_payload(recording_event_handler) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test", ConnectionRole.CLIENT, reader, writer, dispatcher, 4096
+        )
+        await connection.start()
+        with pytest.raises(TypeError, match="bytes-like"):
+            await connection.send("bad-payload")  # type: ignore[arg-type]
+        await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_send_surfaces_writer_drain_failure(recording_event_handler) -> None:
+    class DummyWriter:
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            raise ConnectionResetError("peer reset")
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = AsyncioTcpConnection(
+        "client:drain-failure",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+    await connection.start()
+    with pytest.raises(ConnectionResetError, match="peer reset"):
+        await connection.send(b"payload")
+    await connection.close()
+    await dispatcher.stop()
+
+
+# Metadata parsing and read-loop failure handling.
+def test_tcp_connection_metadata_parsing_tolerates_non_integer_port_values(
+    recording_event_handler,
+) -> None:
+    class DummyReader:
+        async def read(self, _size: int) -> bytes:
+            return b""
+
+    class DummyWriter:
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", "not-an-int")
+            if key == "peername":
+                return ("127.0.0.1", object())
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    connection = AsyncioTcpConnection(
+        "client:metadata",
+        ConnectionRole.CLIENT,
+        DummyReader(),  # type: ignore[arg-type]
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+
+    assert connection.metadata.local_port is None
+    assert connection.metadata.remote_port is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_read_loop_error_emits_event_and_closes(
+    recording_event_handler,
+) -> None:
+    class FaultyReader:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        async def read(self, size: int) -> bytes:
+            self._calls += 1
+            if self._calls == 1:
+                return b"first-chunk"
+            raise RuntimeError("reader-crashed")
+
+    class DummyWriter:
+        def __init__(self) -> None:
+            self._closed = False
+
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            self._closed = True
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = AsyncioTcpConnection(
+        "client:faulty-reader",
+        ConnectionRole.CLIENT,
+        FaultyReader(),  # type: ignore[arg-type]
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+    await connection.start()
+
+    await wait_for_condition(
+        lambda: bool(recording_event_handler.received_events), timeout_seconds=1.0
+    )
+    await wait_for_condition(
+        lambda: bool(recording_event_handler.error_events), timeout_seconds=1.0
+    )
+    await wait_for_condition(
+        lambda: connection.state == ConnectionState.CLOSED, timeout_seconds=1.0
+    )
+    await dispatcher.stop()
+
+    assert recording_event_handler.received_events[0].data == b"first-chunk"
+    assert isinstance(recording_event_handler.error_events[-1].error, RuntimeError)
+
+
+# Close-path publication, callback behavior, and idempotency.
+@pytest.mark.asyncio
+async def test_tcp_connection_close_callback_failure_emits_error_and_closed_once(
+    recording_event_handler,
+) -> None:
+    close_callback_calls = 0
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        nonlocal close_callback_calls
+        close_callback_calls += 1
+        raise RuntimeError("close-callback-failed")
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test-close-callback",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+        await connection.close()
+        await dispatcher.stop()
+
+    assert close_callback_calls == 1
+    assert (
+        len(
+            [
+                event
+                for event in recording_event_handler.events
+                if isinstance(event, NetworkErrorEvent)
+            ]
+        )
+        == 1
+    )
+    assert (
+        len(
+            [
+                event
+                for event in recording_event_handler.events
+                if isinstance(event, ConnectionClosedEvent)
+            ]
+        )
+        == 1
+    )
+    assert connection.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_inline_stop_component_on_closed_event_does_not_deadlock() -> (
+    None
+):
+    observed_events: list[object] = []
+    stop_calls = 0
+
+    class FailingOnClosedHandler:
+        async def on_event(self, event) -> None:
+            observed_events.append(event)
+            if isinstance(event, ConnectionClosedEvent):
+                raise RuntimeError("closed-handler-failed")
+
+    settings = EventDeliverySettings(
+        dispatch_mode=EventDispatchMode.INLINE,
+        handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+    )
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=FailingOnClosedHandler(),
+        delivery=settings,
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:no-deadlock", ConnectionRole.CLIENT, reader, writer, dispatcher, 4096
+        )
+
+        async def stop_component() -> None:
+            nonlocal stop_calls
+            stop_calls += 1
+            await connection.close()
+
+        dispatcher._stop_component_callback = stop_component  # type: ignore[attr-defined]
+
+        await connection.start()
+        await asyncio.wait_for(connection.close(), timeout=1.0)
+
+    assert connection.state == ConnectionState.CLOSED
+    assert stop_calls == 1
+    assert any(isinstance(event, ConnectionClosedEvent) for event in observed_events)
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_callback_runs_before_connection_closed_event() -> None:
+    ordering: list[str] = []
+
+    class OrderingHandler:
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                ordering.append("event")
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        ordering.append("callback")
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=OrderingHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:ordering",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+        await connection.close()
+
+    assert ordering == ["callback", "event"]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_retries_closed_event_publication_after_handler_exception() -> (
+    None
+):
+    close_handler_calls = 0
+    callback_calls = 0
+
+    class FailFirstClosedEventHandler:
+        async def on_event(self, event) -> None:
+            nonlocal close_handler_calls
+            if isinstance(event, ConnectionClosedEvent):
+                close_handler_calls += 1
+                if close_handler_calls == 1:
+                    raise RuntimeError("first-close-event-fails")
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=FailFirstClosedEventHandler(),
+        delivery=EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+        ),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:retry-close-publication",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+
+        with pytest.raises(RuntimeError, match="first-close-event-fails"):
+            await connection.close()
+
+        assert connection.state == ConnectionState.CLOSED
+        assert connection._closed_event_published is False  # type: ignore[attr-defined]
+
+        await connection.close()
+
+    assert callback_calls == 1
+    assert close_handler_calls == 2
+    assert connection._closed_event_published is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_handler_cancelled_error_does_not_mark_publication_success() -> (
+    None
+):
+    closed_handler_calls = 0
+
+    class CancelFirstClosedEventHandler:
+        async def on_event(self, event) -> None:
+            nonlocal closed_handler_calls
+            if isinstance(event, ConnectionClosedEvent):
+                closed_handler_calls += 1
+                if closed_handler_calls == 1:
+                    raise asyncio.CancelledError
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=CancelFirstClosedEventHandler(),
+        delivery=EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+        ),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:cancelled-close-event-publication",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+        )
+        await connection.start()
+
+        with pytest.raises(
+            RuntimeError, match="Network event handler raised asyncio.CancelledError"
+        ):
+            await connection.close()
+
+        assert connection.state == ConnectionState.CLOSED
+        assert connection._closed_event_published is False  # type: ignore[attr-defined]
+
+        await connection.close()
+
+    assert closed_handler_calls == 2
+    assert connection._closed_event_published is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_cancellation_during_closed_event_emit_still_emits_once() -> (
+    None
+):
+    closed_event_started = asyncio.Event()
+    allow_closed_event_handler = asyncio.Event()
+    closed_event_count = 0
+
+    class BlockingOnClosedEventHandler:
+        async def on_event(self, event) -> None:
+            nonlocal closed_event_count
+            if isinstance(event, ConnectionClosedEvent):
+                closed_event_count += 1
+                closed_event_started.set()
+                await allow_closed_event_handler.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=BlockingOnClosedEventHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:cancel-during-emit",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+        )
+        await connection.start()
+
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(closed_event_started.wait(), timeout=1.0)
+        close_task.cancel()
+        allow_closed_event_handler.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+    assert connection.state == ConnectionState.CLOSED
+    assert closed_event_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_concurrent_close_waits_for_shared_publication_and_shares_result() -> (
+    None
+):
+    closed_event_started = asyncio.Event()
+    allow_closed_event_handler = asyncio.Event()
+    closed_event_count = 0
+
+    class BlockingClosedHandler:
+        async def on_event(self, event) -> None:
+            nonlocal closed_event_count
+            if isinstance(event, ConnectionClosedEvent):
+                closed_event_count += 1
+                closed_event_started.set()
+                await allow_closed_event_handler.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=BlockingClosedHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        connection = AsyncioTcpConnection(
+            "client:shared-close-publication",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+        )
+        await connection.start()
+
+        close_task_1 = asyncio.create_task(connection.close())
+        await asyncio.wait_for(closed_event_started.wait(), timeout=1.0)
+        close_task_2 = asyncio.create_task(connection.close())
+        await asyncio.sleep(0)
+        assert close_task_2.done() is False
+
+        allow_closed_event_handler.set()
+        await asyncio.gather(close_task_1, close_task_2)
+
+    assert closed_event_count == 1
+    assert connection._closed_event_published is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_concurrent_close_during_callback_waits_for_same_close_task(
+    recording_event_handler,
+) -> None:
+    callback_started = asyncio.Event()
+    release_callback = asyncio.Event()
+    callback_calls = 0
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+        callback_started.set()
+        await release_callback.wait()
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:concurrent-close-callback-phase",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+
+        close_task_1 = asyncio.create_task(connection.close())
+        await asyncio.wait_for(callback_started.wait(), timeout=1.0)
+        close_task_2 = asyncio.create_task(connection.close())
+        await asyncio.sleep(0)
+        assert close_task_2.done() is False
+
+        release_callback.set()
+        await asyncio.gather(close_task_1, close_task_2)
+        await dispatcher.stop()
+
+    assert callback_calls == 1
+    assert len(recording_event_handler.closed_events) == 1
+    assert connection.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_concurrent_close_during_wait_closed_waits_for_same_close_task() -> (
+    None
+):
+    wait_closed_started = asyncio.Event()
+    release_wait_closed = asyncio.Event()
+    close_event_count = 0
+
+    class CountingClosedHandler:
+        async def on_event(self, event) -> None:
+            nonlocal close_event_count
+            if isinstance(event, ConnectionClosedEvent):
+                close_event_count += 1
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=CountingClosedHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        original_wait_closed = writer.wait_closed
+
+        async def blocking_wait_closed() -> None:
+            wait_closed_started.set()
+            await release_wait_closed.wait()
+            await original_wait_closed()
+
+        writer.wait_closed = blocking_wait_closed  # type: ignore[assignment]
+
+        connection = AsyncioTcpConnection(
+            "client:concurrent-close-teardown-phase",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+        )
+        await connection.start()
+
+        close_task_1 = asyncio.create_task(connection.close())
+        await asyncio.wait_for(wait_closed_started.wait(), timeout=1.0)
+        close_task_2 = asyncio.create_task(connection.close())
+        await asyncio.sleep(0)
+        assert close_task_2.done() is False
+
+        release_wait_closed.set()
+        await asyncio.gather(close_task_1, close_task_2)
+
+    assert close_event_count == 1
+    assert connection.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_cancellation_still_reaches_closed_and_emits_event(
+    recording_event_handler,
+) -> None:
+    callback_started = asyncio.Event()
+    allow_callback_return = asyncio.Event()
+    callback_states: list[ConnectionState] = []
+
+    async def on_closed(connection: AsyncioTcpConnection) -> None:
+        callback_states.append(connection.state)
+        callback_started.set()
+        await allow_callback_return.wait()
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:cancel-close",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(callback_started.wait(), timeout=1.0)
+        close_task.cancel()
+        allow_callback_return.set()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        await wait_for_condition(
+            lambda: connection.state == ConnectionState.CLOSED, timeout_seconds=1.0
+        )
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.closed_events), timeout_seconds=1.0
+        )
+        await dispatcher.stop()
+
+    assert callback_states == [ConnectionState.CLOSING]
+    assert len(recording_event_handler.closed_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_is_idempotent_under_concurrency(
+    recording_event_handler,
+) -> None:
+    close_callback_calls = 0
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        nonlocal close_callback_calls
+        close_callback_calls += 1
+
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test-close-idempotent",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+            on_closed_callback=on_closed,
+        )
+        await connection.start()
+        await asyncio.gather(connection.close(), connection.close())
+        await dispatcher.stop()
+
+    assert close_callback_calls == 1
+    assert len(recording_event_handler.closed_events) == 1
+    assert connection.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_invariant_close_return_is_callback_silent(
+    recording_event_handler,
+) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:post-close-silence",
+            ConnectionRole.CLIENT,
+            reader,
+            writer,
+            dispatcher,
+            4096,
+        )
+        await connection.start()
+        await connection.close()
+        event_count_at_close_return = len(recording_event_handler.events)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await dispatcher.stop()
+
+    assert len(recording_event_handler.events) == event_count_at_close_return
+
+
+# Teardown logging for unexpected close-path failures.
+@pytest.mark.asyncio
+async def test_tcp_connection_close_logs_unexpected_read_task_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class NoOpHandler:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    class DummyWriter:
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    async def failing_read_task() -> None:
+        raise RuntimeError("read-task-crashed")
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=NoOpHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:read-task-log",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+    connection._state = ConnectionState.CONNECTED  # type: ignore[attr-defined]
+    connection._read_task = asyncio.create_task(failing_read_task())  # type: ignore[attr-defined]
+    await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR):
+        await connection.close()
+
+    assert connection.state == ConnectionState.CLOSED
+    assert "Unexpected error while awaiting read task during close." in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_close_logs_unexpected_wait_closed_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class NoOpHandler:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    class DummyWriter:
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            raise RuntimeError("wait-closed-crashed")
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=NoOpHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:wait-closed-log",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+    connection._state = ConnectionState.CONNECTED  # type: ignore[attr-defined]
+
+    with caplog.at_level(logging.ERROR):
+        await connection.close()
+
+    assert connection.state == ConnectionState.CLOSED
+    assert "Unexpected error while awaiting writer.wait_closed() during close." in caplog.text
+
+
+class _FakeWriter:
+    """Writer stub that captures bytes-like payloads without a real socket."""
+
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+
+    def get_extra_info(self, key: str):
+        if key == "sockname":
+            return ("127.0.0.1", 20000)
+        if key == "peername":
+            return ("127.0.0.1", 20001)
+        return None
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+# Bytes-like payload support and closed-event metadata coverage.
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [b"raw", bytearray(b"mutable"), memoryview(b"view")])
+async def test_tcp_connection_send_accepts_bytes_like_payloads(
+    recording_event_handler, payload: bytes | bytearray | memoryview
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    writer = _FakeWriter()
+    connection = AsyncioTcpConnection(
+        "client:test-send-bytes-like",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+    )
+    await connection.start()
+    await connection.send(payload)
+    await connection.close()
+    await dispatcher.stop()
+
+    assert writer.writes == [bytes(payload)]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_closed_event_previous_state_for_explicit_close(
+    recording_event_handler,
+) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test-prev-explicit", ConnectionRole.CLIENT, reader, writer, dispatcher, 1024
+        )
+        await connection.start()
+        await connection.close()
+        await dispatcher.stop()
+
+    assert recording_event_handler.closed_events[-1].previous_state == ConnectionState.CONNECTED
+    assert recording_event_handler.closed_events[-1].metadata == connection.metadata
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_closed_event_previous_state_for_eof_close(
+    recording_event_handler,
+) -> None:
+    async def server_handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(b"bye")
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        dispatcher = make_dispatcher(recording_event_handler)
+        await dispatcher.start()
+        connection = AsyncioTcpConnection(
+            "client:test-prev-eof", ConnectionRole.CLIENT, reader, writer, dispatcher, 1024
+        )
+        await connection.start()
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.closed_events), timeout_seconds=1.0
+        )
+        await dispatcher.stop()
+
+    assert recording_event_handler.closed_events[-1].previous_state == ConnectionState.CONNECTED
+    assert recording_event_handler.closed_events[-1].metadata == connection.metadata

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -644,7 +644,7 @@ async def test_tcp_connection_close_cancellation_during_closed_event_emit_still_
         allow_closed_event_handler.set()
 
         with pytest.raises(asyncio.CancelledError):
-            await close_task
+            _ = await close_task
 
     assert connection.state == ConnectionState.CLOSED
     assert closed_event_count == 1
@@ -836,7 +836,7 @@ async def test_tcp_connection_close_cancellation_still_reaches_closed_and_emits_
         close_task.cancel()
         allow_callback_return.set()
         with pytest.raises(asyncio.CancelledError):
-            await close_task
+            _ = await close_task
 
         await wait_for_condition(
             lambda: connection.state == ConnectionState.CLOSED, timeout_seconds=1.0

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -457,7 +457,7 @@ async def test_server_wait_until_running_succeeds(recording_event_handler) -> No
     )
     start_task = asyncio.create_task(server.start())
     await asyncio.wait_for(server.wait_until_running(timeout_seconds=1.0), timeout=1.0)
-    await start_task
+    _ = await start_task
     assert server.lifecycle_state == ComponentLifecycleState.RUNNING
     await server.stop()
 

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -49,6 +49,11 @@ def _unused_tcp_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _is_timeout_error(error: BaseException) -> bool:
+    """Accept timeout classes used by supported Python asyncio versions."""
+    return isinstance(error, (TimeoutError, asyncio.TimeoutError))
+
+
 class _GoodConnection:
     """Connection double that records sent payloads and supports normal close."""
 
@@ -301,7 +306,7 @@ async def test_server_broadcast_timeout_closes_stalled_connection_and_emits_erro
     assert stalled.state == ConnectionState.CLOSED
     assert stalled.close_calls == 1
     assert recording_event_handler.error_events
-    assert isinstance(recording_event_handler.error_events[-1].error, TimeoutError)
+    assert _is_timeout_error(recording_event_handler.error_events[-1].error)
 
 
 @pytest.mark.asyncio
@@ -761,7 +766,7 @@ async def test_server_idle_timeout_closes_inactive_connection_and_emits_timeout_
         interval_seconds=0.01,
     )
 
-    assert isinstance(recording_event_handler.error_events[-1].error, TimeoutError)
+    assert _is_timeout_error(recording_event_handler.error_events[-1].error)
 
     writer.close()
     with contextlib.suppress(Exception):

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -1,0 +1,1002 @@
+"""
+Contract tests for AsyncioTcpServer.
+
+This module covers server-level behavior that user code depends on: broadcast
+semantics, lifecycle ordering, startup rollback, wait-until-running behavior,
+shutdown races, per-connection teardown, and heartbeat-sender management.
+Several tests patch internal state to isolate rare but critical failure paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionRejectedEvent
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.errors import HeartbeatConfigurationError
+from aionetx.api.heartbeat import HeartbeatRequest
+from aionetx.api.heartbeat import HeartbeatResult
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl._tcp_server_helpers import handle_accepted_client
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import wait_for_condition
+
+
+def _unused_tcp_port() -> int:
+    """Reserve an ephemeral localhost port for a test that needs a unique bind target."""
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _GoodConnection:
+    """Connection double that records sent payloads and supports normal close."""
+
+    def __init__(self, connection_id: str) -> None:
+        self.connection_id = connection_id
+        self.role = ConnectionRole.SERVER
+        self.state = ConnectionState.CONNECTED
+        self.metadata = ConnectionMetadata(connection_id=connection_id, role=ConnectionRole.SERVER)
+        self.sent: list[bytes] = []
+
+    @property
+    def is_connected(self) -> bool:
+        return self.state == ConnectionState.CONNECTED
+
+    async def send(self, data: bytes | bytearray | memoryview) -> None:
+        self.sent.append(bytes(data))
+
+    async def close(self) -> None:
+        self.state = ConnectionState.CLOSED
+
+
+class _FailingConnection(_GoodConnection):
+    """Connection double whose send path always fails."""
+
+    async def send(self, data: bytes) -> None:
+        raise RuntimeError(f"send-failed:{self.connection_id}")
+
+
+class _FailingTrackedConnection(_FailingConnection):
+    """Failing sender that records whether broadcast cleanup closed it."""
+
+    def __init__(self, connection_id: str) -> None:
+        super().__init__(connection_id=connection_id)
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        await super().close()
+
+
+class _FakeWriter:
+    """StreamWriter-shaped test double for accepted-connection helper tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def get_extra_info(self, name: str, default=None):
+        if name == "peername":
+            return ("127.0.0.1", 54321)
+        if name == "sockname":
+            return ("127.0.0.1", 12345)
+        return default
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.closed = True
+
+
+class _BlockingConnection(_GoodConnection):
+    """Connection double whose send path can be paused to model a slow client."""
+
+    def __init__(self, connection_id: str) -> None:
+        super().__init__(connection_id=connection_id)
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+        self.close_calls = 0
+
+    async def send(self, data: bytes | bytearray | memoryview) -> None:
+        del data
+        self.send_started.set()
+        await self.release_send.wait()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.state = ConnectionState.CLOSED
+        self.release_send.set()
+
+
+class _NoopHeartbeatProvider:
+    """Heartbeat provider stub that never requests a heartbeat send."""
+
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        del request
+        return HeartbeatResult(should_send=False)
+
+
+class _TeardownConnection(_GoodConnection):
+    """Connection double that can fail during close while tracking attempts."""
+
+    def __init__(self, connection_id: str, *, fail_on_close: bool) -> None:
+        super().__init__(connection_id=connection_id)
+        self.fail_on_close = fail_on_close
+        self.close_attempts = 0
+
+    async def close(self) -> None:
+        self.close_attempts += 1
+        if self.fail_on_close:
+            raise RuntimeError(f"close-failed:{self.connection_id}")
+        await super().close()
+
+
+class _BlockingCloseConnection(_GoodConnection):
+    """Connection double whose close can be held to test stop convergence."""
+
+    def __init__(self, connection_id: str) -> None:
+        super().__init__(connection_id=connection_id)
+        self.close_started = asyncio.Event()
+        self.release_close = asyncio.Event()
+        self.close_attempts = 0
+
+    async def close(self) -> None:
+        self.close_attempts += 1
+        self.close_started.set()
+        await self.release_close.wait()
+        await super().close()
+
+
+class _TeardownSender:
+    """Heartbeat-sender double that can fail during stop for teardown tests."""
+
+    def __init__(self, connection_id: str, *, fail_on_stop: bool) -> None:
+        self.connection_id = connection_id
+        self.fail_on_stop = fail_on_stop
+        self.stop_attempts = 0
+
+    async def stop(self) -> None:
+        self.stop_attempts += 1
+        if self.fail_on_stop:
+            raise RuntimeError(f"stop-failed:{self.connection_id}")
+
+
+# Broadcast semantics and heartbeat preconditions.
+@pytest.mark.asyncio
+async def test_server_broadcast_continues_when_one_connection_send_fails(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12345, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    good = _GoodConnection(connection_id="server:good:1")
+    bad = _FailingConnection(connection_id="server:bad:1")
+    server._connections = {  # type: ignore[attr-defined]
+        bad.connection_id: bad,  # type: ignore[dict-item]
+        good.connection_id: good,  # type: ignore[dict-item]
+    }
+
+    await server.broadcast(bytearray(b"broadcast-test"))
+
+    assert good.sent == [b"broadcast-test"]
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1].error, RuntimeError)
+    assert recording_event_handler.error_events[-1].resource_id == "tcp/server/127.0.0.1/12345"
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_cleanup_survives_error_event_handler_failure() -> None:
+    class RaiseOnNetworkError:
+        async def on_event(self, event) -> None:
+            if isinstance(event, NetworkErrorEvent):
+                raise RuntimeError("error-event-handler-failed")
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12345,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=RaiseOnNetworkError(),
+    )
+    failing = _FailingTrackedConnection(connection_id="server:bad:1")
+    server._connections = {failing.connection_id: failing}  # type: ignore[attr-defined,dict-item]
+
+    await server.broadcast(b"fanout")
+
+    assert failing.close_calls == 1
+    assert failing.state == ConnectionState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_no_connections_is_noop(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12345, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.broadcast(b"noop")
+    assert recording_event_handler.error_events == []
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_uses_bounded_concurrency_so_slow_client_does_not_block_fast_client(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12345,
+            max_connections=64,
+            broadcast_concurrency_limit=2,
+        ),
+        event_handler=recording_event_handler,
+    )
+    slow = _BlockingConnection(connection_id="server:slow:1")
+    fast = _GoodConnection(connection_id="server:fast:1")
+    server._connections = {  # type: ignore[attr-defined]
+        slow.connection_id: slow,  # type: ignore[dict-item]
+        fast.connection_id: fast,  # type: ignore[dict-item]
+    }
+
+    broadcast_task = asyncio.create_task(server.broadcast(b"fanout"))
+    await asyncio.wait_for(slow.send_started.wait(), timeout=1.0)
+    await wait_for_condition(
+        lambda: fast.sent == [b"fanout"],
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    slow.release_send.set()
+    await asyncio.wait_for(broadcast_task, timeout=1.0)
+    assert fast.sent == [b"fanout"]
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_timeout_closes_stalled_connection_and_emits_error(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12345,
+            max_connections=64,
+            broadcast_concurrency_limit=2,
+            broadcast_send_timeout_seconds=0.01,
+        ),
+        event_handler=recording_event_handler,
+    )
+    stalled = _BlockingConnection(connection_id="server:stalled:1")
+    server._connections = {  # type: ignore[attr-defined]
+        stalled.connection_id: stalled,  # type: ignore[dict-item]
+    }
+
+    await server.broadcast(b"fanout")
+
+    assert stalled.state == ConnectionState.CLOSED
+    assert stalled.close_calls == 1
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1].error, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_server_start_raises_when_heartbeat_enabled_without_provider(
+    recording_event_handler,
+) -> None:
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        AsyncioTcpServer(
+            settings=TcpServerSettings(
+                host="127.0.0.1",
+                port=12345,
+                max_connections=64,
+                heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+            ),
+            event_handler=recording_event_handler,
+        )
+
+
+# Lifecycle coordination for start/stop idempotency.
+@pytest.mark.asyncio
+async def test_server_concurrent_start_and_stop_are_safe(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12348, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    await asyncio.gather(server.start(), server.start())
+    assert server.lifecycle_state == ComponentLifecycleState.RUNNING
+
+    await asyncio.gather(server.stop(), server.stop())
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_concurrent_stop_emits_terminal_transitions_once(
+    recording_event_handler,
+) -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    await server.start()
+    await asyncio.gather(server.stop(), server.stop())
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/server/127.0.0.1/{port}"
+    ]
+    assert (
+        sum(1 for event in component_events if event.current == ComponentLifecycleState.STOPPING)
+        == 1
+    )
+    assert (
+        sum(1 for event in component_events if event.current == ComponentLifecycleState.STOPPED)
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_concurrent_stop_waits_for_active_teardown(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12348, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    blocking = _BlockingCloseConnection("server:blocking-close:1")
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    server._connections = {blocking.connection_id: blocking}  # type: ignore[attr-defined,dict-item]
+
+    first_stop = asyncio.create_task(server.stop())
+    await asyncio.wait_for(blocking.close_started.wait(), timeout=1.0)
+    second_stop = asyncio.create_task(server.stop())
+    await asyncio.sleep(0)
+
+    assert second_stop.done() is False
+
+    blocking.release_close.set()
+    await asyncio.gather(first_stop, second_stop)
+
+    assert blocking.close_attempts == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_lifecycle_events_preserve_start_stop_order(recording_event_handler) -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    await server.start()
+    await server.stop()
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/server/127.0.0.1/{port}"
+    ]
+    assert [event.current for event in component_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_server_start_rolls_back_state_and_allows_retry(
+    recording_event_handler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=22345, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    should_fail = True
+    original_start_server = asyncio.start_server
+
+    async def flaky_start_server(*args, **kwargs):
+        nonlocal should_fail
+        if should_fail:
+            should_fail = False
+            raise OSError("start-failed")
+        return await original_start_server(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "start_server", flaky_start_server)
+
+    with pytest.raises(OSError, match="start-failed"):
+        await server.start()
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+    await server.start()
+    assert server.lifecycle_state == ComponentLifecycleState.RUNNING
+    await server.stop()
+
+
+# Wait helpers and bootstrap state reporting.
+@pytest.mark.asyncio
+async def test_server_wait_until_running_succeeds(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    start_task = asyncio.create_task(server.start())
+    await asyncio.wait_for(server.wait_until_running(timeout_seconds=1.0), timeout=1.0)
+    await start_task
+    assert server.lifecycle_state == ComponentLifecycleState.RUNNING
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_wait_until_running_times_out(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await server.wait_until_running(timeout_seconds=0.01, poll_interval_seconds=0.005)
+
+
+@pytest.mark.asyncio
+async def test_server_wait_until_running_reports_stopped_after_failed_start(
+    recording_event_handler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    async def failing_start_server(*args, **kwargs):
+        del args, kwargs
+        raise OSError("bind-failed")
+
+    monkeypatch.setattr(asyncio, "start_server", failing_start_server)
+
+    with pytest.raises(OSError):
+        await server.start()
+
+    with pytest.raises(ConnectionError, match="is stopped"):
+        await server.wait_until_running(timeout_seconds=0.1, poll_interval_seconds=0.01)
+
+
+class _FailOnStartingLifecycle:
+    """Handler that fails on STARTING to probe inline deadlock safety."""
+
+    async def on_event(self, event) -> None:
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STARTING
+        ):
+            raise RuntimeError("lifecycle-handler-failed")
+
+
+class _FailOnStoppingLifecycle:
+    """Handler that fails on STOPPING to probe cleanup-before-propagation."""
+
+    async def on_event(self, event) -> None:
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            raise RuntimeError("stop-publication-failed")
+
+
+# Start/stop races and inline STOP_COMPONENT failure handling.
+@pytest.mark.asyncio
+async def test_server_start_inline_stop_component_handler_failure_does_not_deadlock() -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            max_connections=64,
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=_FailOnStartingLifecycle(),
+    )
+
+    await asyncio.wait_for(server.start(), timeout=1.0)
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_stop_lifecycle_publication_failure_still_releases_listener() -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=_FailOnStoppingLifecycle(),
+    )
+
+    await server.start()
+    with pytest.raises(RuntimeError, match="stop-publication-failed"):
+        await server.stop()
+
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", port))
+
+
+@pytest.mark.asyncio
+async def test_server_stop_component_reentrant_stop_during_stopping_does_not_deadlock() -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            max_connections=64,
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=_FailOnStoppingLifecycle(),
+    )
+
+    await server.start()
+    await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_illegal_lifecycle_transition(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    with pytest.raises(RuntimeError, match="Illegal lifecycle transition"):
+        await server._set_lifecycle_state(ComponentLifecycleState.RUNNING)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_server_stop_during_start_is_safe(
+    recording_event_handler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+
+    original_start_server = asyncio.start_server
+    gate = asyncio.Event()
+    start_server_entered = asyncio.Event()
+
+    async def delayed_start_server(*args, **kwargs):
+        start_server_entered.set()
+        await gate.wait()
+        return await original_start_server(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "start_server", delayed_start_server)
+
+    start_task = asyncio.create_task(server.start())
+    await asyncio.wait_for(start_server_entered.wait(), timeout=1.0)
+    stop_task = asyncio.create_task(server.stop())
+    gate.set()
+    await asyncio.gather(start_task, stop_task)
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_stop_race_does_not_leave_post_stop_connections(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+    connect_started = asyncio.Event()
+
+    async def _open_client() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        connect_started.set()
+        return await asyncio.open_connection("127.0.0.1", server._settings.port)  # type: ignore[attr-defined]
+
+    client_tasks = [asyncio.create_task(_open_client()) for _ in range(40)]
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+    await server.stop()
+    clients = await asyncio.gather(*client_tasks, return_exceptions=True)
+
+    for client in clients:
+        if isinstance(client, Exception):
+            continue
+        _reader, writer = client
+        writer.write(b"ping")
+        with contextlib.suppress(Exception):
+            await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    assert server.connections == ()
+    assert server._connections == {}  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_server_stop_race_does_not_leave_orphaned_heartbeat_senders(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            max_connections=64,
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        ),
+        event_handler=recording_event_handler,
+        heartbeat_provider=_NoopHeartbeatProvider(),
+    )
+    await server.start()
+
+    clients = [await asyncio.open_connection("127.0.0.1", server._settings.port) for _ in range(8)]  # type: ignore[attr-defined]
+    await wait_for_condition(
+        lambda: len(server._heartbeat_senders) == len(clients),  # type: ignore[attr-defined]
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+    await asyncio.wait_for(server.stop(), timeout=5.0)
+    await wait_for_condition(
+        lambda: not server._heartbeat_senders and not server._connections,  # type: ignore[attr-defined]
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    assert server._heartbeat_senders == {}  # type: ignore[attr-defined]
+    assert server._connections == {}  # type: ignore[attr-defined]
+    heartbeat_tasks = [
+        task
+        for task in asyncio.all_tasks()
+        if "heartbeat-sender" in task.get_name() and not task.done()
+    ]
+    assert heartbeat_tasks == []
+
+    for _reader, writer in clients:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_connections_above_max_connections_and_emits_event(
+    recording_event_handler,
+) -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=1),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    first_reader, first_writer = await asyncio.open_connection("127.0.0.1", port)
+    second_reader, second_writer = await asyncio.open_connection("127.0.0.1", port)
+    await wait_for_condition(
+        lambda: len(server.connections) == 1 and len(recording_event_handler.rejected_events) == 1,
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    rejected_event = recording_event_handler.rejected_events[0]
+    assert isinstance(rejected_event, ConnectionRejectedEvent)
+    assert rejected_event.resource_id == f"tcp/server/127.0.0.1/{port}"
+    assert rejected_event.reason == "max_connections_reached"
+    assert len(server.connections) == 1
+
+    first_writer.close()
+    second_writer.close()
+    with contextlib.suppress(Exception):
+        await first_writer.wait_closed()
+    with contextlib.suppress(Exception):
+        await second_writer.wait_closed()
+    del first_reader, second_reader
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_idle_timeout_closes_inactive_connection_and_emits_timeout_error(
+    recording_event_handler,
+) -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=1,
+            connection_idle_timeout_seconds=0.05,
+        ),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    await wait_for_condition(
+        lambda: bool(server.connections),
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+    await wait_for_condition(
+        lambda: not server.connections and bool(recording_event_handler.error_events),
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    assert isinstance(recording_event_handler.error_events[-1].error, TimeoutError)
+
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_connection_start_failure_does_not_leave_registered_connection(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+
+    async def failing_start(self) -> None:
+        raise RuntimeError(f"start-failed:{self.connection_id}")
+
+    monkeypatch.setattr(AsyncioTcpConnection, "start", failing_start)
+
+    _reader, writer = await asyncio.open_connection("127.0.0.1", server._settings.port)  # type: ignore[attr-defined]
+    await wait_for_condition(
+        lambda: not server._connections and bool(recording_event_handler.error_events),  # type: ignore[attr-defined]
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    assert server._connections == {}  # type: ignore[attr-defined]
+    assert recording_event_handler.error_events
+    assert "start-failed:" in str(recording_event_handler.error_events[-1].error)
+
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_accepted_connection_start_cancelled_error_cleans_registered_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connections: dict[str, AsyncioTcpConnection] = {}
+    writer = _FakeWriter()
+    dispatcher = AsyncioEventDispatcher(
+        _FailOnStartingLifecycle(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logging.getLogger("test"),
+    )
+
+    async def cancelled_start(self) -> None:
+        raise asyncio.CancelledError
+
+    def on_closed(connection: AsyncioTcpConnection) -> None:
+        connections.pop(connection.connection_id, None)
+
+    monkeypatch.setattr(AsyncioTcpConnection, "start", cancelled_start)
+
+    with pytest.raises(asyncio.CancelledError):
+        await handle_accepted_client(
+            reader=asyncio.StreamReader(),
+            writer=writer,  # type: ignore[arg-type]
+            state_lock=asyncio.Lock(),
+            get_lifecycle_state=lambda: ComponentLifecycleState.RUNNING,
+            get_connection_id=lambda: "server:accepted:1",
+            connections=connections,
+            event_dispatcher=dispatcher,
+            max_connections=64,
+            receive_buffer_size=4096,
+            idle_timeout_seconds=None,
+            on_closed_callback=on_closed,
+            heartbeat_settings=TcpHeartbeatSettings(enabled=False),
+            heartbeat_provider=None,
+            heartbeat_senders={},
+            component_id="tcp/server/127.0.0.1/12345",
+            logger=logging.getLogger("test"),
+        )
+
+    assert connections == {}
+    assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_accepted_connection_error_event_failure_still_closes_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connections: dict[str, AsyncioTcpConnection] = {}
+    writer = _FakeWriter()
+    dispatcher = AsyncioEventDispatcher(
+        _FailOnStartingLifecycle(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logging.getLogger("test"),
+    )
+
+    async def failing_start(self) -> None:
+        raise RuntimeError("start-failed")
+
+    async def failing_emit(_event) -> None:
+        raise RuntimeError("error-event-failed")
+
+    def on_closed(connection: AsyncioTcpConnection) -> None:
+        connections.pop(connection.connection_id, None)
+
+    monkeypatch.setattr(AsyncioTcpConnection, "start", failing_start)
+    monkeypatch.setattr(dispatcher, "emit", failing_emit)
+
+    await handle_accepted_client(
+        reader=asyncio.StreamReader(),
+        writer=writer,  # type: ignore[arg-type]
+        state_lock=asyncio.Lock(),
+        get_lifecycle_state=lambda: ComponentLifecycleState.RUNNING,
+        get_connection_id=lambda: "server:accepted:2",
+        connections=connections,
+        event_dispatcher=dispatcher,
+        max_connections=64,
+        receive_buffer_size=4096,
+        idle_timeout_seconds=None,
+        on_closed_callback=on_closed,
+        heartbeat_settings=TcpHeartbeatSettings(enabled=False),
+        heartbeat_provider=None,
+        heartbeat_senders={},
+        component_id="tcp/server/127.0.0.1/12345",
+        logger=logging.getLogger("test"),
+    )
+
+    assert connections == {}
+    assert writer.closed is True
+
+
+# Best-effort teardown and heartbeat cleanup on shutdown.
+@pytest.mark.asyncio
+async def test_server_stop_teardown_is_best_effort_and_emits_error_events(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12349, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    ok_connection = _TeardownConnection("server:ok-close:1", fail_on_close=False)
+    failing_connection = _TeardownConnection("server:bad-close:1", fail_on_close=True)
+    ok_sender = _TeardownSender("server:ok-sender:1", fail_on_stop=False)
+    failing_sender = _TeardownSender("server:bad-sender:1", fail_on_stop=True)
+    server._connections = {  # type: ignore[attr-defined]
+        ok_connection.connection_id: ok_connection,  # type: ignore[dict-item]
+        failing_connection.connection_id: failing_connection,  # type: ignore[dict-item]
+    }
+    server._heartbeat_senders = {  # type: ignore[attr-defined]
+        ok_sender.connection_id: ok_sender,  # type: ignore[dict-item]
+        failing_sender.connection_id: failing_sender,  # type: ignore[dict-item]
+    }
+
+    await server.stop()
+
+    assert ok_connection.close_attempts == 1
+    assert failing_connection.close_attempts == 1
+    assert ok_sender.stop_attempts == 1
+    assert failing_sender.stop_attempts == 1
+    observed_errors = [str(event.error) for event in recording_event_handler.error_events]
+    assert "close-failed:server:bad-close:1" in observed_errors
+    assert "stop-failed:server:bad-sender:1" in observed_errors
+
+
+@pytest.mark.asyncio
+async def test_server_stop_teardown_error_reporting_is_best_effort(
+    recording_event_handler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12350, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    ok_connection = _TeardownConnection("server:ok-close:2", fail_on_close=False)
+    failing_connection = _TeardownConnection("server:bad-close:2", fail_on_close=True)
+    server._connections = {  # type: ignore[attr-defined]
+        ok_connection.connection_id: ok_connection,  # type: ignore[dict-item]
+        failing_connection.connection_id: failing_connection,  # type: ignore[dict-item]
+    }
+
+    async def failing_emit(_event) -> None:
+        raise RuntimeError("emit-failed-during-report")
+
+    monkeypatch.setattr(server._event_dispatcher, "emit", failing_emit)  # type: ignore[attr-defined]
+
+    await server.stop()
+
+    assert ok_connection.close_attempts == 1
+    assert failing_connection.close_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_server_heartbeat_start_failure_rolls_back_sender_registration(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            max_connections=64,
+            heartbeat=TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        ),
+        event_handler=recording_event_handler,
+        heartbeat_provider=_NoopHeartbeatProvider(),
+    )
+    await server.start()
+
+    async def failing_heartbeat_start(self) -> None:
+        raise RuntimeError("heartbeat-start-failed")
+
+    monkeypatch.setattr(AsyncioHeartbeatSender, "start", failing_heartbeat_start)
+
+    _reader, writer = await asyncio.open_connection("127.0.0.1", server._settings.port)  # type: ignore[attr-defined]
+    await wait_for_condition(
+        lambda: (
+            not server._heartbeat_senders  # type: ignore[attr-defined]
+            and not server._connections  # type: ignore[attr-defined]
+            and bool(recording_event_handler.error_events)
+        ),
+        timeout_seconds=1.0,
+        interval_seconds=0.01,
+    )
+
+    assert server._heartbeat_senders == {}  # type: ignore[attr-defined]
+    assert server._connections == {}  # type: ignore[attr-defined]
+    heartbeat_tasks = [
+        task
+        for task in asyncio.all_tasks()
+        if "heartbeat-sender" in task.get_name() and not task.done()
+    ]
+    assert heartbeat_tasks == []
+    assert recording_event_handler.error_events
+    assert "heartbeat-start-failed" in str(recording_event_handler.error_events[-1].error)
+
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    await server.stop()

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -1,0 +1,753 @@
+"""
+Contract tests for the asyncio UDP receiver and sender implementations.
+
+These tests focus on lifecycle rollback, lazy socket creation, fallback
+polling, payload and target validation, and deterministic shutdown. Receiver
+and sender coverage live together because the public UDP API is asymmetric but
+the two components still share socket and lifecycle invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.errors import NetworkConfigurationError, NetworkRuntimeError
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.udp import UdpInvalidTargetError
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.api.udp import UdpSenderStoppedError
+from aionetx.api.udp import UdpSenderSettings
+from aionetx.implementations.asyncio_impl import asyncio_udp_receiver as udp_receiver_module
+from aionetx.implementations.asyncio_impl import asyncio_udp_sender as udp_sender_module
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+class NoopHandler:
+    async def on_event(self, event) -> None:
+        return None
+
+
+class FailOnOpenedHandler:
+    async def on_event(self, event) -> None:
+        if isinstance(event, ConnectionOpenedEvent):
+            raise RuntimeError("boom-on-opened")
+
+
+class FailOnLifecycleStateHandler:
+    def __init__(self, state: ComponentLifecycleState) -> None:
+        self._state = state
+
+    async def on_event(self, event) -> None:
+        if isinstance(event, ComponentLifecycleChangedEvent) and event.current == self._state:
+            raise RuntimeError(f"udp-{self._state.value}-publication-failed")
+
+
+def _get_unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_start_failure_cleans_dispatcher_and_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failing_bind(self: socket.socket, address: tuple[str, int]) -> None:
+        raise OSError("bind-failed")
+
+    monkeypatch.setattr(socket.socket, "bind", failing_bind)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21001),
+        event_handler=NoopHandler(),
+    )
+
+    with pytest.raises(OSError, match="bind-failed"):
+        await receiver.start()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    # Verify that the dispatcher background worker was cleaned up via the public contract.
+    assert not receiver._event_dispatcher.is_running
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_start_failure_rolls_back_without_closed_event(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failing_bind(self: socket.socket, address: tuple[str, int]) -> None:
+        raise OSError("bind-failed")
+
+    monkeypatch.setattr(socket.socket, "bind", failing_bind)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21011),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    with pytest.raises(OSError, match="bind-failed"):
+        await receiver.start()
+
+    lifecycle_states = [
+        event.current
+        for event in awaitable_recording_event_handler.lifecycle_events
+        if event.resource_id == receiver._connection_id  # type: ignore[attr-defined]
+    ]
+    assert lifecycle_states == [ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPED]
+    assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_opened_handler_failure_rolls_back_runtime_resources() -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=FailOnOpenedHandler(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom-on-opened"):
+        await receiver.start()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_starting_lifecycle_failure_rolls_back_dispatcher() -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=FailOnLifecycleStateHandler(ComponentLifecycleState.STARTING),
+    )
+
+    with pytest.raises(RuntimeError, match="udp-starting-publication-failed"):
+        await receiver.start()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_receive_loop_runtime_failure_emits_error_and_stops(
+    awaitable_recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingLoop:
+        async def sock_recvfrom(self, _sock: socket.socket, _size: int):
+            raise RuntimeError("recv-failed")
+
+    monkeypatch.setattr(udp_receiver_module.asyncio, "get_running_loop", lambda: _FailingLoop())
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21002),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await receiver.start()
+    await asyncio.wait_for(awaitable_recording_event_handler.error_observed.wait(), timeout=1.0)
+    await asyncio.wait_for(awaitable_recording_event_handler.connection_closed.wait(), timeout=1.0)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    # lifecycle_state == STOPPED is the public invariant for socket release;
+    # no need to inspect the private _socket attribute.
+    assert (
+        awaitable_recording_event_handler.closed_events[-1].previous_state
+        == ConnectionState.CONNECTED
+    )
+    assert awaitable_recording_event_handler.closed_events[-1].metadata is not None
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_lifecycle_failure_still_closes_socket_and_stops_dispatcher() -> (
+    None
+):
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+            ),
+        ),
+        event_handler=FailOnLifecycleStateHandler(ComponentLifecycleState.STOPPING),
+    )
+
+    await receiver.start()
+    with pytest.raises(RuntimeError, match="udp-stopping-publication-failed"):
+        await receiver.stop()
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_cancellation_still_detaches_receive_task_and_socket() -> None:
+    stopping_seen = asyncio.Event()
+
+    class BlockingStoppingHandler:
+        async def on_event(self, event) -> None:
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current == ComponentLifecycleState.STOPPING
+            ):
+                stopping_seen.set()
+                await asyncio.Event().wait()
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=BlockingStoppingHandler(),
+    )
+
+    await receiver.start()
+    original_task = receiver._task  # type: ignore[attr-defined]
+    stop_task = asyncio.create_task(receiver.stop())
+    await asyncio.wait_for(stopping_seen.wait(), timeout=1.0)
+    stop_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert original_task is not None and original_task.done()
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_inline_handler_can_stop_from_bytes_received_without_self_await() -> (
+    None
+):
+    stopped = asyncio.Event()
+
+    class StopFromBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+
+        async def on_event(self, event) -> None:
+            if self.receiver is not None and type(event).__name__ == "BytesReceivedEvent":
+                await self.receiver.stop()
+                stopped.set()
+
+    port = _get_unused_udp_port()
+    handler = StopFromBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"stop-from-handler")
+        await asyncio.wait_for(stopped.wait(), timeout=1.0)
+        assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert receiver._task is None  # type: ignore[attr-defined]
+    finally:
+        await sender.stop()
+        await receiver.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_nonblocking_fallback_uses_bounded_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _LoopWithoutSockSendTo:
+        pass
+
+    class _TransientBlockingSocket:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def sendto(self, payload: bytes, target: tuple[str, int]) -> None:
+            self.calls += 1
+            if self.calls < 3:
+                raise BlockingIOError
+            return None
+
+        def getsockname(self) -> tuple[str, int]:
+            return ("127.0.0.1", 0)
+
+    sleep_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(
+        udp_sender_module.asyncio, "get_running_loop", lambda: _LoopWithoutSockSendTo()
+    )
+    monkeypatch.setattr(udp_sender_module.asyncio, "sleep", fake_sleep)
+
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=12345)
+    )
+    sock = _TransientBlockingSocket()
+    await sender._send_nonblocking(sock, b"payload", ("127.0.0.1", 12345))  # type: ignore[arg-type,attr-defined]
+
+    assert sock.calls == 3
+    assert sleep_delays == [
+        sender._WOULD_BLOCK_INITIAL_DELAY_SECONDS,
+        sender._WOULD_BLOCK_INITIAL_DELAY_SECONDS * 2,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_nonblocking_fallback_uses_bounded_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _LoopWithoutSockRecvFrom:
+        pass
+
+    class _TransientBlockingSocket:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def recvfrom(self, _size: int) -> tuple[bytes, tuple[str, int]]:
+            self.calls += 1
+            if self.calls < 3:
+                raise BlockingIOError
+            return (b"payload", ("127.0.0.1", 1111))
+
+    sleep_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(udp_receiver_module.asyncio, "sleep", fake_sleep)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21009),
+        event_handler=NoopHandler(),
+    )
+    sock = _TransientBlockingSocket()
+    data, sender = await receiver._recv_nonblocking(_LoopWithoutSockRecvFrom(), sock, 1024)  # type: ignore[arg-type,attr-defined]
+
+    assert data == b"payload"
+    assert sender == ("127.0.0.1", 1111)
+    assert sock.calls == 3
+    assert sleep_delays == [
+        receiver._WOULD_BLOCK_INITIAL_DELAY_SECONDS,
+        receiver._WOULD_BLOCK_INITIAL_DELAY_SECONDS * 2,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_nonblocking_fallback_logs_one_warning_per_receiver(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _LoopWithoutSockRecvFrom:
+        pass
+
+    class _TransientBlockingSocket:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def recvfrom(self, _size: int) -> tuple[bytes, tuple[str, int]]:
+            self.calls += 1
+            if self.calls in (1, 3):
+                raise BlockingIOError
+            return (b"payload", ("127.0.0.1", 1111))
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(udp_receiver_module.asyncio, "sleep", fake_sleep)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21010),
+        event_handler=NoopHandler(),
+    )
+    sock = _TransientBlockingSocket()
+
+    with caplog.at_level(logging.WARNING):
+        await receiver._recv_nonblocking(_LoopWithoutSockRecvFrom(), sock, 1024)  # type: ignore[arg-type,attr-defined]
+        await receiver._recv_nonblocking(_LoopWithoutSockRecvFrom(), sock, 1024)  # type: ignore[arg-type,attr-defined]
+
+    warning_messages = [
+        message
+        for message in caplog.messages
+        if "fallback polling because the event loop does not expose sock_recvfrom" in message
+    ]
+    assert warning_messages == [
+        "UDP is using recvfrom() fallback polling because the event loop does not expose sock_recvfrom()."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_constructor_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    socket_calls: list[tuple[int, int, int]] = []
+    original_socket = socket.socket
+
+    def tracking_socket(family: int, stype: int, proto: int = 0):
+        socket_calls.append((family, stype, proto))
+        return original_socket(family, stype, proto)
+
+    monkeypatch.setattr(udp_sender_module.socket, "socket", tracking_socket)
+
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=12345)
+    )
+    await sender.stop()
+
+    assert socket_calls == []
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_first_send_initializes_socket() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=_get_unused_udp_port())
+    )
+    try:
+        # Verify lazy socket initialization: no socket before first send.
+        assert not sender.is_socket_initialized
+        await sender.send(b"first")
+        assert sender.is_socket_initialized
+    finally:
+        await sender.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_accepts_bytes_like_payloads() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=_get_unused_udp_port())
+    )
+    try:
+        await sender.send(b"bytes")
+        await sender.send(bytearray(b"bytearray"))
+        await sender.send(memoryview(b"memoryview"))
+    finally:
+        await sender.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_stop_before_first_send_is_safe_and_send_after_stop_fails() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=12345)
+    )
+    await sender.stop()
+    await sender.stop()
+
+    with pytest.raises(UdpSenderStoppedError, match="stopped") as exc_info:
+        await sender.send(b"after-stop")
+    assert isinstance(exc_info.value, NetworkRuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_validates_payload_and_target() -> None:
+    sender = AsyncioUdpSender(settings=UdpSenderSettings())
+    try:
+        with pytest.raises(TypeError, match="bytes-like"):
+            await sender.send("not-bytes")  # type: ignore[arg-type]
+        with pytest.raises(UdpInvalidTargetError, match="target host") as exc_info:
+            await sender.send(b"ok")
+        assert isinstance(exc_info.value, NetworkConfigurationError)
+
+        with pytest.raises(UdpInvalidTargetError, match="target host"):
+            await sender.send(b"ok", host="   ", port=9999)
+
+        with pytest.raises(UdpInvalidTargetError, match="target host"):
+            await sender.send(b"ok", host=object(), port=9999)  # type: ignore[arg-type]
+
+        with pytest.raises(UdpInvalidTargetError, match="between 1 and 65535") as invalid_port_exc:
+            await sender.send(b"ok", host="127.0.0.1", port=70000)
+        assert isinstance(invalid_port_exc.value, NetworkConfigurationError)
+
+        with pytest.raises(UdpInvalidTargetError, match="target port"):
+            await sender.send(b"ok", host="127.0.0.1", port=9999.0)  # type: ignore[arg-type]
+    finally:
+        await sender.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_sets_broadcast_socket_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[tuple[int, int, object]] = []
+    original_setsockopt = socket.socket.setsockopt
+
+    def tracking_setsockopt(self: socket.socket, level: int, optname: int, value) -> None:
+        observed.append((level, optname, value))
+        return original_setsockopt(self, level, optname, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", tracking_setsockopt)
+
+    receiver_port = _get_unused_udp_port()
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="255.255.255.255",
+            default_port=receiver_port,
+            enable_broadcast=True,
+        )
+    )
+    try:
+        with contextlib.suppress(OSError):
+            await sender.send(b"broadcast")
+    finally:
+        await sender.stop()
+
+    assert any(
+        level == socket.SOL_SOCKET and optname == socket.SO_BROADCAST
+        for level, optname, _ in observed
+    )
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_target_resolution_prefers_send_arguments_over_defaults() -> None:
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=11000),
+    )
+    seen_targets: list[tuple[str, int]] = []
+
+    async def fake_send_nonblocking(sock, payload: bytes, target: tuple[str, int]) -> None:  # type: ignore[no-untyped-def]
+        seen_targets.append(target)
+
+    sender._send_nonblocking = fake_send_nonblocking  # type: ignore[method-assign,assignment]
+    try:
+        await sender.send(b"default")
+        await sender.send(b"host-only", host="127.0.0.2")
+        await sender.send(b"port-only", port=12000)
+        await sender.send(b"both", host="127.0.0.3", port=13000)
+    finally:
+        await sender.stop()
+
+    assert seen_targets == [
+        ("127.0.0.1", 11000),
+        ("127.0.0.2", 11000),
+        ("127.0.0.1", 12000),
+        ("127.0.0.3", 13000),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_does_not_await_dispatcher_while_holding_state_lock() -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=NoopHandler(),
+    )
+    await receiver.start()
+
+    async def dispatcher_stop_requiring_state_lock() -> None:
+        async with receiver._state_lock:  # type: ignore[attr-defined]
+            return None
+
+    receiver._event_dispatcher.stop = dispatcher_stop_requiring_state_lock  # type: ignore[method-assign]
+    await asyncio.wait_for(receiver.stop(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_from_starting_state_does_not_emit_closed_event(
+    awaitable_recording_event_handler,
+) -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=awaitable_recording_event_handler,
+    )
+
+    receiver._runtime.lifecycle_state = ComponentLifecycleState.STARTING  # type: ignore[attr-defined]
+    receiver._runtime.connection_state = ConnectionState.CREATED  # type: ignore[attr-defined]
+
+    await receiver.stop()
+
+    assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_emits_stopping_closed_stopped_in_order(
+    awaitable_recording_event_handler,
+) -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await receiver.start()
+    await receiver.stop()
+
+    stop_relevant_events = [
+        event
+        for event in awaitable_recording_event_handler.events
+        if (
+            isinstance(event, ConnectionClosedEvent)
+            or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            )
+        )
+    ]
+    assert [type(event).__name__ for event in stop_relevant_events] == [
+        "ComponentLifecycleChangedEvent",
+        "ConnectionClosedEvent",
+        "ComponentLifecycleChangedEvent",
+    ]
+    assert isinstance(stop_relevant_events[0], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[0].current == ComponentLifecycleState.STOPPING
+    assert isinstance(stop_relevant_events[2], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[2].current == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_overlapping_stop_calls_publish_one_stop_sequence(
+    awaitable_recording_event_handler,
+) -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=awaitable_recording_event_handler,
+    )
+    await receiver.start()
+
+    await asyncio.gather(receiver.stop(), receiver.stop())
+
+    stop_lifecycle_events = [
+        event
+        for event in awaitable_recording_event_handler.lifecycle_events
+        if event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+    ]
+    assert [event.current for event in stop_lifecycle_events] == [
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert len(awaitable_recording_event_handler.closed_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_rejects_illegal_lifecycle_transition() -> None:
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=NoopHandler(),
+    )
+
+    with pytest.raises(RuntimeError, match="Illegal lifecycle transition"):
+        await receiver._set_lifecycle_state(ComponentLifecycleState.RUNNING)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_closes_socket_when_bind_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Socket created before bind() must be closed if bind() raises OSError."""
+    closed_sockets: list[socket.socket] = []
+    original_socket_cls = socket.socket
+
+    class TrackingSocket(original_socket_cls):  # type: ignore[misc]
+        def bind(self, address: tuple[str, int]) -> None:
+            raise OSError("bind-failed")
+
+        def close(self) -> None:
+            closed_sockets.append(self)
+            super().close()
+
+    monkeypatch.setattr(udp_sender_module.socket, "socket", TrackingSocket)
+
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=12345)
+    )
+    with pytest.raises(OSError, match="bind-failed"):
+        await sender.send(b"trigger-socket-creation")
+
+    assert len(closed_sockets) == 1, "Socket must be closed when bind() fails"
+    # After a failed initialization the sender must not hold a socket reference.
+    assert not sender.is_socket_initialized
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_refreshes_connection_id_after_ephemeral_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_socket_cls = socket.socket
+
+    class TrackingSocket(original_socket_cls):  # type: ignore[misc]
+        def bind(self, address: tuple[str, int]) -> None:
+            self._bound_address = ("127.0.0.1", 30123)
+
+        def getsockname(self) -> tuple[str, int]:
+            return self._bound_address
+
+    monkeypatch.setattr(udp_sender_module.socket, "socket", TrackingSocket)
+
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="127.0.0.1",
+            default_port=12345,
+            local_host="0.0.0.0",
+            local_port=0,
+        )
+    )
+
+    sock = sender._ensure_socket()  # type: ignore[attr-defined]
+    try:
+        assert sender._connection_id == "udp/sender/127.0.0.1/30123"  # type: ignore[attr-defined]
+        assert sender._logger.extra["connection_id"] == "udp/sender/127.0.0.1/30123"  # type: ignore[attr-defined]
+        assert sock is not None
+    finally:
+        await sender.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_closes_socket_when_setsockopt_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Socket created before setsockopt() must be closed if setsockopt() raises OSError."""
+    closed_sockets: list[socket.socket] = []
+    original_socket_cls = socket.socket
+
+    class TrackingSocket(original_socket_cls):  # type: ignore[misc]
+        def setsockopt(self, level: int, optname: int, value: int) -> None:
+            raise OSError("setsockopt-failed")
+
+        def close(self) -> None:
+            closed_sockets.append(self)
+            super().close()
+
+    monkeypatch.setattr(udp_sender_module.socket, "socket", TrackingSocket)
+
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="127.0.0.1", default_port=12345, enable_broadcast=True
+        )
+    )
+    with pytest.raises(OSError, match="setsockopt-failed"):
+        await sender.send(b"trigger-socket-creation")
+
+    assert len(closed_sockets) == 1, "Socket must be closed when setsockopt() fails"
+    # After a failed initialization the sender must not hold a socket reference.
+    assert not sender.is_socket_initialized

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -31,7 +31,9 @@ from aionetx.api.udp import UdpInvalidTargetError
 from aionetx.api.udp import UdpReceiverSettings
 from aionetx.api.udp import UdpSenderStoppedError
 from aionetx.api.udp import UdpSenderSettings
-from aionetx.implementations.asyncio_impl import asyncio_udp_receiver as udp_receiver_module
+from aionetx.implementations.asyncio_impl import (
+    _asyncio_datagram_receiver_base as datagram_base_module,
+)
 from aionetx.implementations.asyncio_impl import asyncio_udp_sender as udp_sender_module
 from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
@@ -167,7 +169,7 @@ async def test_udp_receiver_receive_loop_runtime_failure_emits_error_and_stops(
         async def sock_recvfrom(self, _sock: socket.socket, _size: int):
             raise RuntimeError("recv-failed")
 
-    monkeypatch.setattr(udp_receiver_module.asyncio, "get_running_loop", lambda: _FailingLoop())
+    monkeypatch.setattr(datagram_base_module.asyncio, "get_running_loop", lambda: _FailingLoop())
 
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(host="127.0.0.1", port=21002),
@@ -244,7 +246,7 @@ async def test_udp_receiver_stop_cancellation_still_detaches_receive_task_and_so
     # Supported Python releases differ in whether this caller cancellation
     # remains visible after inline handler-failure handling. Cleanup is stable.
     with contextlib.suppress(asyncio.CancelledError):
-        await stop_task
+        _ = await stop_task
 
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
@@ -358,7 +360,7 @@ async def test_udp_receiver_nonblocking_fallback_uses_bounded_backoff(
     async def fake_sleep(delay: float) -> None:
         sleep_delays.append(delay)
 
-    monkeypatch.setattr(udp_receiver_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(datagram_base_module.asyncio, "sleep", fake_sleep)
 
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(host="127.0.0.1", port=21009),
@@ -397,7 +399,7 @@ async def test_udp_receiver_nonblocking_fallback_logs_one_warning_per_receiver(
     async def fake_sleep(_delay: float) -> None:
         return None
 
-    monkeypatch.setattr(udp_receiver_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(datagram_base_module.asyncio, "sleep", fake_sleep)
 
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(host="127.0.0.1", port=21010),

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -241,7 +241,9 @@ async def test_udp_receiver_stop_cancellation_still_detaches_receive_task_and_so
     await asyncio.wait_for(stopping_seen.wait(), timeout=1.0)
     stop_task.cancel()
 
-    with pytest.raises(asyncio.CancelledError):
+    # Supported Python releases differ in whether this caller cancellation
+    # remains visible after inline handler-failure handling. Cleanup is stable.
+    with contextlib.suppress(asyncio.CancelledError):
         await stop_task
 
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED

--- a/tests/unit/test_base_network_event_handler.py
+++ b/tests/unit/test_base_network_event_handler.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.base_network_event_handler import BaseNetworkEventHandler
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.connection_events import ConnectionRejectedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import EventDispatchMode
+from aionetx.api.event_delivery_settings import EventHandlerFailurePolicy
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.reconnect_events import ReconnectAttemptFailedEvent
+from aionetx.api.reconnect_events import ReconnectAttemptStartedEvent
+from aionetx.api.reconnect_events import ReconnectScheduledEvent
+
+
+@pytest.mark.asyncio
+async def test_base_network_event_handler_noop_on_event() -> None:
+    handler = BaseNetworkEventHandler()
+    await handler.on_event(
+        ConnectionOpenedEvent(
+            resource_id="x",
+            metadata=ConnectionMetadata(connection_id="x", role=ConnectionRole.CLIENT),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_network_event_handler_default_typed_hooks_are_noops() -> None:
+    handler = BaseNetworkEventHandler()
+    metadata = ConnectionMetadata(connection_id="x", role=ConnectionRole.CLIENT)
+
+    await handler.on_connection_opened(ConnectionOpenedEvent(resource_id="x", metadata=metadata))
+    await handler.on_connection_closed(
+        ConnectionClosedEvent(resource_id="x", previous_state=ConnectionState.CONNECTED)
+    )
+    await handler.on_connection_rejected(
+        ConnectionRejectedEvent(
+            resource_id="server",
+            connection_id="server:rejected:1",
+            reason="max_connections_reached",
+        )
+    )
+    await handler.on_bytes_received(BytesReceivedEvent(resource_id="x", data=b"payload"))
+    await handler.on_error(NetworkErrorEvent(resource_id="x", error=RuntimeError("boom")))
+    await handler.on_handler_failure_policy_stop(
+        HandlerFailurePolicyStopEvent(
+            resource_id="component",
+            triggering_event_name="BytesReceivedEvent",
+            error=RuntimeError("handler-failed"),
+            policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+        )
+    )
+    await handler.on_component_lifecycle_changed(
+        ComponentLifecycleChangedEvent(
+            resource_id="component",
+            previous=ComponentLifecycleState.STARTING,
+            current=ComponentLifecycleState.RUNNING,
+        )
+    )
+    await handler.on_reconnect_attempt_started(
+        ReconnectAttemptStartedEvent(resource_id="client", attempt=1)
+    )
+    await handler.on_reconnect_attempt_failed(
+        ReconnectAttemptFailedEvent(
+            resource_id="client",
+            attempt=1,
+            error=ConnectionRefusedError("refused"),
+            next_delay_seconds=0.5,
+        )
+    )
+    await handler.on_reconnect_scheduled(
+        ReconnectScheduledEvent(resource_id="client", attempt=2, delay_seconds=0.5)
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_network_event_handler_dispatches_to_typed_hooks() -> None:
+    class Handler(BaseNetworkEventHandler):
+        def __init__(self) -> None:
+            self.opened = 0
+            self.received = 0
+
+        async def on_connection_opened(self, event: ConnectionOpenedEvent) -> None:
+            self.opened += 1
+
+        async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+            self.received += 1
+
+    handler = Handler()
+    await handler.on_event(
+        ConnectionOpenedEvent(
+            resource_id="x",
+            metadata=ConnectionMetadata(connection_id="x", role=ConnectionRole.CLIENT),
+        )
+    )
+    await handler.on_event(BytesReceivedEvent(resource_id="x", data=b"abc"))
+
+    assert handler.opened == 1
+    assert handler.received == 1
+
+
+@pytest.mark.asyncio
+async def test_base_network_event_handler_dispatches_subclasses_to_matching_hook() -> None:
+    class DerivedBytesReceivedEvent(BytesReceivedEvent):
+        pass
+
+    class Handler(BaseNetworkEventHandler):
+        def __init__(self) -> None:
+            self.received_types: list[type[BytesReceivedEvent]] = []
+
+        async def on_bytes_received(self, event: BytesReceivedEvent) -> None:
+            self.received_types.append(type(event))
+
+    handler = Handler()
+    await handler.on_event(DerivedBytesReceivedEvent(resource_id="x", data=b"abc"))
+
+    assert handler.received_types == [DerivedBytesReceivedEvent]

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -1,0 +1,1692 @@
+"""
+Contract tests for AsyncioEventDispatcher.
+
+These tests pin the observable delivery semantics that higher-level transports
+rely on: ordering, backpressure, stop boundaries, failure-policy behavior, and
+runtime statistics. They intentionally exercise both inline and background
+dispatch because those semantics are part of the library contract, not just an
+implementation detail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_events import ConnectionOpenedEvent
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.network_event import NetworkEvent
+from aionetx.implementations.asyncio_impl.event_dispatcher import (
+    AsyncioEventDispatcher,
+    DispatcherStopPolicy,
+)
+
+pytestmark = pytest.mark.behavior_critical
+
+
+class Recorder:
+    """Minimal async handler that records delivered events for assertions."""
+
+    def __init__(self, delay: float = 0.0, fail: bool = False) -> None:
+        self.events: list[NetworkEvent] = []
+        self.delay = delay
+        self.fail = fail
+        self._events_changed = asyncio.Condition()
+
+    async def on_event(self, event: NetworkEvent) -> None:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        async with self._events_changed:
+            self.events.append(event)
+            self._events_changed.notify_all()
+        if self.fail:
+            raise RuntimeError("boom")
+
+    async def wait_for_event_count(self, expected_count: int, *, timeout: float = 1.0) -> None:
+        """Block until at least the requested number of events has been observed."""
+
+        async def _wait_until_count() -> None:
+            async with self._events_changed:
+                while len(self.events) < expected_count:
+                    await self._events_changed.wait()
+
+        await asyncio.wait_for(_wait_until_count(), timeout=timeout)
+
+
+def _opened(idx: int | str) -> ConnectionOpenedEvent:
+    """Create a predictable opened event for ordering and queueing assertions."""
+
+    connection_id = f"c{idx}" if isinstance(idx, int) else idx
+    metadata = ConnectionMetadata(connection_id=connection_id, role=ConnectionRole.CLIENT)
+    return ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
+
+
+async def _wait_until_dispatcher_stopping(dispatcher: AsyncioEventDispatcher) -> None:
+    """Yield until stop() has entered the dispatcher stopping state."""
+
+    while not dispatcher.is_stopping:
+        await asyncio.sleep(0)
+
+
+# Basic delivery and handler-isolation guarantees.
+@pytest.mark.asyncio
+async def test_event_ordering_background_mode() -> None:
+    handler = Recorder()
+    dispatcher = AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await dispatcher.emit(_opened(2))
+    await handler.wait_for_event_count(2)
+    await dispatcher.stop()
+    assert [
+        e.metadata.connection_id for e in handler.events if isinstance(e, ConnectionOpenedEvent)
+    ] == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_does_not_break_dispatcher() -> None:
+    handler = Recorder(fail=True)
+    dispatcher = AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await dispatcher.emit(
+        ConnectionClosedEvent(resource_id="c1", previous_state=ConnectionState.CONNECTED)
+    )
+    await handler.wait_for_event_count(2)
+    await dispatcher.stop()
+    assert len(handler.events) == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_background_worker_cleanly() -> None:
+    handler = Recorder(delay=0.01)
+    dispatcher = AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_called_from_event_callback_is_safe(caplog: pytest.LogCaptureFixture) -> None:
+    class StopFromCallbackHandler:
+        def __init__(self) -> None:
+            self.dispatcher: AsyncioEventDispatcher | None = None
+            self.count = 0
+            self.handled = asyncio.Event()
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            del event
+            self.count += 1
+            if self.dispatcher is not None:
+                await self.dispatcher.stop()
+            self.handled.set()
+
+    handler = StopFromCallbackHandler()
+    dispatcher = AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+    handler.dispatcher = dispatcher
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handler.handled.wait(), timeout=1.0)
+
+    assert handler.count == 1
+    assert dispatcher.is_running is False
+    assert "Task cannot await on itself" not in caplog.text
+
+
+# Backpressure semantics under queue saturation.
+@pytest.mark.asyncio
+async def test_drop_newest_backpressure_policy() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    second_handled = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+            elif connection_id == "c2":
+                second_handled.set()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.DROP_NEWEST
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+    allow_first_to_finish.set()
+    await asyncio.wait_for(second_handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+    assert handler.ids == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_drop_oldest_backpressure_policy_keeps_newer_events() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    third_handled = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+            elif connection_id == "c3":
+                third_handled.set()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.DROP_OLDEST
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+    allow_first_to_finish.set()
+    await asyncio.wait_for(third_handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+    assert handler.ids == ["c1", "c3"]
+
+
+@pytest.mark.asyncio
+async def test_block_backpressure_policy_waits_for_queue_space() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    second_started = asyncio.Event()
+    allow_second_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+            self.third_handled = asyncio.Event()
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+            elif connection_id == "c2":
+                second_started.set()
+                await allow_second_to_finish.wait()
+            elif connection_id == "c3":
+                self.third_handled.set()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.BLOCK
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    producer = asyncio.create_task(dispatcher.emit(_opened(3)))
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(producer), timeout=0.05)
+
+    allow_first_to_finish.set()
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
+    await asyncio.wait_for(producer, timeout=1.0)
+    allow_second_to_finish.set()
+    await asyncio.wait_for(handler.third_handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+    assert handler.ids == ["c1", "c2", "c3"]
+
+
+# Dispatch topology and execution-mode behavior.
+@pytest.mark.asyncio
+async def test_inline_mode_dispatches_without_worker_task() -> None:
+    handler = Recorder()
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE)
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await dispatcher.stop()
+    assert dispatcher.is_running is False
+    assert [
+        e.metadata.connection_id for e in handler.events if isinstance(e, ConnectionOpenedEvent)
+    ] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_without_started_worker_falls_back_to_inline() -> None:
+    caller_task = asyncio.current_task()
+    assert caller_task is not None
+
+    seen_tasks: list[asyncio.Task[object] | None] = []
+
+    class TaskRecordingHandler:
+        async def on_event(self, _event: NetworkEvent) -> None:
+            seen_tasks.append(asyncio.current_task())
+
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(TaskRecordingHandler(), settings, logging.getLogger("test"))
+
+    await dispatcher.emit(_opened(1))
+
+    assert seen_tasks == [caller_task]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_with_started_worker_dispatches_on_worker_task() -> None:
+    caller_task = asyncio.current_task()
+    assert caller_task is not None
+
+    handled = asyncio.Event()
+    seen_tasks: list[asyncio.Task[object] | None] = []
+
+    class TaskRecordingHandler:
+        async def on_event(self, _event: NetworkEvent) -> None:
+            seen_tasks.append(asyncio.current_task())
+            handled.set()
+
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(TaskRecordingHandler(), settings, logging.getLogger("test"))
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert len(seen_tasks) == 1
+    assert seen_tasks[0] is not None
+    assert seen_tasks[0] is not caller_task
+
+
+@pytest.mark.asyncio
+async def test_background_mode_handler_spawned_task_does_not_inherit_inline_delivery() -> None:
+    handled_tasks: list[asyncio.Task[None] | None] = []
+    spawned_emit_finished = asyncio.Event()
+    second_seen = asyncio.Event()
+    dispatcher: AsyncioEventDispatcher | None = None
+
+    async def emit_from_spawned_task() -> None:
+        assert dispatcher is not None
+        await dispatcher.emit(_opened(2))
+        spawned_emit_finished.set()
+
+    class SpawningHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            handled_tasks.append(asyncio.current_task())
+            if isinstance(event, ConnectionOpenedEvent) and event.metadata.connection_id == "c1":
+                asyncio.create_task(emit_from_spawned_task())
+                return
+            second_seen.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        SpawningHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(spawned_emit_finished.wait(), timeout=1.0)
+    await asyncio.wait_for(second_seen.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert len(handled_tasks) == 2
+    assert handled_tasks[0] is handled_tasks[1]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_shared_dispatcher_serializes_cross_connection_handler_execution() -> (
+    None
+):
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    second_started = asyncio.Event()
+
+    class BlockingPerConnectionHandler:
+        def __init__(self) -> None:
+            self.active_handlers = 0
+            self.max_active_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            self.active_handlers += 1
+            self.max_active_handlers = max(self.max_active_handlers, self.active_handlers)
+            try:
+                if event.metadata.connection_id == "c1":
+                    first_started.set()
+                    await allow_first_to_finish.wait()
+                elif event.metadata.connection_id == "c2":
+                    second_started.set()
+            finally:
+                self.active_handlers -= 1
+
+    handler = BlockingPerConnectionHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    second_emit_task = asyncio.create_task(dispatcher.emit(_opened(2)))
+    await asyncio.wait_for(second_emit_task, timeout=1.0)
+    assert second_started.is_set() is False
+
+    allow_first_to_finish.set()
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert handler.max_active_handlers == 1
+
+
+@pytest.mark.asyncio
+async def test_background_mode_isolated_dispatchers_allow_parallel_handler_execution() -> None:
+    release_handlers = asyncio.Event()
+    both_started = asyncio.Event()
+    shared_lock = asyncio.Lock()
+
+    class ParallelTracker:
+        def __init__(self) -> None:
+            self.active_handlers = 0
+            self.max_active_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            async with shared_lock:
+                self.active_handlers += 1
+                self.max_active_handlers = max(self.max_active_handlers, self.active_handlers)
+                if self.active_handlers == 2:
+                    both_started.set()
+            await release_handlers.wait()
+            async with shared_lock:
+                self.active_handlers -= 1
+
+    tracker = ParallelTracker()
+    dispatcher_one = AsyncioEventDispatcher(
+        tracker,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    dispatcher_two = AsyncioEventDispatcher(
+        tracker,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+
+    await dispatcher_one.start()
+    await dispatcher_two.start()
+
+    emit_tasks = [
+        asyncio.create_task(dispatcher_one.emit(_opened("iso-1"))),
+        asyncio.create_task(dispatcher_two.emit(_opened("iso-2"))),
+    ]
+    await asyncio.wait_for(both_started.wait(), timeout=1.0)
+    release_handlers.set()
+    await asyncio.wait_for(asyncio.gather(*emit_tasks), timeout=1.0)
+
+    await dispatcher_one.stop()
+    await dispatcher_two.stop()
+
+    assert tracker.max_active_handlers == 2
+
+
+@pytest.mark.asyncio
+async def test_shared_dispatcher_block_policy_cold_source_event_is_eventually_delivered() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    cold_handled = asyncio.Event()
+
+    class AsymmetricLoadHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "hot-0":
+                first_started.set()
+                await release_first.wait()
+            if connection_id == "cold-1":
+                cold_handled.set()
+
+    handler = AsymmetricLoadHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=1,
+            backpressure_policy=EventBackpressurePolicy.BLOCK,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened("hot-0"))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    async def _emit_hot_burst() -> None:
+        for index in range(1, 4):
+            await dispatcher.emit(_opened(f"hot-{index}"))
+
+    hot_task = asyncio.create_task(_emit_hot_burst())
+    cold_task = asyncio.create_task(dispatcher.emit(_opened("cold-1")))
+    release_first.set()
+
+    await asyncio.wait_for(asyncio.gather(hot_task, cold_task), timeout=2.0)
+    await asyncio.wait_for(cold_handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert "cold-1" in handler.ids
+
+
+@pytest.mark.asyncio
+async def test_shared_dispatcher_drop_newest_can_drop_cold_source_under_hot_pressure() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    hot1_handled = asyncio.Event()
+
+    class AsymmetricLoadHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "hot-0":
+                first_started.set()
+                await release_first.wait()
+            if connection_id == "hot-1":
+                hot1_handled.set()
+
+    handler = AsymmetricLoadHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=1,
+            backpressure_policy=EventBackpressurePolicy.DROP_NEWEST,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened("hot-0"))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    await dispatcher.emit(_opened("hot-1"))
+    await dispatcher.emit(_opened("cold-1"))
+    release_first.set()
+    await asyncio.wait_for(hot1_handled.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert handler.ids == ["hot-0", "hot-1"]
+
+
+# Stop-boundary behavior and in-flight draining rules.
+@pytest.mark.asyncio
+async def test_background_mode_drops_events_emitted_after_stop_completed() -> None:
+    handler = Recorder()
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+
+    await dispatcher.start()
+    await dispatcher.stop()
+    await dispatcher.emit(_opened(99))
+
+    assert handler.events == []
+
+
+@pytest.mark.asyncio
+async def test_background_mode_drops_events_emitted_after_stop_begins() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    stop_started = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.events: list[NetworkEvent] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionOpenedEvent) and event.metadata.connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    async def stop_dispatcher() -> None:
+        stop_started.set()
+        await dispatcher.stop()
+
+    stop_task = asyncio.create_task(stop_dispatcher())
+    await asyncio.wait_for(stop_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    allow_first_to_finish.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    ids = [e.metadata.connection_id for e in handler.events if isinstance(e, ConnectionOpenedEvent)]
+    assert ids == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_emit_stop_boundary_is_deterministic_across_repeated_runs() -> None:
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+
+    for _ in range(50):
+        first_started = asyncio.Event()
+        allow_first_to_finish = asyncio.Event()
+
+        class BlockingHandler:
+            def __init__(self) -> None:
+                self.events: list[NetworkEvent] = []
+
+            async def on_event(self, event: NetworkEvent) -> None:
+                self.events.append(event)
+                if (
+                    isinstance(event, ConnectionOpenedEvent)
+                    and event.metadata.connection_id == "c1"
+                ):
+                    first_started.set()
+                    await allow_first_to_finish.wait()
+
+        handler = BlockingHandler()
+        dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+
+        await dispatcher.start()
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(dispatcher.stop())
+        await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+
+        late_emit_task = asyncio.create_task(dispatcher.emit(_opened(2)))
+        await asyncio.wait_for(late_emit_task, timeout=1.0)
+
+        allow_first_to_finish.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+
+        ids = [
+            e.metadata.connection_id for e in handler.events if isinstance(e, ConnectionOpenedEvent)
+        ]
+        assert ids == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_stop_boundary_drops_concurrent_emit_burst() -> None:
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+
+    for _ in range(25):
+        first_started = asyncio.Event()
+        allow_first_to_finish = asyncio.Event()
+
+        class BlockingHandler:
+            def __init__(self) -> None:
+                self.events: list[NetworkEvent] = []
+
+            async def on_event(self, event: NetworkEvent) -> None:
+                self.events.append(event)
+                if (
+                    isinstance(event, ConnectionOpenedEvent)
+                    and event.metadata.connection_id == "c1"
+                ):
+                    first_started.set()
+                    await allow_first_to_finish.wait()
+
+        handler = BlockingHandler()
+        dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+
+        await dispatcher.start()
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(dispatcher.stop())
+        await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+
+        late_emit_tasks = [
+            asyncio.create_task(dispatcher.emit(_opened(idx))) for idx in range(2, 12)
+        ]
+        await asyncio.wait_for(asyncio.gather(*late_emit_tasks), timeout=1.0)
+
+        allow_first_to_finish.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+
+        ids = [
+            event.metadata.connection_id
+            for event in handler.events
+            if isinstance(event, ConnectionOpenedEvent)
+        ]
+        assert ids == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_background_mode_post_stop_emit_burst_is_unsignaled_noop() -> None:
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+
+    for _ in range(25):
+        handler = Recorder()
+        dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+        start_gate = asyncio.Event()
+
+        async def _emit_when_released(idx: int) -> None:
+            await start_gate.wait()
+            await dispatcher.emit(_opened(idx))
+
+        await dispatcher.start()
+        await dispatcher.stop()
+
+        post_stop_emit_tasks = [
+            asyncio.create_task(_emit_when_released(idx)) for idx in range(20, 35)
+        ]
+        start_gate.set()
+        await asyncio.wait_for(asyncio.gather(*post_stop_emit_tasks), timeout=1.0)
+
+        assert handler.events == []
+
+
+@pytest.mark.asyncio
+async def test_blocking_producer_is_released_when_dispatcher_stops() -> None:
+    handler_started = asyncio.Event()
+    unblock_handler = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, _event: NetworkEvent) -> None:
+            handler_started.set()
+            await unblock_handler.wait()
+
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.BLOCK
+    )
+    dispatcher = AsyncioEventDispatcher(BlockingHandler(), settings, logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    blocked_producer = asyncio.create_task(dispatcher.emit(_opened(3)))
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(blocked_producer), timeout=0.05)
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    unblock_handler.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+    await asyncio.wait_for(blocked_producer, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_block_backpressure_stop_releases_multiple_blocked_producers_without_new_delivery() -> (
+    None
+):
+    handler_started = asyncio.Event()
+    unblock_handler = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+            self.second_seen = asyncio.Event()
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                handler_started.set()
+                await unblock_handler.wait()
+            elif connection_id == "c2":
+                self.second_seen.set()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.BLOCK
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    producer_attempted = [asyncio.Event() for _ in range(3, 9)]
+
+    async def _produce(idx: int, attempted: asyncio.Event) -> None:
+        attempted.set()
+        await dispatcher.emit(_opened(idx))
+
+    blocked_producers = [
+        asyncio.create_task(_produce(idx, attempted))
+        for idx, attempted in zip(range(3, 9), producer_attempted, strict=True)
+    ]
+    await asyncio.wait_for(
+        asyncio.gather(*(event.wait() for event in producer_attempted)), timeout=1.0
+    )
+    assert all(task.done() is False for task in blocked_producers)
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    unblock_handler.set()
+
+    await asyncio.wait_for(stop_task, timeout=1.0)
+    await asyncio.wait_for(asyncio.gather(*blocked_producers), timeout=1.0)
+    await asyncio.wait_for(handler.second_seen.wait(), timeout=1.0)
+
+    assert handler.ids == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_block_backpressure_stop_counts_blocked_producers_as_stop_phase_drops() -> None:
+    handler_started = asyncio.Event()
+    unblock_handler = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent) and event.metadata.connection_id == "c1":
+                handler_started.set()
+                await unblock_handler.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(
+            max_pending_events=1, backpressure_policy=EventBackpressurePolicy.BLOCK
+        ),
+        logging.getLogger("test"),
+        error_source="tcp/server/127.0.0.1/9010",
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+
+    producer_tasks = [asyncio.create_task(dispatcher.emit(_opened(idx))) for idx in range(3, 6)]
+    await asyncio.sleep(0)
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    unblock_handler.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+    await asyncio.wait_for(asyncio.gather(*producer_tasks), timeout=1.0)
+
+    stats = dispatcher.runtime_stats
+    # c3-c5 were blocked behind BLOCK backpressure and released on stop.
+    assert stats.dropped_stop_phase_total >= 3
+
+
+@pytest.mark.asyncio
+async def test_block_backpressure_stop_boundary_releases_blocked_producers_and_drops_late_emit() -> (
+    None
+):
+    handler_started = asyncio.Event()
+    unblock_handler = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+            self.second_seen = asyncio.Event()
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                handler_started.set()
+                await unblock_handler.wait()
+            elif connection_id == "c2":
+                self.second_seen.set()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.BLOCK
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    blocked = [asyncio.create_task(dispatcher.emit(_opened(idx))) for idx in range(3, 7)]
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await dispatcher.emit(_opened(99))
+    unblock_handler.set()
+
+    await asyncio.wait_for(stop_task, timeout=1.0)
+    await asyncio.wait_for(asyncio.gather(*blocked), timeout=1.0)
+    await asyncio.wait_for(handler.second_seen.wait(), timeout=1.0)
+
+    assert handler.ids == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_drop_oldest_saturated_queue_preserves_pre_stop_order_during_shutdown() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.DROP_OLDEST
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await asyncio.gather(*(dispatcher.emit(_opened(idx)) for idx in range(4, 8)))
+
+    allow_first_to_finish.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    assert handler.ids == ["c1", "c3"]
+
+
+@pytest.mark.asyncio
+async def test_drop_newest_saturated_queue_drains_pre_stop_event_and_drops_post_stop_emits() -> (
+    None
+):
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        max_pending_events=1, backpressure_policy=EventBackpressurePolicy.DROP_NEWEST
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await asyncio.gather(*(dispatcher.emit(_opened(idx)) for idx in range(4, 8)))
+
+    allow_first_to_finish.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    assert handler.ids == ["c1", "c2"]
+
+
+# Explicit queue-accounting invariants for saturated backpressure cases.
+def _simulate_saturated_queue_suffix(
+    *,
+    policy: EventBackpressurePolicy,
+    capacity: int,
+    emitted_ids: list[str],
+) -> list[str]:
+    """Model the suffix a saturated queue should retain for a drop policy."""
+
+    queue: list[str] = []
+    for connection_id in emitted_ids:
+        if len(queue) < capacity:
+            queue.append(connection_id)
+            continue
+        if policy == EventBackpressurePolicy.DROP_OLDEST:
+            queue.pop(0)
+            queue.append(connection_id)
+            continue
+        if policy == EventBackpressurePolicy.DROP_NEWEST:
+            continue
+        raise AssertionError(f"Unsupported policy for simulation: {policy}")
+    return queue
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "capacity"),
+    [
+        (EventBackpressurePolicy.DROP_NEWEST, 1),
+        (EventBackpressurePolicy.DROP_NEWEST, 3),
+        (EventBackpressurePolicy.DROP_OLDEST, 1),
+        (EventBackpressurePolicy.DROP_OLDEST, 3),
+    ],
+)
+async def test_backpressure_drop_policies_match_queue_accounting_invariant_under_saturation(
+    policy: EventBackpressurePolicy,
+    capacity: int,
+) -> None:
+    """Invariant: delivered suffix must equal explicit saturated-queue accounting model."""
+    for _ in range(20):
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        class BlockingThenRecordHandler:
+            def __init__(self) -> None:
+                self.ids: list[str] = []
+
+            async def on_event(self, event: NetworkEvent) -> None:
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                connection_id = event.metadata.connection_id
+                self.ids.append(connection_id)
+                if connection_id == "c1":
+                    first_started.set()
+                    await release_first.wait()
+
+        handler = BlockingThenRecordHandler()
+        dispatcher = AsyncioEventDispatcher(
+            handler,
+            EventDeliverySettings(max_pending_events=capacity, backpressure_policy=policy),
+            logging.getLogger("test"),
+        )
+        await dispatcher.start()
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        burst_ids = [f"c{idx}" for idx in range(2, 14)]
+        for connection_id in burst_ids:
+            await dispatcher.emit(_opened(connection_id))
+
+        expected_suffix = _simulate_saturated_queue_suffix(
+            policy=policy, capacity=capacity, emitted_ids=burst_ids
+        )
+
+        release_first.set()
+        await dispatcher.stop()
+
+        assert handler.ids == ["c1", *expected_suffix]
+
+
+@pytest.mark.asyncio
+async def test_block_policy_repeated_concurrent_emit_accounting_is_lossless_and_bounded() -> None:
+    """Invariant: BLOCK never drops accepted emits and queue occupancy never exceeds configured capacity."""
+    capacity = 2
+
+    async def _wait_until_queue_is_full(dispatcher: AsyncioEventDispatcher) -> None:
+        while len(dispatcher._queue) < capacity:  # type: ignore[attr-defined]
+            await asyncio.sleep(0)
+
+    for _ in range(15):
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        handler_seen: list[str] = []
+        producer_attempted = [asyncio.Event() for _ in range(2, 12)]
+
+        class BlockingThenRecordHandler:
+            async def on_event(self, event: NetworkEvent) -> None:
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                connection_id = event.metadata.connection_id
+                handler_seen.append(connection_id)
+                if connection_id == "c1":
+                    first_started.set()
+                    await release_first.wait()
+
+        dispatcher = AsyncioEventDispatcher(
+            BlockingThenRecordHandler(),
+            EventDeliverySettings(
+                max_pending_events=capacity, backpressure_policy=EventBackpressurePolicy.BLOCK
+            ),
+            logging.getLogger("test"),
+        )
+        await dispatcher.start()
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        async def _produce(idx: int, attempted: asyncio.Event) -> None:
+            attempted.set()
+            await dispatcher.emit(_opened(idx))
+
+        producers = [
+            asyncio.create_task(_produce(idx, attempted))
+            for idx, attempted in zip(range(2, 12), producer_attempted, strict=True)
+        ]
+        await asyncio.wait_for(
+            asyncio.gather(*(attempted.wait() for attempted in producer_attempted)), timeout=1.0
+        )
+        await asyncio.wait_for(_wait_until_queue_is_full(dispatcher), timeout=1.0)
+
+        # Queue occupancy invariant while handler is blocked.
+        assert len(dispatcher._queue) == capacity  # type: ignore[attr-defined]
+        assert any(task.done() is False for task in producers)
+
+        release_first.set()
+        await asyncio.wait_for(asyncio.gather(*producers), timeout=2.0)
+        await dispatcher.stop()
+
+        delivered_payload = handler_seen[1:]
+        expected_payload = [f"c{idx}" for idx in range(2, 12)]
+        assert sorted(delivered_payload) == sorted(expected_payload)
+        assert len(delivered_payload) == len(expected_payload)
+        assert len(set(delivered_payload)) == len(expected_payload)
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_supports_start_stop_start_reuse() -> None:
+    handler = Recorder()
+    dispatcher = AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await handler.wait_for_event_count(1)
+    await dispatcher.stop()
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened(2))
+    await handler.wait_for_event_count(2)
+    await dispatcher.stop()
+
+    ids = [e.metadata.connection_id for e in handler.events if isinstance(e, ConnectionOpenedEvent)]
+    assert ids == ["c1", "c2"]
+
+
+# Runtime statistics and observability counters.
+@pytest.mark.asyncio
+async def test_runtime_stats_capture_inline_fallback_and_dispatch_attempts() -> None:
+    handler = Recorder()
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+
+    await dispatcher.emit(_opened(1))
+
+    stats = dispatcher.runtime_stats
+    assert stats.emit_calls_total == 1
+    assert stats.inline_fallback_total == 1
+    assert stats.handler_dispatch_attempts_total == 1
+    assert stats.enqueued_total == 0
+    assert stats.queue_peak == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_stats_capture_backpressure_drop_counts() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_first.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(
+            max_pending_events=1, backpressure_policy=EventBackpressurePolicy.DROP_NEWEST
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+
+    release_first.set()
+    await dispatcher.stop()
+
+    stats = dispatcher.runtime_stats
+    assert stats.emit_calls_total == 3
+    assert stats.enqueued_total == 2
+    assert stats.dropped_backpressure_newest_total == 1
+    assert stats.dropped_backpressure_oldest_total == 0
+    assert stats.queue_peak == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_stats_capture_stop_phase_drop_counts() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_first.wait()
+
+    settings = EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND)
+    dispatcher = AsyncioEventDispatcher(BlockingHandler(), settings, logging.getLogger("test"))
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+    release_first.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    stats = dispatcher.runtime_stats
+    assert stats.emit_calls_total == 3
+    assert stats.dropped_stop_phase_total == 2
+    assert stats.enqueued_total == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_stats_characterize_stop_with_pending_queue_work() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_first.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(
+            max_pending_events=2, backpressure_policy=EventBackpressurePolicy.BLOCK
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    await dispatcher.emit(_opened(2))
+    await dispatcher.emit(_opened(3))
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await dispatcher.emit(_opened(99))
+    release_first.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    stats = dispatcher.runtime_stats
+    assert stats.enqueued_total == 3
+    assert stats.dropped_stop_phase_total == 1
+    assert stats.queue_depth == 0
+    assert stats.queue_peak == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_phase_drops_emit_distinct_warning_signal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent) and event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_first.wait()
+
+    caplog.set_level(logging.WARNING)
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+        error_source="tcp/server/127.0.0.1/9000",
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+    release_first.set()
+    await asyncio.wait_for(stop_task, timeout=1.0)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("dispatcher stop is in progress" in message for message in messages)
+    assert all("Dropped newest event due to backpressure." not in message for message in messages)
+
+
+# Handler-failure policies exposed through the dispatcher contract.
+@pytest.mark.asyncio
+async def test_handler_failure_policy_emit_error_event_emits_network_error_event() -> None:
+    handler = Recorder(fail=True)
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.EMIT_ERROR_EVENT,
+        ),
+        logging.getLogger("test"),
+        error_source="tcp/client/127.0.0.1/12345",
+    )
+
+    await dispatcher.emit(_opened(1))
+
+    error_events = [event for event in handler.events if isinstance(event, NetworkErrorEvent)]
+    assert len(handler.events) == 2
+    assert len(error_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_emit_error_event_does_not_recurse_on_network_error_event() -> (
+    None
+):
+    handler = Recorder(fail=True)
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.EMIT_ERROR_EVENT,
+        ),
+        logging.getLogger("test"),
+        error_source="tcp/client/127.0.0.1/12345",
+    )
+
+    await dispatcher.emit(
+        NetworkErrorEvent(resource_id="tcp/client/127.0.0.1/12345", error=RuntimeError("origin"))
+    )
+
+    assert len(handler.events) == 1
+    assert isinstance(handler.events[0], NetworkErrorEvent)
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_stop_component_invokes_stop_callback() -> None:
+    handler = Recorder(fail=True)
+    stop_calls = 0
+
+    async def stop_component() -> None:
+        nonlocal stop_calls
+        stop_calls += 1
+
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+
+    await dispatcher.emit(_opened(1))
+
+    stop_events = [
+        event for event in handler.events if isinstance(event, HandlerFailurePolicyStopEvent)
+    ]
+    assert len(stop_events) == 1
+    assert stop_events[0].triggering_event_name == "ConnectionOpenedEvent"
+    assert stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_stop_component_is_safe_in_background_worker() -> None:
+    stop_calls = 0
+    stopped = asyncio.Event()
+
+    class StopInBackgroundHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            del event
+            raise RuntimeError("boom")
+
+    async def stop_component() -> None:
+        nonlocal stop_calls
+        stop_calls += 1
+        stopped.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        StopInBackgroundHandler(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(stopped.wait(), timeout=1.0)
+    await dispatcher.stop()
+    assert stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_emit_error_event_does_not_deadlock_when_block_queue_is_full() -> (
+    None
+):
+    first_started = asyncio.Event()
+    release_failure = asyncio.Event()
+    second_delivered = asyncio.Event()
+    error_event_delivered = asyncio.Event()
+
+    class FailFirstThenRecord:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                if event.metadata.connection_id == "c1":
+                    first_started.set()
+                    await release_failure.wait()
+                    raise RuntimeError("boom")
+                if event.metadata.connection_id == "c2":
+                    second_delivered.set()
+                    return
+            if isinstance(event, NetworkErrorEvent):
+                error_event_delivered.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        FailFirstThenRecord(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=1,
+            backpressure_policy=EventBackpressurePolicy.BLOCK,
+            handler_failure_policy=EventHandlerFailurePolicy.EMIT_ERROR_EVENT,
+        ),
+        logging.getLogger("test"),
+        error_source="tcp/client/127.0.0.1/12345",
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+
+    release_failure.set()
+    await asyncio.wait_for(error_event_delivered.wait(), timeout=1.0)
+    await asyncio.wait_for(second_delivered.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_stop_component_does_not_deadlock_when_block_queue_is_full() -> (
+    None
+):
+    first_started = asyncio.Event()
+    release_failure = asyncio.Event()
+    second_delivered = asyncio.Event()
+    stop_event_delivered = asyncio.Event()
+    stop_callback_called = asyncio.Event()
+
+    class FailFirstThenRecord:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                if event.metadata.connection_id == "c1":
+                    first_started.set()
+                    await release_failure.wait()
+                    raise RuntimeError("boom")
+                if event.metadata.connection_id == "c2":
+                    second_delivered.set()
+                    return
+            if isinstance(event, HandlerFailurePolicyStopEvent):
+                stop_event_delivered.set()
+
+    async def stop_component() -> None:
+        stop_callback_called.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        FailFirstThenRecord(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=1,
+            backpressure_policy=EventBackpressurePolicy.BLOCK,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await dispatcher.emit(_opened(2))
+
+    release_failure.set()
+    await asyncio.wait_for(stop_event_delivered.wait(), timeout=1.0)
+    await asyncio.wait_for(stop_callback_called.wait(), timeout=1.0)
+    await asyncio.wait_for(second_delivered.wait(), timeout=1.0)
+    await dispatcher.stop()
+    assert dispatcher.runtime_stats.queue_depth == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_component_policy_with_concurrent_external_stop_is_non_recursive_and_non_deadlocking() -> (
+    None
+):
+    stop_calls = 0
+    callback_started = asyncio.Event()
+    callback_finished = asyncio.Event()
+    observed: list[NetworkEvent] = []
+    dispatcher: AsyncioEventDispatcher
+
+    class FailingThenRecordHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            observed.append(event)
+            if isinstance(event, ConnectionOpenedEvent):
+                raise RuntimeError("boom")
+
+    async def stop_component() -> None:
+        nonlocal stop_calls
+        stop_calls += 1
+        callback_started.set()
+        await dispatcher.stop()
+        callback_finished.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        FailingThenRecordHandler(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(callback_started.wait(), timeout=1.0)
+    external_stop_task = asyncio.create_task(dispatcher.stop())
+    await asyncio.wait_for(callback_finished.wait(), timeout=1.0)
+    await asyncio.wait_for(external_stop_task, timeout=1.0)
+
+    assert stop_calls == 1
+    assert dispatcher.is_running is False
+    assert sum(isinstance(event, HandlerFailurePolicyStopEvent) for event in observed) == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_component_policy_emits_observable_stop_event_before_callback() -> None:
+    observed: list[NetworkEvent] = []
+
+    class FailingThenRecordHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            observed.append(event)
+            if isinstance(event, ConnectionOpenedEvent):
+                raise RuntimeError("boom")
+
+    stop_calls = 0
+
+    async def stop_component() -> None:
+        nonlocal stop_calls
+        stop_calls += 1
+
+    dispatcher = AsyncioEventDispatcher(
+        FailingThenRecordHandler(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        error_source="tcp/client/127.0.0.1/12345",
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+
+    await dispatcher.emit(_opened(7))
+
+    assert isinstance(observed[1], HandlerFailurePolicyStopEvent)
+    assert stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_raise_in_inline_mode_raises() -> None:
+    handler = Recorder(fail=True)
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+        ),
+        logging.getLogger("test"),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await dispatcher.emit(_opened(1))
+
+
+# Stop-policy validation and compatibility rules.
+def test_dispatcher_stop_policy_disabled_is_explicit_default() -> None:
+    dispatcher = AsyncioEventDispatcher(
+        Recorder(),
+        EventDeliverySettings(),
+        logging.getLogger("test"),
+    )
+
+    assert dispatcher.stop_policy == DispatcherStopPolicy.disabled()
+
+
+def test_dispatcher_stop_policy_rejects_enabled_without_callback() -> None:
+    with pytest.raises(ValueError, match="requires a callback"):
+        AsyncioEventDispatcher(
+            Recorder(),
+            EventDeliverySettings(),
+            logging.getLogger("test"),
+            stop_policy=DispatcherStopPolicy(enabled=True),
+        )
+
+
+def test_dispatcher_rejects_legacy_callback_and_explicit_policy_together() -> None:
+    async def stop_component() -> None:
+        return None
+
+    with pytest.raises(ValueError, match="either stop_policy or stop_component_callback"):
+        AsyncioEventDispatcher(
+            Recorder(),
+            EventDeliverySettings(),
+            logging.getLogger("test"),
+            stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+            stop_component_callback=stop_component,
+        )
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_policy_raise_in_inline_mode_background_still_logs_only() -> None:
+    handler = Recorder(fail=True)
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await handler.wait_for_event_count(1)
+    await dispatcher.stop()
+    assert len(handler.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_cancelled_error_is_treated_as_handler_failure() -> None:
+    first_seen = asyncio.Event()
+    second_seen = asyncio.Event()
+    events: list[NetworkEvent] = []
+
+    class CancelFirstThenRecord:
+        async def on_event(self, event: NetworkEvent) -> None:
+            events.append(event)
+            if len(events) == 1:
+                first_seen.set()
+                raise asyncio.CancelledError
+            second_seen.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        CancelFirstThenRecord(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.LOG_ONLY,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened(1))
+    await asyncio.wait_for(first_seen.wait(), timeout=1.0)
+
+    assert dispatcher.is_running is True
+    assert dispatcher.runtime_stats.handler_failures_total == 1
+
+    await dispatcher.emit(_opened(2))
+    await asyncio.wait_for(second_seen.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+    assert [type(event).__name__ for event in events] == [
+        "ConnectionOpenedEvent",
+        "ConnectionOpenedEvent",
+    ]

--- a/tests/unit/test_event_identity_resource_id.py
+++ b/tests/unit/test_event_identity_resource_id.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_events import ConnectionOpenedEvent, ConnectionRejectedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import EventDispatchMode, EventHandlerFailurePolicy
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+
+
+def test_resource_id_is_canonical_identity_across_events() -> None:
+    metadata = ConnectionMetadata(connection_id="conn-1", role=ConnectionRole.CLIENT)
+
+    events = [
+        BytesReceivedEvent(resource_id="conn-1", data=b"x"),
+        ConnectionClosedEvent(resource_id="conn-1", previous_state=ConnectionState.CONNECTED),
+        ConnectionOpenedEvent(resource_id="conn-1", metadata=metadata),
+        ConnectionRejectedEvent(
+            resource_id="component-1",
+            connection_id="component-1/rejected-1",
+            reason="max_connections_reached",
+            remote_host="127.0.0.1",
+            remote_port=9876,
+        ),
+        NetworkErrorEvent(resource_id="component-1", error=RuntimeError("boom")),
+        HandlerFailurePolicyStopEvent(
+            resource_id="component-1",
+            triggering_event_name="BytesReceivedEvent",
+            error=RuntimeError("stop"),
+            policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            dispatch_mode=EventDispatchMode.INLINE,
+        ),
+        ComponentLifecycleChangedEvent(
+            resource_id="component-1",
+            previous=ComponentLifecycleState.STARTING,
+            current=ComponentLifecycleState.RUNNING,
+        ),
+        ReconnectAttemptStartedEvent(resource_id="component-1", attempt=1),
+        ReconnectAttemptFailedEvent(
+            resource_id="component-1", attempt=1, error=RuntimeError("fail")
+        ),
+        ReconnectScheduledEvent(resource_id="component-1", attempt=2, delay_seconds=0.25),
+    ]
+
+    assert [event.resource_id for event in events] == [
+        "conn-1",
+        "conn-1",
+        "conn-1",
+        "component-1",
+        "component-1",
+        "component-1",
+        "component-1",
+        "component-1",
+        "component-1",
+        "component-1",
+    ]
+
+
+def test_connection_opened_event_rejects_mismatched_resource_id() -> None:
+    metadata = ConnectionMetadata(connection_id="conn-actual", role=ConnectionRole.CLIENT)
+
+    with pytest.raises(ValueError, match="resource_id must match metadata.connection_id"):
+        ConnectionOpenedEvent(resource_id="conn-other", metadata=metadata)
+
+
+def test_generic_consumer_groups_by_resource_id_without_branching() -> None:
+    events = [
+        BytesReceivedEvent(resource_id="conn-a", data=b"a"),
+        ConnectionClosedEvent(resource_id="conn-a", previous_state=ConnectionState.CONNECTED),
+        ConnectionRejectedEvent(
+            resource_id="component-b",
+            connection_id="component-b/rejected-2",
+            reason="max_connections_reached",
+        ),
+        NetworkErrorEvent(resource_id="component-b", error=RuntimeError("err")),
+        ReconnectScheduledEvent(resource_id="component-b", attempt=2, delay_seconds=1.5),
+    ]
+
+    grouped: dict[str, int] = {}
+    for event in events:
+        grouped[event.resource_id] = grouped.get(event.resource_id, 0) + 1
+
+    assert grouped == {"conn-a": 2, "component-b": 3}

--- a/tests/unit/test_event_registry_consistency.py
+++ b/tests/unit/test_event_registry_consistency.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_metadata import ConnectionMetadata
+from aionetx.api.connection_events import ConnectionOpenedEvent, ConnectionRejectedEvent
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.event_delivery_settings import EventDispatchMode, EventHandlerFailurePolicy
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.api._event_registry import (
+    NETWORK_EVENT_HANDLER_METHODS,
+    NETWORK_EVENT_RECORDING_BUCKETS,
+    NETWORK_EVENT_REGISTRY,
+    NETWORK_EVENT_TYPES,
+    EventRegistryEntry,
+    validate_network_event_registry_conformance,
+)
+from aionetx.api.reconnect_events import (
+    ReconnectAttemptFailedEvent,
+    ReconnectAttemptStartedEvent,
+    ReconnectScheduledEvent,
+)
+from aionetx.api.base_network_event_handler import BaseNetworkEventHandler
+from aionetx.api.network_event import NetworkEvent
+from aionetx.testing import RecordingEventHandler
+
+
+def _example_events() -> list[object]:
+    metadata = ConnectionMetadata(connection_id="c-1", role=ConnectionRole.CLIENT)
+    return [
+        ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata),
+        ConnectionRejectedEvent(
+            resource_id="tcp/server/127.0.0.1/1234",
+            connection_id="tcp/server/127.0.0.1/1234/connection/rejected-1",
+            reason="max_connections_reached",
+            remote_host="127.0.0.1",
+            remote_port=4567,
+        ),
+        ConnectionClosedEvent(resource_id="c-1", previous_state=ConnectionState.CONNECTED),
+        BytesReceivedEvent(resource_id="c-1", data=b"payload"),
+        NetworkErrorEvent(resource_id="tcp/client/127.0.0.1/1234", error=RuntimeError("boom")),
+        ComponentLifecycleChangedEvent(
+            resource_id="tcp/client/127.0.0.1/1234",
+            previous=ComponentLifecycleState.STARTING,
+            current=ComponentLifecycleState.RUNNING,
+        ),
+        HandlerFailurePolicyStopEvent(
+            resource_id="tcp/client/127.0.0.1/1234",
+            triggering_event_name="NetworkErrorEvent",
+            error=RuntimeError("handler"),
+            policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+        ),
+        ReconnectAttemptStartedEvent(resource_id="tcp/client/127.0.0.1/1234", attempt=1),
+        ReconnectAttemptFailedEvent(
+            resource_id="tcp/client/127.0.0.1/1234",
+            attempt=1,
+            error=RuntimeError("dial"),
+            next_delay_seconds=0.5,
+        ),
+        ReconnectScheduledEvent(
+            resource_id="tcp/client/127.0.0.1/1234", attempt=2, delay_seconds=1.0
+        ),
+    ]
+
+
+def test_registry_contains_unique_event_types() -> None:
+    event_types = [entry.event_type for entry in NETWORK_EVENT_REGISTRY]
+    assert len(event_types) == len(set(event_types))
+    assert tuple(event_types) == NETWORK_EVENT_TYPES
+
+
+def test_registry_projection_maps_stay_aligned_with_registry_entries() -> None:
+    expected_handler_methods = {
+        entry.event_type: entry.handler_method_name for entry in NETWORK_EVENT_REGISTRY
+    }
+    expected_recording_buckets = {
+        entry.event_type: entry.recording_bucket_name for entry in NETWORK_EVENT_REGISTRY
+    }
+
+    assert NETWORK_EVENT_HANDLER_METHODS == expected_handler_methods
+    assert NETWORK_EVENT_RECORDING_BUCKETS == expected_recording_buckets
+
+
+def test_registry_conformance_accepts_current_union_and_registry() -> None:
+    validate_network_event_registry_conformance(NetworkEvent, NETWORK_EVENT_REGISTRY)
+
+
+def test_registry_conformance_raises_for_missing_registry_entries() -> None:
+    with pytest.raises(RuntimeError, match="Missing registry entries for: BytesReceivedEvent"):
+        validate_network_event_registry_conformance(
+            ConnectionOpenedEvent | BytesReceivedEvent,
+            (
+                EventRegistryEntry(
+                    event_type=ConnectionOpenedEvent,
+                    handler_method_name="on_connection_opened",
+                    recording_bucket_name="opened_events",
+                ),
+            ),
+        )
+
+
+def test_registry_conformance_raises_for_extra_registry_entries() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="Registry contains events missing from the union: BytesReceivedEvent",
+    ):
+        validate_network_event_registry_conformance(
+            ConnectionOpenedEvent,
+            (
+                EventRegistryEntry(
+                    event_type=ConnectionOpenedEvent,
+                    handler_method_name="on_connection_opened",
+                    recording_bucket_name="opened_events",
+                ),
+                EventRegistryEntry(
+                    event_type=BytesReceivedEvent,
+                    handler_method_name="on_bytes_received",
+                    recording_bucket_name="received_events",
+                ),
+            ),
+        )
+
+
+def test_reconnect_registry_event_types_match_reconnect_event_model() -> None:
+    reconnect_types = {
+        entry.event_type
+        for entry in NETWORK_EVENT_REGISTRY
+        if entry.handler_method_name.startswith("on_reconnect_")
+    }
+
+    assert reconnect_types == {
+        ReconnectAttemptStartedEvent,
+        ReconnectAttemptFailedEvent,
+        ReconnectScheduledEvent,
+    }
+
+
+def test_base_network_event_handler_declares_all_registry_typed_hooks() -> None:
+    for hook_name in NETWORK_EVENT_HANDLER_METHODS.values():
+        assert hasattr(BaseNetworkEventHandler, hook_name), (
+            "BaseNetworkEventHandler must expose a typed hook for every registry event."
+        )
+
+
+def test_recording_event_handler_declares_all_registry_recording_buckets() -> None:
+    handler = RecordingEventHandler()
+    for bucket_name in NETWORK_EVENT_RECORDING_BUCKETS.values():
+        assert hasattr(handler, bucket_name), (
+            "RecordingEventHandler must expose a bucket for every registry event."
+        )
+
+
+@pytest.mark.asyncio
+async def test_recording_event_handler_uses_registry_for_all_event_types() -> None:
+    handler = RecordingEventHandler()
+    for event in _example_events():
+        await handler.on_event(event)
+
+    assert len(handler.events) == len(NETWORK_EVENT_TYPES)
+    for bucket_name in NETWORK_EVENT_RECORDING_BUCKETS.values():
+        assert len(getattr(handler, bucket_name)) == 1
+    assert handler.received_by_connection["c-1"] == [b"payload"]

--- a/tests/unit/test_heartbeat_validation.py
+++ b/tests/unit/test_heartbeat_validation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.errors import HeartbeatConfigurationError
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from tests.internal_asyncio_impl_refs import validate_heartbeat_provider
+
+
+def test_heartbeat_validation_requires_provider_when_enabled() -> None:
+    with pytest.raises(HeartbeatConfigurationError, match="heartbeat_provider"):
+        validate_heartbeat_provider(
+            heartbeat_settings=TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+            heartbeat_provider=None,
+        )
+
+
+def test_heartbeat_validation_allows_missing_provider_when_disabled() -> None:
+    validate_heartbeat_provider(
+        heartbeat_settings=TcpHeartbeatSettings(enabled=False, interval_seconds=1.0),
+        heartbeat_provider=None,
+    )

--- a/tests/unit/test_identifier_schema.py
+++ b/tests/unit/test_identifier_schema.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.connection_lifecycle import ConnectionRole
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import AsyncioMulticastReceiver
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from tests.internal_asyncio_impl_refs import (
+    multicast_receiver_component_id,
+    tcp_client_component_id,
+    tcp_client_connection_id,
+    tcp_server_component_id,
+    tcp_server_connection_id,
+    udp_receiver_component_id,
+)
+from tests.helpers import wait_for_condition
+
+
+def _unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_component_id_helpers_follow_canonical_schema() -> None:
+    assert tcp_client_component_id("127.0.0.1", 5000) == "tcp/client/127.0.0.1/5000"
+    assert (
+        tcp_client_connection_id("127.0.0.1", 5000, ("10.0.0.1", 6000))
+        == "tcp/client/10.0.0.1/6000/connection"
+    )
+    assert (
+        tcp_client_connection_id("127.0.0.1", 5000, None) == "tcp/client/127.0.0.1/5000/connection"
+    )
+    assert tcp_client_component_id("127.0.0.1", 5000) != tcp_client_connection_id(
+        "127.0.0.1", 5000, None
+    )
+    assert tcp_server_component_id("127.0.0.1", 5001) == "tcp/server/127.0.0.1/5001"
+    assert (
+        tcp_server_connection_id(("10.0.0.2", 7000), 3) == "tcp/server/10.0.0.2/7000/connection/3"
+    )
+    assert tcp_server_connection_id(None, 4) == "tcp/server/unknown/unknown/connection/4"
+    assert udp_receiver_component_id("0.0.0.0", 9000) == "udp/receiver/0.0.0.0/9000"
+    assert multicast_receiver_component_id("239.0.0.1", 9999) == "udp/multicast/239.0.0.1/9999"
+
+
+def test_connection_role_excludes_udp_sender() -> None:
+    assert "UDP_SENDER" not in ConnectionRole.__members__
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_lifecycle_events_use_component_ids(recording_event_handler) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=65001,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    await client.start()
+    await client.stop()
+    assert any(
+        event.resource_id == "tcp/client/127.0.0.1/65001"
+        for event in recording_event_handler.lifecycle_events
+    )
+    assert all(
+        event.resource_id == "tcp/client/127.0.0.1/65001"
+        for event in recording_event_handler.reconnect_attempt_started_events
+    )
+    assert all(
+        event.resource_id == "tcp/client/127.0.0.1/65001"
+        for event in recording_event_handler.reconnect_attempt_failed_events
+    )
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_connection_events_use_connection_ids(
+    recording_event_handler, unused_tcp_port: int
+) -> None:
+    async def handle_client(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", unused_tcp_port)
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=recording_event_handler,
+    )
+    try:
+        await client.start()
+        await wait_for_condition(
+            lambda: bool(recording_event_handler.opened_events), timeout_seconds=1.0
+        )
+        assert recording_event_handler.opened_events
+        assert all(
+            event.resource_id.startswith(f"tcp/client/127.0.0.1/{unused_tcp_port}/connection")
+            for event in recording_event_handler.opened_events
+        )
+        assert all(
+            event.resource_id != f"tcp/client/127.0.0.1/{unused_tcp_port}"
+            for event in recording_event_handler.opened_events
+        )
+    finally:
+        await client.stop()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_lifecycle_events_use_component_ids(recording_event_handler) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    await server.start()
+    await server.stop()
+    assert any(
+        event.resource_id.startswith("tcp/server/")
+        for event in recording_event_handler.lifecycle_events
+    )
+
+
+@pytest.mark.asyncio
+async def test_datagram_receivers_use_canonical_component_ids(recording_event_handler) -> None:
+    udp_receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_unused_udp_port()),
+        event_handler=recording_event_handler,
+    )
+    await udp_receiver.start()
+    await udp_receiver.stop()
+    assert any(
+        event.resource_id.startswith("udp/receiver/")
+        for event in recording_event_handler.lifecycle_events
+    )
+
+    multicast_receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(group_ip="239.255.0.50", port=21055),
+        event_handler=recording_event_handler,
+    )
+    assert multicast_receiver._connection_id.startswith("udp/multicast/")  # type: ignore[attr-defined]

--- a/tests/unit/test_installed_artifact_script_import_boundaries.py
+++ b/tests/unit/test_installed_artifact_script_import_boundaries.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _root_imported_symbols(script_path: Path) -> set[str]:
+    module = ast.parse(script_path.read_text(encoding="utf-8"))
+    symbols: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.ImportFrom) and node.module == "aionetx":
+            symbols.update(alias.name for alias in node.names)
+    return symbols
+
+
+def test_installed_artifact_scripts_only_import_curated_root_symbols() -> None:
+    import aionetx
+
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts = [
+        repo_root / "scripts" / "ci" / "installed_artifact_smoke.py",
+        repo_root / "scripts" / "ci" / "installed_artifact_semantic_minisuite.py",
+    ]
+
+    allowed_root_symbols = set(aionetx.PUBLIC_API)
+    for script in scripts:
+        imported_from_root = _root_imported_symbols(script)
+        assert imported_from_root.issubset(allowed_root_symbols), (
+            f"{script.relative_to(repo_root)} imports non-root curated symbols: "
+            f"{sorted(imported_from_root - allowed_root_symbols)!r}"
+        )

--- a/tests/unit/test_lifecycle_guards.py
+++ b/tests/unit/test_lifecycle_guards.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from tests.internal_asyncio_impl_refs import (
+    LifecycleRole,
+    assert_legal_lifecycle_transition,
+)
+
+
+@pytest.mark.parametrize("role", list(LifecycleRole))
+def test_lifecycle_policy_is_shared_across_managed_roles(role: LifecycleRole) -> None:
+    assert_legal_lifecycle_transition(
+        component_name=f"component/{role.value}",
+        role=role,
+        previous=ComponentLifecycleState.STOPPED,
+        target=ComponentLifecycleState.STARTING,
+    )
+    assert_legal_lifecycle_transition(
+        component_name=f"component/{role.value}",
+        role=role,
+        previous=ComponentLifecycleState.STARTING,
+        target=ComponentLifecycleState.RUNNING,
+    )
+    assert_legal_lifecycle_transition(
+        component_name=f"component/{role.value}",
+        role=role,
+        previous=ComponentLifecycleState.RUNNING,
+        target=ComponentLifecycleState.STOPPING,
+    )
+    assert_legal_lifecycle_transition(
+        component_name=f"component/{role.value}",
+        role=role,
+        previous=ComponentLifecycleState.STOPPING,
+        target=ComponentLifecycleState.STOPPED,
+    )
+
+
+@pytest.mark.parametrize("role", list(LifecycleRole))
+def test_lifecycle_policy_rejects_running_to_stopped_for_all_roles(role: LifecycleRole) -> None:
+    with pytest.raises(RuntimeError, match="Illegal lifecycle transition"):
+        assert_legal_lifecycle_transition(
+            component_name=f"component/{role.value}",
+            role=role,
+            previous=ComponentLifecycleState.RUNNING,
+            target=ComponentLifecycleState.STOPPED,
+        )
+
+
+@pytest.mark.parametrize("role", list(LifecycleRole))
+@pytest.mark.parametrize(
+    ("previous", "target"),
+    [
+        (ComponentLifecycleState.STOPPED, ComponentLifecycleState.RUNNING),
+        (ComponentLifecycleState.STOPPED, ComponentLifecycleState.STOPPING),
+        (ComponentLifecycleState.RUNNING, ComponentLifecycleState.STARTING),
+        (ComponentLifecycleState.STOPPING, ComponentLifecycleState.RUNNING),
+    ],
+)
+def test_lifecycle_policy_rejects_invalid_cross_state_transitions_for_all_roles(
+    role: LifecycleRole,
+    previous: ComponentLifecycleState,
+    target: ComponentLifecycleState,
+) -> None:
+    with pytest.raises(RuntimeError, match="Illegal lifecycle transition"):
+        assert_legal_lifecycle_transition(
+            component_name=f"component/{role.value}",
+            role=role,
+            previous=previous,
+            target=target,
+        )

--- a/tests/unit/test_lifecycle_publication.py
+++ b/tests/unit/test_lifecycle_publication.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from tests.internal_asyncio_impl_refs import (
+    apply_stopped_transition_if_stopping,
+    apply_stopping_transition_if_active,
+)
+
+
+def test_apply_stopping_transition_if_active_applies_for_starting_or_running() -> None:
+    state = ComponentLifecycleState.STARTING
+    applied: list[tuple[ComponentLifecycleState, ComponentLifecycleState]] = []
+
+    def _get_state() -> ComponentLifecycleState:
+        return state
+
+    def _apply(target: ComponentLifecycleState):
+        nonlocal state
+        previous = state
+        state = target
+        applied.append((previous, target))
+        return (previous, target)
+
+    event = apply_stopping_transition_if_active(get_state=_get_state, apply_transition=_apply)
+
+    assert event == (ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPING)
+    assert applied == [(ComponentLifecycleState.STARTING, ComponentLifecycleState.STOPPING)]
+
+
+def test_apply_stopping_transition_if_active_is_noop_when_already_stopped() -> None:
+    state = ComponentLifecycleState.STOPPED
+
+    def _get_state() -> ComponentLifecycleState:
+        return state
+
+    def _apply(_target: ComponentLifecycleState):
+        raise AssertionError("apply_transition should not be called")
+
+    event = apply_stopping_transition_if_active(get_state=_get_state, apply_transition=_apply)
+
+    assert event is None
+
+
+def test_apply_stopped_transition_if_stopping_applies_only_from_stopping() -> None:
+    state = ComponentLifecycleState.STOPPING
+    applied: list[tuple[ComponentLifecycleState, ComponentLifecycleState]] = []
+
+    def _get_state() -> ComponentLifecycleState:
+        return state
+
+    def _apply(target: ComponentLifecycleState):
+        nonlocal state
+        previous = state
+        state = target
+        applied.append((previous, target))
+        return (previous, target)
+
+    event = apply_stopped_transition_if_stopping(get_state=_get_state, apply_transition=_apply)
+
+    assert event == (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+    assert applied == [(ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)]
+
+
+def test_apply_stopped_transition_if_stopping_is_noop_outside_stopping() -> None:
+    state = ComponentLifecycleState.RUNNING
+
+    def _get_state() -> ComponentLifecycleState:
+        return state
+
+    def _apply(_target: ComponentLifecycleState):
+        raise AssertionError("apply_transition should not be called")
+
+    event = apply_stopped_transition_if_stopping(get_state=_get_state, apply_transition=_apply)
+
+    assert event is None
+
+
+def test_lifecycle_invariant_stopping_transition_is_not_reentrant_once_stopped() -> None:
+    state = ComponentLifecycleState.STOPPED
+
+    def _get_state() -> ComponentLifecycleState:
+        return state
+
+    def _apply(_target: ComponentLifecycleState):
+        raise AssertionError("apply_transition should not be called after STOPPED is published")
+
+    event = apply_stopping_transition_if_active(get_state=_get_state, apply_transition=_apply)
+
+    assert event is None
+
+
+@pytest.mark.parametrize(
+    ("state", "helper"),
+    [
+        (
+            ComponentLifecycleState.STARTING,
+            apply_stopping_transition_if_active,
+        ),
+        (
+            ComponentLifecycleState.RUNNING,
+            apply_stopping_transition_if_active,
+        ),
+        (
+            ComponentLifecycleState.STOPPING,
+            apply_stopped_transition_if_stopping,
+        ),
+    ],
+)
+def test_transition_helpers_fail_fast_if_transition_returns_none(
+    state: ComponentLifecycleState,
+    helper,
+) -> None:
+    with pytest.raises(RuntimeError, match="expected .* transition event"):
+        helper(
+            get_state=lambda: state,
+            apply_transition=lambda _target: None,
+        )

--- a/tests/unit/test_logging_utils.py
+++ b/tests/unit/test_logging_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.internal_asyncio_impl_refs import WarningRateLimiter
+
+
+def test_warning_rate_limiter_rejects_non_positive_interval() -> None:
+    with pytest.raises(ValueError, match="interval_seconds must be > 0"):
+        WarningRateLimiter(interval_seconds=0)
+
+
+def test_warning_rate_limiter_suppresses_repeated_warnings_within_interval() -> None:
+    limiter = WarningRateLimiter(interval_seconds=0.05)
+
+    assert limiter.should_log("x") is True
+    assert limiter.should_log("x") is False
+    time.sleep(0.06)
+    assert limiter.should_log("x") is True
+
+
+def test_warning_rate_limiter_rejects_non_positive_max_keys() -> None:
+    with pytest.raises(ValueError, match="max_keys must be >= 1"):
+        WarningRateLimiter(interval_seconds=1.0, max_keys=0)
+
+
+def test_warning_rate_limiter_evicts_oldest_key_when_max_keys_reached() -> None:
+    limiter = WarningRateLimiter(interval_seconds=60.0, max_keys=3)
+
+    assert limiter.should_log("a") is True
+    assert limiter.should_log("b") is True
+    assert limiter.should_log("c") is True
+    # Dict is now full (3 entries: a, b, c).  Adding "d" should evict "a" (FIFO).
+    assert limiter.should_log("d") is True
+    assert len(limiter._last_logged_at) == 3
+    assert "a" not in limiter._last_logged_at
+    assert "b" in limiter._last_logged_at
+    assert "c" in limiter._last_logged_at
+    assert "d" in limiter._last_logged_at
+
+
+def test_warning_rate_limiter_does_not_evict_on_existing_key_update() -> None:
+    limiter = WarningRateLimiter(interval_seconds=0.01, max_keys=2)
+
+    assert limiter.should_log("a") is True
+    assert limiter.should_log("b") is True
+    # Both slots are occupied. Updating an existing key ("a") after interval
+    # must NOT evict anything — the dict stays at 2 entries.
+    time.sleep(0.02)
+    assert limiter.should_log("a") is True
+    assert len(limiter._last_logged_at) == 2
+    assert "a" in limiter._last_logged_at
+    assert "b" in limiter._last_logged_at

--- a/tests/unit/test_logging_visibility.py
+++ b/tests/unit/test_logging_visibility.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import logging
+import socket
+
+import pytest
+
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+
+class NoopHandler:
+    async def on_event(self, event) -> None:  # pragma: no cover - behavior is logger-focused
+        return None
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.asyncio
+async def test_client_and_server_emit_lifecycle_debug_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    handler = NoopHandler()
+    port = _unused_port()
+
+    server = AsyncioTcpServer(
+        TcpServerSettings(host="127.0.0.1", port=port, max_connections=64), handler
+    )
+    await server.start()
+
+    client = AsyncioTcpClient(
+        TcpClientSettings(
+            host="127.0.0.1", port=port, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        handler,
+    )
+    await client.start()
+    await client.wait_until_connected(timeout_seconds=1.0)
+    await client.stop()
+    await server.stop()
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Starting TCP client" in message for message in messages)
+    assert any("TCP client stopped" in message for message in messages)
+    assert any("Starting TCP server" in message for message in messages)
+    assert any("TCP server stopped" in message for message in messages)

--- a/tests/unit/test_owner_loop_guard.py
+++ b/tests/unit/test_owner_loop_guard.py
@@ -1,0 +1,402 @@
+"""
+Tests for assert_running_on_owner_loop and the cross-loop guards on transports.
+
+These checks pin the fail-fast behavior around event-loop ownership.
+
+Coverage strategy:
+- Unit-test the helper directly for the three cases: no running loop, same
+  loop (no-op), and a different loop (error).
+- Smoke-test that each public transport method is wired to the guard by
+  supplying a manually created event loop as the owner; calling the method
+  from the *test* loop (which is a different loop) must raise RuntimeError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aionetx.implementations.asyncio_impl.runtime_utils import assert_running_on_owner_loop
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the helper function
+# ---------------------------------------------------------------------------
+
+
+def test_assert_running_on_owner_loop_raises_when_no_running_loop() -> None:
+    """RuntimeError must be raised synchronously when there is no running loop."""
+    with pytest.raises(RuntimeError, match="No running loop detected"):
+        assert_running_on_owner_loop(class_name="MyClass", owner_loop=None)
+
+
+@pytest.mark.asyncio
+async def test_assert_running_on_owner_loop_passes_for_same_loop() -> None:
+    """Guard must be a no-op when called from the owner loop."""
+    loop = asyncio.get_running_loop()
+    assert_running_on_owner_loop(class_name="MyClass", owner_loop=loop)
+
+
+@pytest.mark.asyncio
+async def test_assert_running_on_owner_loop_returns_current_loop() -> None:
+    """
+    Return value must be the running loop so callers can pin it on first use.
+
+    Also verifies the guard passes (no raise) when owner_loop is None — the
+    "not yet bound" case.
+    """
+    loop = asyncio.get_running_loop()
+    returned = assert_running_on_owner_loop(class_name="MyClass", owner_loop=None)
+    assert returned is loop
+
+
+@pytest.mark.asyncio
+async def test_assert_running_on_owner_loop_raises_for_different_loop() -> None:
+    """RuntimeError must be raised when the owner loop differs from the caller's loop."""
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RuntimeError, match="different event loop"):
+            assert_running_on_owner_loop(class_name="MyClass", owner_loop=foreign_loop)
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_assert_running_on_owner_loop_message_contains_class_name() -> None:
+    """Error message must include the class_name so callers can identify the component."""
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RuntimeError, match="SpecialTransport"):
+            assert_running_on_owner_loop(class_name="SpecialTransport", owner_loop=foreign_loop)
+    finally:
+        foreign_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Wiring smoke tests: each transport method must forward to the guard
+# ---------------------------------------------------------------------------
+# These tests inject a *foreign* event loop as the owner so that any method
+# call from the test loop (a different loop) triggers the cross-loop guard.
+# This confirms the guard is actually called — not just that the helper works.
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_start_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_client import TcpClientSettings
+    from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=9999,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_Noop(),
+        )
+        client._owner_loop = foreign_loop  # simulate: owned by a different loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await client.start()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_stop_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_client import TcpClientSettings
+    from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=9999,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_Noop(),
+        )
+        client._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await client.stop()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_wait_until_connected_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_client import TcpClientSettings
+    from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=9999,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_Noop(),
+        )
+        client._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await client.wait_until_connected()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_start_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_server import TcpServerSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        server = AsyncioTcpServer(
+            settings=TcpServerSettings(host="127.0.0.1", port=9999, max_connections=64),
+            event_handler=_Noop(),
+        )
+        server._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await server.start()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_stop_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_server import TcpServerSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        server = AsyncioTcpServer(
+            settings=TcpServerSettings(host="127.0.0.1", port=9999, max_connections=64),
+            event_handler=_Noop(),
+        )
+        server._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await server.stop()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_wait_until_running_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_server import TcpServerSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        server = AsyncioTcpServer(
+            settings=TcpServerSettings(host="127.0.0.1", port=9999, max_connections=64),
+            event_handler=_Noop(),
+        )
+        server._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await server.wait_until_running()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_broadcast_raises_on_wrong_loop() -> None:
+    from aionetx.api.tcp_server import TcpServerSettings
+    from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        server = AsyncioTcpServer(
+            settings=TcpServerSettings(host="127.0.0.1", port=9999, max_connections=64),
+            event_handler=_Noop(),
+        )
+        server._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await server.broadcast(b"hello")
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_start_raises_on_wrong_loop() -> None:
+    from aionetx.api.udp import UdpReceiverSettings
+    from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        receiver = AsyncioUdpReceiver(
+            settings=UdpReceiverSettings(host="127.0.0.1", port=9999),
+            event_handler=_Noop(),
+        )
+        receiver._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await receiver.start()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_raises_on_wrong_loop() -> None:
+    from aionetx.api.udp import UdpReceiverSettings
+    from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        receiver = AsyncioUdpReceiver(
+            settings=UdpReceiverSettings(host="127.0.0.1", port=9999),
+            event_handler=_Noop(),
+        )
+        receiver._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await receiver.stop()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_multicast_receiver_start_raises_on_wrong_loop() -> None:
+    from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+    from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
+        AsyncioMulticastReceiver,
+    )
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        receiver = AsyncioMulticastReceiver(
+            settings=MulticastReceiverSettings(group_ip="239.0.0.1", port=9999),
+            event_handler=_Noop(),
+        )
+        receiver._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await receiver.start()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_multicast_receiver_stop_raises_on_wrong_loop() -> None:
+    from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+    from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
+        AsyncioMulticastReceiver,
+    )
+
+    class _Noop:
+        async def on_event(self, event: object) -> None:
+            return None
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        receiver = AsyncioMulticastReceiver(
+            settings=MulticastReceiverSettings(group_ip="239.0.0.1", port=9999),
+            event_handler=_Noop(),
+        )
+        receiver._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await receiver.stop()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_send_raises_on_wrong_loop() -> None:
+    from aionetx.api.udp import UdpSenderSettings
+    from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        sender = AsyncioUdpSender(
+            settings=UdpSenderSettings(default_host="127.0.0.1", default_port=9999),
+        )
+        sender._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await sender.send(b"hello")
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_stop_raises_on_wrong_loop() -> None:
+    from aionetx.api.udp import UdpSenderSettings
+    from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        sender = AsyncioUdpSender(
+            settings=UdpSenderSettings(default_host="127.0.0.1", default_port=9999),
+        )
+        sender._owner_loop = foreign_loop
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await sender.stop()
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_stop_is_idempotent_from_any_loop_when_already_closed() -> None:
+    """
+    stop() must not fire the guard when the sender is already closed.
+
+    The closed-check short-circuit (``if self._closed: return``) must fire
+    *before* the owner-loop guard so that defensive ``stop()`` calls on an
+    already-stopped sender never raise even when called from a context that
+    would otherwise trigger the cross-loop check.
+    """
+    from aionetx.api.udp import UdpSenderSettings
+    from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        sender = AsyncioUdpSender(
+            settings=UdpSenderSettings(default_host="127.0.0.1", default_port=9999),
+        )
+        sender._closed = True  # simulate: already stopped
+        sender._owner_loop = foreign_loop  # would trigger guard if reached
+        # Should not raise — closed guard fires first
+        await sender.stop()
+    finally:
+        foreign_loop.close()

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -1,0 +1,95 @@
+"""
+Public import-boundary tests for the curated aionetx API.
+
+These checks stay intentionally small. They cover the import paths that user
+code is encouraged to rely on, while avoiding assertions that pin internal
+module layout, implementation namespaces, or complete export lists.
+"""
+
+from __future__ import annotations
+
+import aionetx
+import pytest
+
+from aionetx import (
+    AsyncioNetworkFactory,
+    BaseNetworkEventHandler,
+    NetworkEvent,
+    TcpClientSettings,
+    TcpServerSettings,
+)
+from aionetx.api import (
+    MulticastReceiverProtocol,
+    NetworkConfigurationError,
+    NetworkLayerError,
+    NetworkRuntimeError,
+    TcpClientProtocol,
+    TcpServerProtocol,
+    TypedEventRouter,
+    UdpInvalidTargetError,
+    UdpReceiverProtocol,
+    UdpSenderProtocol,
+    UdpSenderStoppedError,
+)
+
+
+def test_package_root_exports_recommended_entry_points() -> None:
+    assert aionetx.AsyncioNetworkFactory is AsyncioNetworkFactory
+    assert aionetx.TcpClientSettings is TcpClientSettings
+    assert aionetx.TcpServerSettings is TcpServerSettings
+    assert aionetx.BaseNetworkEventHandler is BaseNetworkEventHandler
+    assert aionetx.NetworkEvent is NetworkEvent
+
+
+def test_aionetx_api_exports_transport_protocols_for_advanced_usage() -> None:
+    import aionetx.api as api
+
+    assert api.TcpClientProtocol is TcpClientProtocol
+    assert api.TcpServerProtocol is TcpServerProtocol
+    assert api.UdpReceiverProtocol is UdpReceiverProtocol
+    assert api.UdpSenderProtocol is UdpSenderProtocol
+    assert api.MulticastReceiverProtocol is MulticastReceiverProtocol
+
+
+def test_aionetx_api_exports_udp_send_exceptions() -> None:
+    import aionetx.api as api
+
+    assert api.UdpSenderStoppedError is UdpSenderStoppedError
+    assert api.UdpInvalidTargetError is UdpInvalidTargetError
+
+
+def test_aionetx_api_exports_exception_bases_and_typed_router() -> None:
+    import aionetx.api as api
+
+    assert api.NetworkLayerError is NetworkLayerError
+    assert api.NetworkConfigurationError is NetworkConfigurationError
+    assert api.NetworkRuntimeError is NetworkRuntimeError
+    assert api.TypedEventRouter is TypedEventRouter
+
+
+def test_recording_event_handler_is_available_only_from_testing_namespace() -> None:
+    from aionetx.testing import RecordingEventHandler
+
+    assert RecordingEventHandler.__name__ == "RecordingEventHandler"
+    assert "RecordingEventHandler" not in aionetx.PUBLIC_API
+
+    with pytest.raises(ImportError):
+        exec("from aionetx import RecordingEventHandler", {})
+
+
+@pytest.mark.parametrize(
+    "unsupported_root_symbol",
+    [
+        "TcpClientProtocol",
+        "TcpServerProtocol",
+        "UdpReceiverProtocol",
+        "UdpSenderProtocol",
+        "MulticastReceiverProtocol",
+        "ConnectionClosedEvent",
+    ],
+)
+def test_root_import_does_not_expose_advanced_or_internal_symbols(
+    unsupported_root_symbol: str,
+) -> None:
+    with pytest.raises(ImportError):
+        exec(f"from aionetx import {unsupported_root_symbol}", {})

--- a/tests/unit/test_reconnect_backoff.py
+++ b/tests/unit/test_reconnect_backoff.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from aionetx.api.reconnect_jitter import ReconnectJitter
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from tests.internal_asyncio_impl_refs import ReconnectBackoff
+
+
+def test_reconnect_backoff_progression_and_reset() -> None:
+    backoff = ReconnectBackoff(
+        TcpReconnectSettings(
+            enabled=True,
+            initial_delay_seconds=1.0,
+            max_delay_seconds=5.0,
+            backoff_factor=2.0,
+        )
+    )
+    assert backoff.next_delay() == 1.0
+    assert backoff.next_delay() == 2.0
+    assert backoff.next_delay() == 4.0
+    assert backoff.next_delay() == 5.0
+    assert backoff.next_delay() == 5.0
+
+    backoff.reset()
+    assert backoff.next_delay() == 1.0
+
+
+def test_reconnect_backoff_full_jitter() -> None:
+    backoff = ReconnectBackoff(
+        TcpReconnectSettings(
+            enabled=True,
+            initial_delay_seconds=4.0,
+            max_delay_seconds=10.0,
+            backoff_factor=2.0,
+            jitter=ReconnectJitter.FULL,
+        )
+    )
+    with patch("random.uniform", return_value=1.25) as mocked_uniform:
+        assert backoff.next_delay() == 1.25
+        mocked_uniform.assert_called_once_with(0.0, 4.0)
+
+
+def test_reconnect_backoff_equal_jitter() -> None:
+    backoff = ReconnectBackoff(
+        TcpReconnectSettings(
+            enabled=True,
+            initial_delay_seconds=8.0,
+            max_delay_seconds=10.0,
+            backoff_factor=2.0,
+            jitter=ReconnectJitter.EQUAL,
+        )
+    )
+    with patch("random.uniform", return_value=1.5) as mocked_uniform:
+        assert backoff.next_delay() == 5.5
+        mocked_uniform.assert_called_once_with(0.0, 4.0)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,376 @@
+import pytest
+
+from aionetx.api.heartbeat import TcpHeartbeatSettings
+from aionetx.api.event_delivery_settings import (
+    EventBackpressurePolicy,
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.errors import (
+    InvalidNetworkConfigurationError,
+    NetworkConfigurationError,
+    NetworkRuntimeError,
+)
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.reconnect_jitter import ReconnectJitter
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import (
+    UdpInvalidTargetError,
+    UdpReceiverSettings,
+    UdpSenderSettings,
+    UdpSenderStoppedError,
+)
+
+
+def test_reconnect_settings_validate_success() -> None:
+    TcpReconnectSettings(
+        enabled=True,
+        initial_delay_seconds=1.0,
+        max_delay_seconds=5.0,
+        backoff_factor=2.0,
+    ).validate()
+
+
+def test_reconnect_settings_validate_success_with_jitter() -> None:
+    TcpReconnectSettings(
+        enabled=True,
+        initial_delay_seconds=1.0,
+        max_delay_seconds=5.0,
+        backoff_factor=2.0,
+        jitter=ReconnectJitter.FULL,
+    ).validate()
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: TcpReconnectSettings(initial_delay_seconds=0), "initial_delay_seconds"),
+        (lambda: TcpReconnectSettings(max_delay_seconds=0), "max_delay_seconds"),
+        (
+            lambda: TcpReconnectSettings(initial_delay_seconds=2.0, max_delay_seconds=1.0),
+            "max_delay_seconds",
+        ),
+        (lambda: TcpReconnectSettings(backoff_factor=0.5), "backoff_factor"),
+    ],
+)
+def test_reconnect_settings_validate_failure(factory, message: str) -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match=message):
+        factory()
+
+
+def test_reconnect_settings_validate_failure_for_invalid_jitter() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="jitter"):
+        TcpReconnectSettings(jitter="full")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"initial_delay_seconds": float("nan")},
+        {"initial_delay_seconds": float("inf")},
+        {"max_delay_seconds": float("nan")},
+        {"max_delay_seconds": float("inf")},
+        {"backoff_factor": float("nan")},
+        {"backoff_factor": float("inf")},
+        {"enabled": "yes"},
+    ],
+)
+def test_reconnect_settings_reject_wrong_type_and_non_finite_values(kwargs) -> None:
+    with pytest.raises(InvalidNetworkConfigurationError):
+        TcpReconnectSettings(**kwargs)  # type: ignore[arg-type]
+
+
+def test_heartbeat_settings_validate_failure() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="interval_seconds"):
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"enabled": "yes"},
+        {"enabled": True, "interval_seconds": float("nan")},
+        {"enabled": True, "interval_seconds": float("inf")},
+        {"enabled": True, "interval_seconds": "1"},
+    ],
+)
+def test_heartbeat_settings_reject_wrong_type_and_non_finite_values(kwargs) -> None:
+    with pytest.raises(InvalidNetworkConfigurationError):
+        TcpHeartbeatSettings(**kwargs)  # type: ignore[arg-type]
+
+
+def test_tcp_client_settings_validate_failure() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="port"):
+        TcpClientSettings(host="127.0.0.1", port=0)
+
+
+def test_tcp_client_settings_validate_failure_for_empty_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        TcpClientSettings(host="", port=1234)
+
+
+def test_tcp_client_settings_retry_policy_requires_reconnect_enabled() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="error_policy"):
+        TcpClientSettings(
+            host="127.0.0.1",
+            port=1234,
+            reconnect=TcpReconnectSettings(enabled=False),
+            error_policy=ErrorPolicy.RETRY,
+        )
+
+
+def test_tcp_client_settings_validate_failure_for_zero_connect_timeout() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="connect_timeout_seconds"):
+        TcpClientSettings(host="127.0.0.1", port=1234, connect_timeout_seconds=0)
+
+
+def test_tcp_client_settings_validate_failure_for_negative_connect_timeout() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="connect_timeout_seconds"):
+        TcpClientSettings(host="127.0.0.1", port=1234, connect_timeout_seconds=-1.0)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"host": 123},
+        {"port": 1234.5},
+        {"port": True},
+        {"receive_buffer_size": 1024.0},
+        {"receive_buffer_size": True},
+        {"connect_timeout_seconds": float("nan")},
+        {"connect_timeout_seconds": float("inf")},
+        {"connect_timeout_seconds": "1"},
+        {"error_policy": "retry"},
+    ],
+)
+def test_tcp_client_settings_reject_wrong_type_and_non_finite_values(kwargs) -> None:
+    settings_kwargs = {"host": "127.0.0.1", "port": 1234}
+    settings_kwargs.update(kwargs)
+    with pytest.raises(InvalidNetworkConfigurationError):
+        TcpClientSettings(**settings_kwargs)  # type: ignore[arg-type]
+
+
+def test_tcp_server_settings_validate_failure() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="backlog"):
+        TcpServerSettings(host="127.0.0.1", port=1, max_connections=64, backlog=0)
+
+
+def test_tcp_server_settings_validate_failure_for_none_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        TcpServerSettings(host=None, port=1, max_connections=64)  # type: ignore[arg-type]
+
+
+def test_tcp_server_settings_validate_failure_for_empty_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        TcpServerSettings(host="", port=1, max_connections=64)
+
+
+def test_tcp_server_settings_validate_failure_for_whitespace_only_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        TcpServerSettings(host="   ", port=1, max_connections=64)
+
+
+def test_tcp_server_settings_validate_failure_for_non_positive_max_connections() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="max_connections"):
+        TcpServerSettings(host="127.0.0.1", port=1, max_connections=0)
+
+
+def test_tcp_server_settings_validate_failure_for_non_positive_idle_timeout() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="connection_idle_timeout_seconds"):
+        TcpServerSettings(
+            host="127.0.0.1",
+            port=1,
+            max_connections=64,
+            connection_idle_timeout_seconds=0,
+        )
+
+
+def test_tcp_server_settings_validate_failure_for_non_positive_broadcast_concurrency_limit() -> (
+    None
+):
+    with pytest.raises(InvalidNetworkConfigurationError, match="broadcast_concurrency_limit"):
+        TcpServerSettings(
+            host="127.0.0.1",
+            port=1,
+            max_connections=64,
+            broadcast_concurrency_limit=0,
+        )
+
+
+def test_tcp_server_settings_validate_failure_for_non_positive_broadcast_send_timeout() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="broadcast_send_timeout_seconds"):
+        TcpServerSettings(
+            host="127.0.0.1",
+            port=1,
+            max_connections=64,
+            broadcast_send_timeout_seconds=0,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"host": 123},
+        {"port": 1234.5},
+        {"max_connections": 64.0},
+        {"connection_idle_timeout_seconds": float("nan")},
+        {"connection_idle_timeout_seconds": float("inf")},
+        {"broadcast_concurrency_limit": True},
+        {"broadcast_send_timeout_seconds": float("nan")},
+        {"receive_buffer_size": 4096.0},
+        {"backlog": "100"},
+    ],
+)
+def test_tcp_server_settings_reject_wrong_type_and_non_finite_values(kwargs) -> None:
+    settings_kwargs = {"host": "127.0.0.1", "port": 1, "max_connections": 64}
+    settings_kwargs.update(kwargs)
+    with pytest.raises(InvalidNetworkConfigurationError):
+        TcpServerSettings(**settings_kwargs)  # type: ignore[arg-type]
+
+
+def test_multicast_receiver_settings_validate_failure() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="group_ip"):
+        MulticastReceiverSettings(group_ip="", port=5000)
+
+
+def test_multicast_receiver_settings_validate_failure_for_invalid_group_ip() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="group_ip"):
+        MulticastReceiverSettings(group_ip="not-an-ip", port=5000)
+
+
+def test_multicast_receiver_settings_validate_failure_for_non_multicast_group_ip() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="multicast"):
+        MulticastReceiverSettings(group_ip="127.0.0.1", port=5000)
+
+
+def test_multicast_receiver_settings_validate_failure_for_invalid_bind_ip() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="bind_ip"):
+        MulticastReceiverSettings(group_ip="239.0.0.1", port=5000, bind_ip="not-an-ip")
+
+
+def test_multicast_receiver_settings_validate_failure_for_non_positive_receive_buffer() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="receive_buffer_size"):
+        MulticastReceiverSettings(group_ip="239.0.0.1", port=5000, receive_buffer_size=0)
+
+
+def test_multicast_receiver_settings_validate_failure_for_invalid_interface_ip() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="interface_ip"):
+        MulticastReceiverSettings(
+            group_ip="239.0.0.1",
+            port=5000,
+            interface_ip="not-an-ip",
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"group_ip": 123},
+        {"port": 5000.0},
+        {"bind_ip": b"0.0.0.0"},
+        {"interface_ip": object()},
+        {"receive_buffer_size": True},
+    ],
+)
+def test_multicast_receiver_settings_reject_wrong_type_values(kwargs) -> None:
+    settings_kwargs = {"group_ip": "239.0.0.1", "port": 5000}
+    settings_kwargs.update(kwargs)
+    with pytest.raises(InvalidNetworkConfigurationError):
+        MulticastReceiverSettings(**settings_kwargs)  # type: ignore[arg-type]
+
+
+def test_udp_receiver_settings_validate_failure_for_empty_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        UdpReceiverSettings(host="", port=5000)
+
+
+def test_udp_receiver_settings_validate_failure_for_whitespace_only_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        UdpReceiverSettings(host="   ", port=5000)
+
+
+def test_udp_sender_settings_validate_failure_for_whitespace_only_default_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="default_host"):
+        UdpSenderSettings(default_host="   ", default_port=5000)
+
+
+def test_udp_sender_settings_validate_failure_for_whitespace_only_local_host() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="local_host"):
+        UdpSenderSettings(local_host="   ")
+
+
+def test_udp_sender_settings_validate_failure_for_invalid_default_port() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="default_port"):
+        UdpSenderSettings(default_host="127.0.0.1", default_port=70000)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: UdpReceiverSettings(host=123, port=5000),
+        lambda: UdpReceiverSettings(host="127.0.0.1", port=5000.0),
+        lambda: UdpReceiverSettings(host="127.0.0.1", port=True),
+        lambda: UdpReceiverSettings(host="127.0.0.1", port=5000, receive_buffer_size=65535.0),
+        lambda: UdpReceiverSettings(host="127.0.0.1", port=5000, enable_broadcast="yes"),
+        lambda: UdpSenderSettings(default_host=b"127.0.0.1", default_port=5000),
+        lambda: UdpSenderSettings(default_host="127.0.0.1", default_port=5000.0),
+        lambda: UdpSenderSettings(local_host=123),
+        lambda: UdpSenderSettings(local_port=False),
+        lambda: UdpSenderSettings(enable_broadcast=1),
+    ],
+)
+def test_udp_settings_reject_wrong_type_values(factory) -> None:
+    with pytest.raises(InvalidNetworkConfigurationError):
+        factory()  # type: ignore[misc]
+
+
+def test_event_delivery_settings_validate_failure_for_invalid_handler_failure_policy() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="handler_failure_policy"):
+        EventDeliverySettings(handler_failure_policy="log_only")  # type: ignore[arg-type]
+
+
+def test_event_delivery_settings_validate_failure_for_invalid_dispatch_mode() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="dispatch_mode"):
+        EventDeliverySettings(dispatch_mode="inline")  # type: ignore[arg-type]
+
+
+def test_event_delivery_settings_validate_failure_for_invalid_backpressure_policy() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="backpressure_policy"):
+        EventDeliverySettings(backpressure_policy="block")  # type: ignore[arg-type]
+
+
+def test_event_delivery_settings_validate_success_for_enum_values() -> None:
+    EventDeliverySettings(
+        dispatch_mode=EventDispatchMode.INLINE,
+        backpressure_policy=EventBackpressurePolicy.DROP_NEWEST,
+    ).validate()
+
+
+def test_settings_construction_is_fail_fast() -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="handler_failure_policy"):
+        EventDeliverySettings(handler_failure_policy="invalid")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("max_pending_events", [0.5, True, "1"])
+def test_event_delivery_settings_reject_wrong_type_max_pending_events(max_pending_events) -> None:
+    with pytest.raises(InvalidNetworkConfigurationError, match="max_pending_events"):
+        EventDeliverySettings(max_pending_events=max_pending_events)  # type: ignore[arg-type]
+
+
+def test_error_taxonomy_splits_configuration_and_runtime_errors() -> None:
+    assert issubclass(InvalidNetworkConfigurationError, NetworkConfigurationError)
+    assert issubclass(UdpInvalidTargetError, NetworkConfigurationError)
+    assert issubclass(UdpSenderStoppedError, NetworkRuntimeError)
+
+
+def test_error_taxonomy_keeps_configuration_and_runtime_categories_disjoint() -> None:
+    assert not issubclass(UdpSenderStoppedError, NetworkConfigurationError)
+    assert not issubclass(UdpInvalidTargetError, NetworkRuntimeError)
+
+
+def test_error_policy_enum_values_still_validate_under_fail_fast_model() -> None:
+    EventDeliverySettings(handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT)

--- a/tests/unit/test_settings_property_based.py
+++ b/tests/unit/test_settings_property_based.py
@@ -1,0 +1,128 @@
+"""
+Property-based tests for settings validation.
+
+Uses Hypothesis to generate random inputs and verify that the invariants
+described in TcpClientSettings.validate() hold for arbitrary values — not
+just the hand-picked examples in test_settings.py.
+
+These tests are OPT-IN.  They are skipped automatically when the
+``hypothesis`` package is not installed.  To run them:
+
+    pip install -e ".[dev-hypothesis]"
+    pytest -m hypothesis
+
+They are intentionally excluded from the required CI gate.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+hypothesis = pytest.importorskip(
+    "hypothesis", reason="hypothesis not installed; skipping property-based tests"
+)
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from aionetx.api.errors import InvalidNetworkConfigurationError  # noqa: E402
+from aionetx.api.tcp_client import TcpClientSettings  # noqa: E402
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings  # noqa: E402
+
+pytestmark = pytest.mark.hypothesis
+
+
+# ---------------------------------------------------------------------------
+# Host validation
+# ---------------------------------------------------------------------------
+
+
+@given(host=st.text(max_size=200).filter(lambda s: len(s.strip()) == 0))
+@settings(max_examples=50)
+def test_empty_or_whitespace_host_always_invalid(host: str) -> None:
+    """Any empty or whitespace-only host string must be rejected."""
+    with pytest.raises(InvalidNetworkConfigurationError, match="host"):
+        TcpClientSettings(host=host, port=1234).validate()
+
+
+# ---------------------------------------------------------------------------
+# Port validation
+# ---------------------------------------------------------------------------
+
+
+@given(port=st.integers(max_value=0))
+@settings(max_examples=50)
+def test_non_positive_port_always_invalid(port: int) -> None:
+    """Ports ≤ 0 are always invalid (unbounded below for full coverage)."""
+    with pytest.raises(InvalidNetworkConfigurationError, match="port"):
+        TcpClientSettings(host="127.0.0.1", port=port).validate()
+
+
+@given(port=st.integers(min_value=65_536))
+@settings(max_examples=50)
+def test_port_above_65535_always_invalid(port: int) -> None:
+    """Ports > 65535 are always invalid (unbounded above for full coverage)."""
+    with pytest.raises(InvalidNetworkConfigurationError, match="port"):
+        TcpClientSettings(host="127.0.0.1", port=port).validate()
+
+
+@given(port=st.integers(min_value=1, max_value=65_535))
+@settings(max_examples=50)
+def test_valid_port_range_always_accepted(port: int) -> None:
+    """Ports in [1, 65535] with a valid host must not raise."""
+    TcpClientSettings(host="127.0.0.1", port=port).validate()
+
+
+# ---------------------------------------------------------------------------
+# receive_buffer_size validation
+# ---------------------------------------------------------------------------
+
+
+@given(size=st.integers(min_value=-1_000, max_value=0))
+@settings(max_examples=50)
+def test_non_positive_receive_buffer_size_always_invalid(size: int) -> None:
+    """receive_buffer_size ≤ 0 must always be rejected."""
+    with pytest.raises(InvalidNetworkConfigurationError, match="receive_buffer_size"):
+        TcpClientSettings(host="127.0.0.1", port=1234, receive_buffer_size=size).validate()
+
+
+# ---------------------------------------------------------------------------
+# connect_timeout_seconds validation
+# ---------------------------------------------------------------------------
+
+
+@given(timeout=st.floats(max_value=0.0, allow_nan=False, allow_infinity=False))
+@settings(max_examples=50)
+def test_non_positive_connect_timeout_always_invalid(timeout: float) -> None:
+    """connect_timeout_seconds ≤ 0 must always be rejected."""
+    with pytest.raises(InvalidNetworkConfigurationError, match="connect_timeout_seconds"):
+        TcpClientSettings(host="127.0.0.1", port=1234, connect_timeout_seconds=timeout).validate()
+
+
+@given(
+    timeout=st.floats(
+        min_value=sys.float_info.min, max_value=3600.0, allow_nan=False, allow_infinity=False
+    )
+)
+@settings(max_examples=50)
+def test_positive_connect_timeout_always_accepted(timeout: float) -> None:
+    """Any positive connect_timeout_seconds must be accepted (down to the smallest float > 0)."""
+    TcpClientSettings(host="127.0.0.1", port=1234, connect_timeout_seconds=timeout).validate()
+
+
+# ---------------------------------------------------------------------------
+# Reconnect initial_delay_seconds validation
+# ---------------------------------------------------------------------------
+
+
+@given(delay=st.floats(max_value=0.0, allow_nan=False, allow_infinity=False))
+@settings(max_examples=50)
+def test_non_positive_reconnect_initial_delay_always_invalid(delay: float) -> None:
+    """TcpReconnectSettings with initial_delay_seconds ≤ 0 must be rejected."""
+    with pytest.raises(InvalidNetworkConfigurationError):
+        TcpReconnectSettings(
+            enabled=True,
+            initial_delay_seconds=delay,
+        ).validate()

--- a/tests/unit/test_start_stop_toctou.py
+++ b/tests/unit/test_start_stop_toctou.py
@@ -1,0 +1,308 @@
+"""
+Regression tests for the TOCTOU race in start().
+
+Root cause (pre-fix):
+  Both AsyncioTcpClient.start() and AsyncioTcpServer.start() used a
+  two-lock pattern:
+
+      Lock 1: check state, set flags (state stays STOPPED)
+      # --- window: dispatcher.start() outside the lock ---
+      Lock 2: transition STOPPED → STARTING → RUNNING
+
+  A concurrent stop() that ran during the window saw state=STOPPED and
+  treated the call as a no-op.  start() then completed to RUNNING with
+  the stop() silently lost.
+
+Fix:
+  dispatcher.start() and the STARTING transition now happen inside Lock 1,
+  so no concurrent stop() can interleave between "state check" and "state
+  update".  stop() either completes before start() acquires the lock (and
+  is itself a no-op because state is STOPPED and start() has not begun) or
+  it runs after start() releases the lock (sees RUNNING, transitions
+  correctly to STOPPED).
+
+Test strategy:
+  Monkeypatch AsyncioEventDispatcher.start() to insert an asyncio.sleep(0)
+  yield point.  With the old two-lock pattern this yield gave stop() an
+  opening to run while the lock was not held.  With the fix the lock covers
+  the entire startup sequence; stop() blocks on it and only runs after
+  start() is fully committed to RUNNING — guaranteeing a proper teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
+    AsyncioMulticastReceiver,
+)
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+
+
+class _NoopHandler:
+    async def on_event(self, event: NetworkEvent) -> None:
+        return None
+
+
+def _unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+# ---------------------------------------------------------------------------
+# Helper: patched dispatcher that yields inside start() to expose the window
+# ---------------------------------------------------------------------------
+
+
+def _patch_dispatcher_start_with_yield(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Patch AsyncioEventDispatcher.start() to yield once before proceeding.
+
+    This creates a suspension point that — with the *old* two-lock pattern —
+    would have allowed a concurrent stop() to run and observe state=STOPPED
+    (treating the stop() as a no-op).  After the fix the lock is held during
+    this yield, so the window no longer exists.
+    """
+    original_start = AsyncioEventDispatcher.start
+
+    async def start_with_yield(self: AsyncioEventDispatcher) -> None:
+        await asyncio.sleep(0)  # yield to allow other coroutines to run
+        await original_start(self)
+
+    monkeypatch.setattr(AsyncioEventDispatcher, "start", start_with_yield)
+
+
+# ---------------------------------------------------------------------------
+# TCP Client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_concurrent_stop_not_lost_during_dispatcher_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    stop() called concurrently with start() must not be silently dropped.
+
+    Pre-fix: with a yield in dispatcher.start() outside the lock, stop()
+    would see state=STOPPED, be a no-op, and start() would complete to
+    RUNNING — stop() effectively lost.
+
+    Post-fix: dispatcher.start() runs inside the lock.  stop() blocks until
+    start() releases the lock (with state already RUNNING), then correctly
+    transitions RUNNING → STOPPED.
+    """
+    _patch_dispatcher_start_with_yield(monkeypatch)
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+
+    # Schedule start() first; the single sleep(0) in start() lets stop() be
+    # created *while* start() still holds _state_lock (the yield is now inside
+    # the lock).  stop() therefore blocks on the lock and only runs after
+    # start() has fully committed to RUNNING and released the lock.
+    start_task = asyncio.create_task(client.start())
+    await asyncio.sleep(0)  # advance start() to the sleep(0) inside the lock
+    stop_task = asyncio.create_task(client.stop())
+    await asyncio.gather(start_task, stop_task, return_exceptions=True)
+
+    # After the fix: stop() serialised after start() → component is STOPPED.
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED, (
+        "stop() must not be silently lost during start() — component must end up STOPPED"
+    )
+    assert not client._event_dispatcher.is_running, (
+        "dispatcher must be stopped when component lifecycle is STOPPED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_state_and_dispatcher_always_consistent_under_rapid_oscillation() -> None:
+    """
+    Rapid start/stop oscillation must never leave state and dispatcher inconsistent.
+
+    Runs 10 start/stop cycles and asserts the invariant after each cycle:
+      - RUNNING  → dispatcher.is_running is True
+      - STOPPED  → dispatcher.is_running is False
+    """
+    port = _unused_tcp_port()
+    # Use a real server so the client can actually connect (reconnect=False
+    # means the client won't retry; we just need start() to succeed at least once).
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    await server.start()
+    try:
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+            ),
+            event_handler=_NoopHandler(),
+        )
+        for _ in range(10):
+            await client.start()
+            await client.stop()
+            state = client.lifecycle_state
+            dispatcher_running = client._event_dispatcher.is_running
+            if state == ComponentLifecycleState.RUNNING:
+                assert dispatcher_running, "dispatcher must be running when state is RUNNING"
+            else:
+                assert not dispatcher_running, (
+                    "dispatcher must not be running when state is STOPPED"
+                )
+    finally:
+        await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# TCP Server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_concurrent_stop_not_lost_during_dispatcher_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    stop() called concurrently with server start() must not be silently dropped.
+
+    Same invariant as the client test: after concurrent start()+stop() the
+    component must not remain in RUNNING with an orphaned dispatcher.
+    """
+    _patch_dispatcher_start_with_yield(monkeypatch)
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+
+    # Same sequencing rationale as the client test: stop() is created while
+    # start() holds _state_lock (the patched sleep(0) is inside the lock), so
+    # stop() blocks on the lock and only runs after start() reaches RUNNING.
+    start_task = asyncio.create_task(server.start())
+    await asyncio.sleep(0)  # advance start() to the sleep(0) inside the lock
+    stop_task = asyncio.create_task(server.stop())
+    await asyncio.gather(start_task, stop_task, return_exceptions=True)
+
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED, (
+        "stop() must not be silently lost during server start() — server must end up STOPPED"
+    )
+    assert not server._event_dispatcher.is_running, (
+        "dispatcher must be stopped when server lifecycle is STOPPED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_state_and_dispatcher_always_consistent_under_rapid_oscillation() -> None:
+    """Rapid server start/stop oscillation must never leave state and dispatcher inconsistent."""
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=_unused_tcp_port(), max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    for _ in range(10):
+        await server.start()
+        await server.stop()
+        state = server.lifecycle_state
+        dispatcher_running = server._event_dispatcher.is_running
+        if state == ComponentLifecycleState.RUNNING:
+            assert dispatcher_running, "dispatcher must be running when state is RUNNING"
+        else:
+            assert not dispatcher_running, "dispatcher must not be running when state is STOPPED"
+
+
+# ---------------------------------------------------------------------------
+# UDP Receiver / Multicast Receiver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_concurrent_stop_not_lost_during_dispatcher_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    stop() racing with UDP receiver start() must still leave the receiver stopped.
+
+    This pins the datagram-base startup fix so UDP receivers cannot regress back
+    to the same lost-stop window that previously affected TCP transports.
+    """
+    _patch_dispatcher_start_with_yield(monkeypatch)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_unused_udp_port()),
+        event_handler=_NoopHandler(),
+    )
+
+    start_task = asyncio.create_task(receiver.start())
+    await asyncio.sleep(0)
+    stop_task = asyncio.create_task(receiver.stop())
+    await asyncio.gather(start_task, stop_task, return_exceptions=True)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED, (
+        "UDP receiver stop() must not be silently lost during startup."
+    )
+    assert not receiver._event_dispatcher.is_running, (
+        "UDP receiver dispatcher must be stopped when lifecycle is STOPPED."
+    )
+
+
+@pytest.mark.asyncio
+async def test_multicast_receiver_concurrent_stop_not_lost_during_dispatcher_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    stop() racing with multicast receiver start() must still leave the receiver stopped.
+
+    The shared datagram-base fix must protect both generic UDP and multicast
+    receivers from the same startup TOCTOU.
+    """
+    _patch_dispatcher_start_with_yield(monkeypatch)
+
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.1",
+            port=_unused_udp_port(),
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+        ),
+        event_handler=_NoopHandler(),
+    )
+
+    start_task = asyncio.create_task(receiver.start())
+    await asyncio.sleep(0)
+    stop_task = asyncio.create_task(receiver.stop())
+    await asyncio.gather(start_task, stop_task, return_exceptions=True)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED, (
+        "Multicast receiver stop() must not be silently lost during startup."
+    )
+    assert not receiver._event_dispatcher.is_running, (
+        "Multicast receiver dispatcher must be stopped when lifecycle is STOPPED."
+    )

--- a/tests/unit/test_task_leak_detection.py
+++ b/tests/unit/test_task_leak_detection.py
@@ -1,0 +1,215 @@
+"""
+Resource-leak detection tests.
+
+Invariant: every asyncio Task created by start() must be cancelled and
+awaited by stop().  A leaked task causes memory growth and can execute
+stale callbacks on the next start() cycle.
+
+Strategy: snapshot asyncio.all_tasks() before start() and after stop(),
+subtract the current task and any tasks that were already present, and
+assert the set is empty.
+
+Coverage:
+- AsyncioTcpClient (with real server so the supervisor connects)
+- AsyncioTcpServer
+- AsyncioUdpReceiver
+- AsyncioUdpSender (stateless; start/send/stop cycle)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings, UdpSenderSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+def _unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _Noop:
+    async def on_event(self, event: NetworkEvent) -> None:
+        return None
+
+
+def _leaked_tasks(tasks_before: set[asyncio.Task[object]]) -> set[asyncio.Task[object]]:
+    """Return tasks present after stop() that were not present before start()."""
+    current = asyncio.current_task()
+    return asyncio.all_tasks() - tasks_before - ({current} if current is not None else set())
+
+
+# ---------------------------------------------------------------------------
+# TCP Client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_start_stop_leaves_no_dangling_tasks() -> None:
+    """
+    TCP client leaves no asyncio tasks running after stop().
+
+    Both server and client are started/stopped inside the measurement window
+    so that server-side per-connection tasks (created after the client
+    connects) are also accounted for in the final snapshot.
+    """
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_Noop(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_Noop(),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await server.start()
+    await client.start()
+    # Wait for supervisor to connect so the receive-loop task is also started.
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    assert connection.is_connected
+    await client.stop()
+    await server.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"TCP client leaked {len(leaked)} task(s): {leaked}"
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_failed_start_stop_leaves_no_dangling_tasks() -> None:
+    """Failed TCP client startup still tears down supervision tasks cleanly."""
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            reconnect=TcpReconnectSettings(enabled=False),
+            connect_timeout_seconds=0.2,
+        ),
+        event_handler=_Noop(),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await client.start()
+    with pytest.raises(ConnectionError):
+        await client.wait_until_connected(timeout_seconds=0.5, poll_interval_seconds=0.02)
+    await client.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"TCP client failed start leaked {len(leaked)} task(s): {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# TCP Server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_start_stop_leaves_no_dangling_tasks() -> None:
+    """TCP server leaves no asyncio tasks running after stop()."""
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_Noop(),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await server.start()
+    await server.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"TCP server leaked {len(leaked)} task(s): {leaked}"
+
+
+@pytest.mark.asyncio
+async def test_tcp_server_with_connected_client_stop_leaves_no_dangling_tasks() -> None:
+    """TCP server cleans up all per-connection tasks when stopped."""
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_Noop(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_Noop(),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await server.start()
+    await client.start()
+    connection = await client.wait_until_connected(timeout_seconds=3.0)
+    assert connection.is_connected
+
+    await client.stop()
+    await server.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"TCP server + client leaked {len(leaked)} task(s): {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# UDP Receiver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_start_stop_leaves_no_dangling_tasks() -> None:
+    """UDP receiver leaves no asyncio tasks running after stop()."""
+    port = _unused_udp_port()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=port),
+        event_handler=_Noop(),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await receiver.start()
+    await receiver.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"UDP receiver leaked {len(leaked)} task(s): {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# UDP Sender
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_udp_sender_send_stop_leaves_no_dangling_tasks() -> None:
+    """UDP sender leaves no asyncio tasks running after stop()."""
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=_unused_udp_port()),
+    )
+
+    tasks_before = set(asyncio.all_tasks())
+    await sender.send(b"probe")
+    await sender.stop()
+
+    leaked = _leaked_tasks(tasks_before)
+    assert not leaked, f"UDP sender leaked {len(leaked)} task(s): {leaked}"

--- a/tests/unit/test_tcp_client_lifecycle_state_machine.py
+++ b/tests/unit/test_tcp_client_lifecycle_state_machine.py
@@ -1,0 +1,341 @@
+"""
+State-machine tests for AsyncioTcpClient lifecycle transitions.
+
+This module isolates the managed client lifecycle contract: legal transition
+order, start/stop idempotency, waiter unblocking, and handler-failure
+interactions during startup. Reconnect semantics are covered elsewhere; this
+file focuses on the lifecycle state machine itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.event_delivery_settings import (
+    EventDeliverySettings,
+    EventDispatchMode,
+    EventHandlerFailurePolicy,
+)
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+
+pytestmark = pytest.mark.behavior_critical
+
+
+async def _no_op_server_handler(
+    _reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    writer.close()
+    await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_client_lifecycle_start_stop_is_deterministic(recording_event_handler) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port), recording_event_handler
+        )
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        await client.start()
+        assert client.lifecycle_state == ComponentLifecycleState.RUNNING
+        await client.wait_until_connected(timeout_seconds=2.0)
+        await client.stop()
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_client_lifecycle_events_preserve_start_stop_order(recording_event_handler) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port), recording_event_handler
+        )
+        await client.start()
+        await client.stop()
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/client/127.0.0.1/{port}"
+    ]
+    assert [event.current for event in component_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_concurrent_start_and_stop_are_safe(recording_event_handler) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port), recording_event_handler
+        )
+
+        await asyncio.gather(client.start(), client.start())
+        assert client.lifecycle_state == ComponentLifecycleState.RUNNING
+
+        await asyncio.gather(client.stop(), client.stop())
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+class _FailOnClientStartingLifecycle:
+    async def on_event(self, event) -> None:
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STARTING
+        ):
+            raise RuntimeError("client-lifecycle-handler-failed")
+
+
+@pytest.mark.asyncio
+async def test_client_start_inline_stop_component_handler_failure_does_not_deadlock() -> None:
+    client = AsyncioTcpClient(
+        TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.INLINE,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        _FailOnClientStartingLifecycle(),
+    )
+
+    await asyncio.wait_for(client.start(), timeout=1.0)
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_illegal_lifecycle_transition(recording_event_handler) -> None:
+    client = AsyncioTcpClient(
+        TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+        ),
+        recording_event_handler,
+    )
+
+    with pytest.raises(RuntimeError, match="Illegal lifecycle transition"):
+        await client._transition_lifecycle_state(ComponentLifecycleState.RUNNING)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_client_stop_during_start_is_safe(recording_event_handler) -> None:
+    gate = asyncio.Event()
+
+    async def delayed_open_connection(*, host: str, port: int):
+        del host, port
+        await gate.wait()
+        raise OSError("connect-cancelled")
+
+    client = AsyncioTcpClient(
+        TcpClientSettings(host="127.0.0.1", port=12345),
+        recording_event_handler,
+        connection_opener=delayed_open_connection,
+    )
+    start_task = asyncio.create_task(client.start())
+    await asyncio.sleep(0)
+    stop_task = asyncio.create_task(client.stop())
+    gate.set()
+    await asyncio.gather(start_task, stop_task)
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == "tcp/client/127.0.0.1/12345"
+    ]
+    assert [event.current for event in component_events][-2:] == [
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert (
+        sum(1 for event in component_events if event.current == ComponentLifecycleState.STOPPING)
+        == 1
+    )
+    assert (
+        sum(1 for event in component_events if event.current == ComponentLifecycleState.STOPPED)
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_repeated_restart_cycles_keep_lifecycle_transitions_coherent(
+    recording_event_handler,
+) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port),
+            recording_event_handler,
+        )
+
+        for _ in range(3):
+            await client.start()
+            await client.wait_until_connected(timeout_seconds=2.0)
+            await client.stop()
+            assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/client/127.0.0.1/{port}"
+    ]
+    states = [event.current for event in component_events]
+
+    assert states == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_stop_during_start_unblocks_pending_connect_waiters(
+    recording_event_handler,
+) -> None:
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def delayed_open_connection(*, host: str, port: int):
+        del host, port
+        connect_started.set()
+        await release_connect.wait()
+        raise OSError("connect-cancelled")
+
+    client = AsyncioTcpClient(
+        TcpClientSettings(host="127.0.0.1", port=12345),
+        recording_event_handler,
+        connection_opener=delayed_open_connection,
+    )
+    await client.start()
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+
+    waiters = [
+        asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0)) for _ in range(3)
+    ]
+
+    async def _all_waiters_pending() -> None:
+        while not all(waiter.done() is False for waiter in waiters):
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_all_waiters_pending(), timeout=0.5)
+
+    stop_tasks = [asyncio.create_task(client.stop()), asyncio.create_task(client.stop())]
+    release_connect.set()
+    await asyncio.gather(*stop_tasks)
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert all(isinstance(result, ConnectionError) for result in results)
+
+
+@pytest.mark.asyncio
+async def test_client_repeated_start_is_idempotent_and_does_not_duplicate_start_events(
+    recording_event_handler,
+) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port), recording_event_handler
+        )
+        await client.start()
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=2.0)
+        await client.stop()
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/client/127.0.0.1/{port}"
+    ]
+    assert [event.current for event in component_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_repeated_stop_is_idempotent_and_does_not_duplicate_terminal_events(
+    recording_event_handler,
+) -> None:
+    server = await asyncio.start_server(_no_op_server_handler, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        client = AsyncioTcpClient(
+            TcpClientSettings(host="127.0.0.1", port=port), recording_event_handler
+        )
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=2.0)
+        await client.stop()
+        await client.stop()
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/client/127.0.0.1/{port}"
+    ]
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert [event.current for event in component_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.RUNNING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_fail_fast_connect_failure_unblocks_pending_connect_waiters(
+    recording_event_handler,
+) -> None:
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def failing_open_connection(*, host: str, port: int):
+        del host, port
+        connect_started.set()
+        await release_connect.wait()
+        raise OSError("connect-failed")
+
+    client = AsyncioTcpClient(
+        TcpClientSettings(host="127.0.0.1", port=12345),
+        recording_event_handler,
+        connection_opener=failing_open_connection,
+    )
+    await client.start()
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+
+    waiters = [
+        asyncio.create_task(client.wait_until_connected(timeout_seconds=2.0)) for _ in range(3)
+    ]
+    await asyncio.sleep(0)
+    assert all(waiter.done() is False for waiter in waiters)
+    release_connect.set()
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert all(isinstance(result, ConnectionError) for result in results)

--- a/tests/unit/test_typed_event_router.py
+++ b/tests/unit/test_typed_event_router.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.typed_event_router import TypedEventRouter
+
+
+@pytest.mark.asyncio
+async def test_typed_event_router_dispatches_registered_handler() -> None:
+    router = TypedEventRouter()
+    seen: list[bytes] = []
+
+    async def handle_bytes(event: BytesReceivedEvent) -> None:
+        seen.append(event.data)
+
+    router.register(BytesReceivedEvent, handle_bytes)
+
+    handled = await router.dispatch(BytesReceivedEvent(resource_id="x", data=b"abc"))
+
+    assert handled is True
+    assert seen == [b"abc"]
+
+
+@pytest.mark.asyncio
+async def test_typed_event_router_returns_false_when_unhandled() -> None:
+    router = TypedEventRouter()
+
+    handled = await router.dispatch(
+        ConnectionClosedEvent(
+            resource_id="x",
+            previous_state=ConnectionState.CONNECTED,
+        )
+    )
+
+    assert handled is False
+
+
+@pytest.mark.asyncio
+async def test_typed_event_router_prefers_most_specific_subclass_handler() -> None:
+    class DerivedBytesReceivedEvent(BytesReceivedEvent):
+        pass
+
+    router = TypedEventRouter()
+    calls: list[str] = []
+
+    async def handle_base(event: BytesReceivedEvent) -> None:
+        calls.append("base")
+
+    async def handle_derived(event: DerivedBytesReceivedEvent) -> None:
+        calls.append("derived")
+
+    router.register(BytesReceivedEvent, handle_base)
+    router.register(DerivedBytesReceivedEvent, handle_derived)
+
+    handled = await router.dispatch(DerivedBytesReceivedEvent(resource_id="x", data=b"payload"))
+
+    assert handled is True
+    assert calls == ["derived"]
+
+
+@pytest.mark.asyncio
+async def test_typed_event_router_prefers_first_registered_on_equal_specificity() -> None:
+    router = TypedEventRouter()
+    calls: list[str] = []
+
+    async def first(event: BytesReceivedEvent) -> None:
+        calls.append("first")
+
+    async def second(event: BytesReceivedEvent) -> None:
+        calls.append("second")
+
+    router.register(BytesReceivedEvent, first)
+    router.register(BytesReceivedEvent, second)
+
+    handled = await router.dispatch(BytesReceivedEvent(resource_id="x", data=b"abc"))
+
+    assert handled is True
+    assert calls == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_typed_event_router_propagates_handler_exceptions() -> None:
+    router = TypedEventRouter()
+
+    async def failing_handler(event: BytesReceivedEvent) -> None:
+        raise RuntimeError("router-handler-failed")
+
+    router.register(BytesReceivedEvent, failing_handler)
+
+    with pytest.raises(RuntimeError, match="router-handler-failed"):
+        await router.dispatch(BytesReceivedEvent(resource_id="x", data=b"data"))

--- a/tests/unit/test_udp_fallback_warning.py
+++ b/tests/unit/test_udp_fallback_warning.py
@@ -1,0 +1,178 @@
+"""
+Dedicated unit test for the UDP recvfrom() fallback-warning limiter.
+
+The _AsyncioDatagramReceiverBase class has a two-layer warning-suppression
+mechanism:
+
+  1. Module-level WarningRateLimiter (_recv_fallback_warning_limiter): rate-
+     limits by a key derived from connection_id, with a 300-second interval.
+  2. Per-instance flag (recv_fallback_warning_emitted on _DatagramRuntimeState):
+     permanently suppresses subsequent warnings from the *same receiver* once
+     the first warning has been emitted.
+
+These tests verify that logger.warning is called exactly once (first fallback)
+and NOT called on subsequent fallbacks from the same receiver instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aionetx.api.udp import UdpReceiverSettings
+from aionetx.implementations.asyncio_impl import _asyncio_datagram_receiver_base as base_module
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+
+
+class _NoopHandler:
+    async def on_event(self, event) -> None:
+        return None
+
+
+class _LoopWithoutSockRecvFrom:
+    """Minimal event loop stub that does NOT expose sock_recvfrom."""
+
+    pass
+
+
+class _AlwaysSuccessSocket:
+    """Socket stub whose recvfrom() always succeeds immediately."""
+
+    def recvfrom(self, _size: int) -> tuple[bytes, tuple[str, int]]:
+        return (b"data", ("127.0.0.1", 9999))
+
+
+@pytest.mark.asyncio
+async def test_fallback_warning_emitted_exactly_once_on_first_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logger.warning is called exactly once when sock_recvfrom is absent."""
+    monkeypatch.setattr(base_module.asyncio, "sleep", AsyncMock())
+
+    # Reset the module-level rate limiter so prior test runs don't suppress
+    # the warning for this connection_id key.
+    monkeypatch.setattr(
+        base_module,
+        "_recv_fallback_warning_limiter",
+        base_module.WarningRateLimiter(interval_seconds=300.0),
+    )
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21900),
+        event_handler=_NoopHandler(),
+    )
+
+    loop_stub = _LoopWithoutSockRecvFrom()
+    sock_stub = _AlwaysSuccessSocket()
+
+    with patch.object(receiver._logger, "warning") as mock_warning:
+        # First fallback invocation — should trigger the warning.
+        await receiver._recv_nonblocking(loop_stub, sock_stub, 1024)  # type: ignore[arg-type]
+
+        assert mock_warning.call_count == 1, (
+            "Expected exactly one logger.warning call on first fallback, "
+            f"got {mock_warning.call_count}"
+        )
+        call_args = mock_warning.call_args
+        assert "recvfrom() fallback polling" in str(call_args), (
+            f"Warning message does not mention recvfrom() fallback: {call_args}"
+        )
+        assert "sock_recvfrom" in str(call_args), (
+            f"Warning message does not mention sock_recvfrom: {call_args}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_fallback_warning_suppressed_on_second_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logger.warning is NOT called again on a second fallback from the same receiver."""
+    monkeypatch.setattr(base_module.asyncio, "sleep", AsyncMock())
+
+    # Reset the module-level rate limiter so prior test runs don't suppress
+    # the warning for this connection_id key.
+    monkeypatch.setattr(
+        base_module,
+        "_recv_fallback_warning_limiter",
+        base_module.WarningRateLimiter(interval_seconds=300.0),
+    )
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21901),
+        event_handler=_NoopHandler(),
+    )
+
+    loop_stub = _LoopWithoutSockRecvFrom()
+    sock_stub = _AlwaysSuccessSocket()
+
+    with patch.object(receiver._logger, "warning") as mock_warning:
+        # First fallback — warning should be emitted.
+        await receiver._recv_nonblocking(loop_stub, sock_stub, 1024)  # type: ignore[arg-type]
+        assert mock_warning.call_count == 1, "First fallback must emit one warning"
+
+        # Second fallback from the same receiver instance — the per-instance
+        # flag recv_fallback_warning_emitted is now True, so the warning must
+        # NOT be repeated regardless of the rate limiter state.
+        await receiver._recv_nonblocking(loop_stub, sock_stub, 1024)  # type: ignore[arg-type]
+        assert mock_warning.call_count == 1, (
+            "Second fallback must NOT emit another warning; "
+            f"logger.warning was called {mock_warning.call_count} times total"
+        )
+
+
+@pytest.mark.asyncio
+async def test_fallback_limiter_flag_is_set_after_first_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """recv_fallback_warning_emitted is True after the first fallback call."""
+    monkeypatch.setattr(base_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        base_module,
+        "_recv_fallback_warning_limiter",
+        base_module.WarningRateLimiter(interval_seconds=300.0),
+    )
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21902),
+        event_handler=_NoopHandler(),
+    )
+
+    loop_stub = _LoopWithoutSockRecvFrom()
+    sock_stub = _AlwaysSuccessSocket()
+
+    assert not receiver._runtime.recv_fallback_warning_emitted  # type: ignore[attr-defined]
+
+    await receiver._recv_nonblocking(loop_stub, sock_stub, 1024)  # type: ignore[arg-type]
+
+    assert receiver._runtime.recv_fallback_warning_emitted, (  # type: ignore[attr-defined]
+        "recv_fallback_warning_emitted must be True after the first fallback"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fallback_warning_not_emitted_when_sock_recvfrom_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No warning is emitted when the loop supports sock_recvfrom()."""
+
+    class _LoopWithSockRecvFrom:
+        async def sock_recvfrom(self, sock: object, size: int) -> tuple[bytes, tuple[str, int]]:
+            return (b"data", ("127.0.0.1", 9999))
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=21903),
+        event_handler=_NoopHandler(),
+    )
+
+    loop_stub = _LoopWithSockRecvFrom()
+    sock_stub = _AlwaysSuccessSocket()
+
+    with patch.object(receiver._logger, "warning") as mock_warning:
+        await receiver._recv_nonblocking(loop_stub, sock_stub, 1024)  # type: ignore[arg-type]
+
+        assert mock_warning.call_count == 0, (
+            "No warning should be emitted when sock_recvfrom() is present; "
+            f"logger.warning was called {mock_warning.call_count} times"
+        )
+    assert not receiver._runtime.recv_fallback_warning_emitted  # type: ignore[attr-defined]

--- a/tests/unit/test_udp_sender_fallback_warning.py
+++ b/tests/unit/test_udp_sender_fallback_warning.py
@@ -1,0 +1,181 @@
+"""
+Dedicated unit test for the UDP sendto() fallback-warning limiter.
+
+Mirrors ``test_udp_fallback_warning.py`` (receiver side). The sender uses the
+same two-layer suppression mechanism:
+
+  1. Module-level ``_send_fallback_warning_limiter`` (``WarningRateLimiter``),
+     keyed by connection_id.
+  2. Per-instance flag ``_sendto_fallback_warning_emitted``: permanently
+     suppresses subsequent warnings from the *same sender* after the first.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aionetx.api.udp import UdpSenderSettings
+from aionetx.implementations.asyncio_impl import asyncio_udp_sender as sender_module
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+class _LoopWithoutSockSendTo:
+    """Minimal event loop stub that does NOT expose sock_sendto."""
+
+
+class _AlwaysSuccessSocket:
+    """Socket stub whose sendto() always succeeds immediately."""
+
+    def sendto(self, _payload: bytes, _target: tuple[str, int]) -> int:
+        return len(_payload)
+
+    def getsockname(self) -> tuple[str, int]:
+        return ("127.0.0.1", 22000)
+
+
+def _make_sender(port_offset: int) -> AsyncioUdpSender:
+    return AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="127.0.0.1",
+            default_port=21000 + port_offset,
+            local_host="127.0.0.1",
+            local_port=22000 + port_offset,
+        )
+    )
+
+
+def _reset_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sender_module,
+        "_send_fallback_warning_limiter",
+        sender_module.WarningRateLimiter(interval_seconds=300.0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_sender_fallback_warning_emitted_exactly_once_on_first_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logger.warning is called exactly once when sock_sendto is absent."""
+    _reset_limiter(monkeypatch)
+
+    sender = _make_sender(1)
+    # Pin the owner loop so _assert_owner_loop does not fire. We only exercise
+    # _send_nonblocking directly here.
+    sock_stub = _AlwaysSuccessSocket()
+    loop_stub = _LoopWithoutSockSendTo()
+
+    with patch.object(sender_module.asyncio, "get_running_loop", return_value=loop_stub):
+        with patch.object(sender._logger, "warning") as mock_warning:
+            await sender._send_nonblocking(sock_stub, b"x", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+
+            assert mock_warning.call_count == 1
+            call_args = str(mock_warning.call_args)
+            assert "sendto() fallback polling" in call_args
+            assert "sock_sendto" in call_args
+
+
+@pytest.mark.asyncio
+async def test_sender_fallback_warning_suppressed_on_second_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """logger.warning is NOT called again on a second fallback from the same sender."""
+    _reset_limiter(monkeypatch)
+
+    sender = _make_sender(2)
+    sock_stub = _AlwaysSuccessSocket()
+    loop_stub = _LoopWithoutSockSendTo()
+
+    with patch.object(sender_module.asyncio, "get_running_loop", return_value=loop_stub):
+        with patch.object(sender._logger, "warning") as mock_warning:
+            await sender._send_nonblocking(sock_stub, b"x", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+            assert mock_warning.call_count == 1
+
+            await sender._send_nonblocking(sock_stub, b"y", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+            assert mock_warning.call_count == 1, (
+                f"Second fallback must not emit another warning; got {mock_warning.call_count}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_sender_fallback_flag_is_set_after_first_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_limiter(monkeypatch)
+
+    sender = _make_sender(3)
+    sock_stub = _AlwaysSuccessSocket()
+    loop_stub = _LoopWithoutSockSendTo()
+
+    assert not sender._sendto_fallback_warning_emitted
+
+    with patch.object(sender_module.asyncio, "get_running_loop", return_value=loop_stub):
+        await sender._send_nonblocking(sock_stub, b"x", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+
+    assert sender._sendto_fallback_warning_emitted
+
+
+@pytest.mark.asyncio
+async def test_sender_fallback_warning_not_emitted_when_sock_sendto_present() -> None:
+    class _LoopWithSockSendTo:
+        async def sock_sendto(
+            self, _sock: object, _payload: bytes, _target: tuple[str, int]
+        ) -> None:
+            return None
+
+    sender = _make_sender(4)
+    sock_stub = _AlwaysSuccessSocket()
+    loop_stub = _LoopWithSockSendTo()
+
+    with patch.object(sender_module.asyncio, "get_running_loop", return_value=loop_stub):
+        with patch.object(sender._logger, "warning") as mock_warning:
+            await sender._send_nonblocking(sock_stub, b"x", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+            assert mock_warning.call_count == 0
+
+    assert not sender._sendto_fallback_warning_emitted
+
+
+@pytest.mark.asyncio
+async def test_sender_fallback_warning_uses_actual_bound_socket_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_limiter(monkeypatch)
+
+    class _EphemeralSocket:
+        def __init__(self, bound_port: int) -> None:
+            self._bound_port = bound_port
+
+        def sendto(self, _payload: bytes, _target: tuple[str, int]) -> int:
+            return len(_payload)
+
+        def getsockname(self) -> tuple[str, int]:
+            return ("127.0.0.1", self._bound_port)
+
+    loop_stub = _LoopWithoutSockSendTo()
+    sender_a = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="127.0.0.1",
+            default_port=21010,
+            local_host="0.0.0.0",
+            local_port=0,
+        )
+    )
+    sender_b = AsyncioUdpSender(
+        settings=UdpSenderSettings(
+            default_host="127.0.0.1",
+            default_port=21011,
+            local_host="0.0.0.0",
+            local_port=0,
+        )
+    )
+
+    with patch.object(sender_module.asyncio, "get_running_loop", return_value=loop_stub):
+        with patch.object(sender_a._logger, "warning") as warning_a:
+            await sender_a._send_nonblocking(_EphemeralSocket(30101), b"x", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+            assert warning_a.call_count == 1
+
+        with patch.object(sender_b._logger, "warning") as warning_b:
+            await sender_b._send_nonblocking(_EphemeralSocket(30102), b"y", ("127.0.0.1", 9999))  # type: ignore[arg-type]
+            assert warning_b.call_count == 1

--- a/tests/unit/test_validate_release_provenance_script.py
+++ b/tests/unit/test_validate_release_provenance_script.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "ci" / "validate_release_provenance.py"
+SCRIPT_GLOBALS = runpy.run_path(str(SCRIPT_PATH))
+
+validate_tag_release = SCRIPT_GLOBALS["validate_tag_release"]
+validate_manual_testpypi_release = SCRIPT_GLOBALS["validate_manual_testpypi_release"]
+read_pyproject_version = SCRIPT_GLOBALS["read_pyproject_version"]
+
+
+def run_script_cli(
+    *,
+    tag_name: str = "",
+    event_name: str = "",
+    publish_target: str = "",
+    release_version: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "TAG_NAME": tag_name,
+            "EVENT_NAME": event_name,
+            "PUBLISH_TARGET": publish_target,
+            "RELEASE_VERSION": release_version,
+        }
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+
+
+def test_validate_tag_release_accepts_matching_tag() -> None:
+    validate_tag_release(tag_name="v1.2.3", pyproject_version="1.2.3")
+
+
+def test_validate_tag_release_rejects_mismatch() -> None:
+    with pytest.raises(AssertionError, match="Tag/version mismatch"):
+        validate_tag_release(tag_name="v1.2.4", pyproject_version="1.2.3")
+
+
+def test_validate_manual_testpypi_release_requires_dispatch_target() -> None:
+    with pytest.raises(AssertionError, match="workflow_dispatch"):
+        validate_manual_testpypi_release(
+            event_name="push",
+            publish_target="testpypi",
+            declared_release_version="1.2.3",
+            pyproject_version="1.2.3",
+        )
+
+
+def test_validate_manual_testpypi_release_rejects_empty_version() -> None:
+    with pytest.raises(AssertionError, match="requires RELEASE_VERSION"):
+        validate_manual_testpypi_release(
+            event_name="workflow_dispatch",
+            publish_target="testpypi",
+            declared_release_version="",
+            pyproject_version="1.2.3",
+        )
+
+
+def test_validate_manual_testpypi_release_rejects_mismatch() -> None:
+    with pytest.raises(AssertionError, match="Release provenance mismatch"):
+        validate_manual_testpypi_release(
+            event_name="workflow_dispatch",
+            publish_target="testpypi",
+            declared_release_version="1.2.4",
+            pyproject_version="1.2.3",
+        )
+
+
+def test_validate_manual_testpypi_release_accepts_match() -> None:
+    validate_manual_testpypi_release(
+        event_name="workflow_dispatch",
+        publish_target="testpypi",
+        declared_release_version="1.2.3",
+        pyproject_version="1.2.3",
+    )
+
+
+def test_script_cli_succeeds_for_manual_testpypi_with_matching_version() -> None:
+    version = read_pyproject_version()
+    result = run_script_cli(
+        event_name="workflow_dispatch",
+        publish_target="testpypi",
+        release_version=version,
+    )
+
+    assert result.returncode == 0
+    assert "Manual TestPyPI provenance verified" in result.stdout
+
+
+def test_script_cli_fails_for_manual_testpypi_with_missing_version() -> None:
+    result = run_script_cli(
+        event_name="workflow_dispatch",
+        publish_target="testpypi",
+    )
+
+    assert result.returncode != 0
+    assert "requires RELEASE_VERSION" in result.stderr
+
+
+def test_script_cli_ignores_tag_name_for_manual_testpypi_context() -> None:
+    version = read_pyproject_version()
+    result = run_script_cli(
+        tag_name="main",
+        event_name="workflow_dispatch",
+        publish_target="testpypi",
+        release_version=version,
+    )
+
+    assert result.returncode == 0
+    assert "Manual TestPyPI provenance verified" in result.stdout
+
+
+def test_script_cli_succeeds_for_matching_tag_context() -> None:
+    version = read_pyproject_version()
+    result = run_script_cli(
+        tag_name=f"v{version}",
+        event_name="push",
+    )
+
+    assert result.returncode == 0
+    assert f"Tag/version match verified: v{version}" in result.stdout
+
+
+def test_script_cli_fails_for_unsupported_context() -> None:
+    result = run_script_cli(
+        event_name="workflow_dispatch",
+        publish_target="none",
+    )
+
+    assert result.returncode != 0
+    assert "Unsupported provenance check context" in result.stderr

--- a/tests/unit/test_version_and_repr.py
+++ b/tests/unit/test_version_and_repr.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for __version__ and __repr__.
+
+Ensures the canonical user-facing introspection surfaces are correct for all
+four transport implementations.
+"""
+
+from __future__ import annotations
+
+import aionetx
+from aionetx.api.tcp_client import TcpClientSettings
+from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
+from aionetx.api.tcp_server import TcpServerSettings
+from aionetx.api.udp import UdpReceiverSettings, UdpSenderSettings
+from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
+from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
+from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+
+
+# ---------------------------------------------------------------------------
+# __version__
+# ---------------------------------------------------------------------------
+
+
+def test_version_attribute_exists() -> None:
+    """aionetx.__version__ must exist and be a non-empty string."""
+    assert hasattr(aionetx, "__version__")
+    assert isinstance(aionetx.__version__, str)
+    assert aionetx.__version__, "aionetx.__version__ must not be empty"
+
+
+def test_version_in_all() -> None:
+    """__version__ must be in aionetx.__all__ so it is part of the public API."""
+    assert "__version__" in aionetx.__all__
+
+
+def test_version_format_is_dotted_numeric() -> None:
+    """Version string must look like PEP 440 (at least MAJOR.MINOR.PATCH)."""
+    parts = aionetx.__version__.split(".")
+    assert len(parts) >= 3, (
+        f"__version__ {aionetx.__version__!r} does not contain at least 3 dot-separated components"
+    )
+    # Each leading component must be a digit string.
+    for part in parts[:3]:
+        assert part.isdigit() or part.split("a")[0].isdigit() or part.split("b")[0].isdigit(), (
+            f"Version component {part!r} is not numeric"
+        )
+
+
+# ---------------------------------------------------------------------------
+# __repr__ on all four transport implementations
+# ---------------------------------------------------------------------------
+
+
+class _Noop:
+    async def on_event(self, event: object) -> None:
+        return None
+
+
+def test_tcp_client_repr_contains_expected_fields() -> None:
+    """AsyncioTcpClient.__repr__ must include host, port, and lifecycle state."""
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=5000,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_Noop(),
+    )
+    r = repr(client)
+    assert "AsyncioTcpClient" in r
+    assert "127.0.0.1" in r
+    assert "5000" in r
+    assert "stopped" in r.lower()
+
+
+def test_tcp_server_repr_contains_expected_fields() -> None:
+    """AsyncioTcpServer.__repr__ must include host, port, and lifecycle state."""
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="0.0.0.0", port=8080, max_connections=64),
+        event_handler=_Noop(),
+    )
+    r = repr(server)
+    assert "AsyncioTcpServer" in r
+    assert "0.0.0.0" in r
+    assert "8080" in r
+    assert "stopped" in r.lower()
+
+
+def test_udp_receiver_repr_contains_expected_fields() -> None:
+    """AsyncioUdpReceiver.__repr__ must include host, port, and lifecycle state."""
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=6000),
+        event_handler=_Noop(),
+    )
+    r = repr(receiver)
+    assert "AsyncioUdpReceiver" in r
+    assert "127.0.0.1" in r
+    assert "6000" in r
+    assert "stopped" in r.lower()
+
+
+def test_udp_sender_repr_contains_expected_fields() -> None:
+    """AsyncioUdpSender.__repr__ must include default_host, default_port, and closed status."""
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="192.168.1.1", default_port=9000),
+    )
+    r = repr(sender)
+    assert "AsyncioUdpSender" in r
+    assert "192.168.1.1" in r
+    assert "9000" in r
+    assert "False" in r  # closed=False before stop()
+
+
+def test_repr_is_str_type() -> None:
+    """repr() on all four implementations must return a plain str."""
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=1234, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=_Noop(),
+    )
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=1235, max_connections=64),
+        event_handler=_Noop(),
+    )
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=1236),
+        event_handler=_Noop(),
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=1237),
+    )
+    for obj in (client, server, receiver, sender):
+        assert isinstance(repr(obj), str), f"repr({type(obj).__name__}) did not return str"


### PR DESCRIPTION
## Summary

This PR adds the initial public project snapshot for `aionetx`.

`aionetx` is a pre-1.0 asyncio-first transport library for TCP, UDP, and IPv4 multicast primitives. The project focuses on explicit lifecycle semantics, structured event delivery, configurable backpressure, and a strict transport-only boundary.

## What is included

- TCP client and server transport primitives
- UDP sender, UDP receiver, and IPv4 multicast receiver primitives
- explicit managed lifecycle events and connection events
- configurable event delivery, backpressure, and handler-failure behavior
- optional TCP client reconnect and heartbeat support
- examples, tests, typing metadata, and CI/release verification workflows

## Verification

- `python -m pytest -q`
- `python -m coverage run --source=src/aionetx -m pytest -q`
- `python -m coverage report -m`
- `ruff check .`
- `ruff format --check .`
- `mypy src`
- wheel/sdist build
- `twine check`
- installed-artifact smoke test
- installed-artifact semantic minisuite

## Release note

This is an alpha/pre-1.0 public baseline. It is intended to make the project reviewable and usable for integration work, but it is not being advertised as production-ready yet.
