### PR TITLE
chore(openssf): harden baseline compliance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ Keep the PR focused on one concern. Refactoring-only and behavior-change PRs are
 
 ## Checklist
 
+- [ ] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
 - [ ] Tests added or updated for new or changed behavior (or explicitly explain why none are needed).
 - [ ] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
 - [ ] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     # Weekly SHA-pin validation every Monday at 07:00 UTC
     - cron: "0 7 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   # Calibration note:
   # - Required lanes are runtime trust, integration confidence, packaging/release, and static analysis.
@@ -141,6 +144,22 @@ jobs:
           pip install -e .[dev]
       - name: Mypy
         run: mypy src
+
+  # Tier: dependency policy gate (pull requests only)
+  dependency_review:
+    name: Required - dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
 
   # Tier: runtime-semantic trust gates
   required_behavior_tests:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,8 @@ jobs:
     name: CodeQL - Python security analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # CodeQL is always non-blocking for pre-release; results appear in the
-    # Security tab without gating the required CI trust envelope.
-    continue-on-error: true
+    # CodeQL analysis itself is required. Security-alert thresholds are
+    # enforced by branch protection/code-scanning settings and release gates.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,25 @@ Thanks for contributing.
 By participating in this project you agree to abide by the
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Developer Certificate of Origin
+
+All code contributions must be made with Developer Certificate of
+Origin (DCO) sign-off. Add a `Signed-off-by` trailer to every commit:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The usual Git command is:
+
+```bash
+git commit -s
+```
+
+By signing off, you assert that you have the right to submit the
+contribution under the project license. Pull requests with unsigned
+commits are not accepted once the repository DCO check is enabled.
+
 ## Project-specific expectations
 
 These rules are critical and must be preserved:

--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ One callback (`on_event`) keeps the integration contract stable and small across
 </details>
 
 <details>
-<summary><strong>What do lifecycle guarantees mean—and not mean?</strong></summary>
+<summary><strong>What do lifecycle guarantees mean - and not mean?</strong></summary>
 
 Lifecycle states and transitions are explicit, observable, and monotonic for managed components. They do not imply protocol-level correctness, message completeness, or business-level delivery guarantees.
 
@@ -821,11 +821,12 @@ Choose direct `asyncio` if you need very custom low-level control and are comfor
 - `docs/platform_notes.md`: platform-specific runtime behavior (socket bind reuse/exclusivity, UDP fallback polling on Windows)
 - `docs/timing_and_latency.md`: timing envelope, what aionetx guarantees and does not, suitability statement
 - `docs/logging.md`: logger hierarchy, structured context, recommended levels, and a minimal `dictConfig`
+- `docs/reproducible_build.md`: release artifact verification, provenance/SBOM checks, and reproducible rebuild recipe
 - `docs/breaking_changes/README.md`: compatibility-note format and expectations for supported upgrade-path changes
 - `CHANGELOG.md`: user-visible changes per release, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
-- `SECURITY.md`: supported versions, private vulnerability reporting channels, and security-scope boundaries
+- `SECURITY.md`: supported versions, private vulnerability reporting, security-scope boundaries, secrets policy, SCA/SAST thresholds, and threat model
 - `SUPPORT.md`: how to get help, report issues, and ask questions
-- `CONTRIBUTING.md`: concise contribution workflow
+- `CONTRIBUTING.md`: concise contribution workflow, DCO sign-off, and review expectations
 - `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1, community standards, and enforcement contact
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,59 @@ basis. Realistic commitments:
   rework. Credit is given to the reporter in the advisory unless the
   reporter asks to stay anonymous.
 
+## Secrets and Credentials
+
+Project secrets must not be committed to the repository. Required
+credentials must be stored only in GitHub Secrets, GitHub Environments,
+or the corresponding service provider's protected secret store. Release
+publishing should prefer short-lived credentials and OpenID Connect
+(OIDC) trusted publishing over long-lived upload tokens.
+
+Secrets and credentials must be scoped to the minimum required
+permission. Access must be removed when it is no longer needed. Any
+secret that is exposed, suspected to be exposed, or accessible to a
+person who no longer needs it must be revoked and rotated before the
+next release that depends on it.
+
+## Maintainer and Collaborator Access
+
+Access to sensitive project resources is granted on a least-privilege
+basis. Before a collaborator receives elevated access to the repository,
+release workflow, package publishing settings, security advisories, or
+stored secrets, the maintainer must review:
+
+- the concrete access need and intended duration
+- whether a lower-permission role is sufficient
+- whether the collaborator uses multi-factor authentication
+- recent project activity and trust context
+
+Elevated access must be removed when the need ends. Public code changes
+continue to go through pull requests and required checks even when made
+by collaborators with repository access.
+
+## Dependency and Static Analysis Policy
+
+Software composition analysis (SCA) findings are handled before release:
+
+- High and critical dependency vulnerability findings block releases
+  unless they are documented as non-exploitable for this project.
+- License findings must be triaged before release.
+- Any non-exploitability or policy suppression must include a written
+  rationale that can be reviewed later.
+
+Static application security testing (SAST) findings are handled before
+merge or release:
+
+- High and critical CodeQL or equivalent security findings block release.
+- Medium findings must be triaged before release.
+- False-positive or non-exploitable suppressions require a written
+  rationale. Dismissal without a reason is not acceptable.
+
+If a dependency vulnerability is known but does not affect `aionetx`,
+the project publishes a VEX-style justification or equivalent advisory
+note explaining why the vulnerable component or code path is not
+exploitable in this project.
+
 ## Out of Scope
 
 The following are **not** treated as security vulnerabilities because

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,6 +101,35 @@ the project publishes a VEX-style justification or equivalent advisory
 note explaining why the vulnerable component or code path is not
 exploitable in this project.
 
+## Threat Model and Attack Surface
+
+Primary actors:
+
+- application developers embedding `aionetx`
+- remote TCP, UDP, or multicast peers
+- local processes that can interact with sockets or event handlers
+- maintainers and collaborators with repository or release access
+- CI/CD and package release workflows
+
+Assets that need protection:
+
+- sockets, file descriptors, and asyncio tasks owned by transports
+- lifecycle state and event stream integrity
+- package artifacts, release provenance, and security advisories
+- repository settings, CI credentials, and package publishing authority
+
+Main attack surfaces:
+
+- raw network input delivered to user handlers
+- handler exceptions, cancellation, and backpressure behavior
+- lifecycle transitions, reconnect loops, heartbeat loops, and cleanup
+- CI workflow inputs, dependency updates, and release metadata
+
+Current mitigations include explicit lifecycle state tests, bounded
+event queues with configurable backpressure, no payload logging by
+default, CodeQL, Dependabot, release provenance checks, OIDC trusted
+publishing, artifact attestations, and branch protection rules.
+
 ## Out of Scope
 
 The following are **not** treated as security vulnerabilities because

--- a/docs/reproducible_build.md
+++ b/docs/reproducible_build.md
@@ -10,6 +10,35 @@ rebuilds of the same release ref.
 - The reference value is `git log -1 --format=%ct <ref>`.
 - Reproducibility means the same source tree and build inputs produce identical artifacts.
 
+## Release asset verification
+
+For an official release, verify that the release identity and artifacts
+all point to the same version:
+
+1. Check that the GitHub Release tag, PyPI version, `pyproject.toml`
+   version, and `CHANGELOG.md` entry agree.
+2. Confirm that the tag is in the `MarcusKorinth/aionetx` repository.
+3. Download the wheel, source distribution, and `aionetx-sbom.spdx.json`
+   from the GitHub Release or the package index.
+4. Verify GitHub artifact attestations for each release asset:
+
+```bash
+gh attestation verify aionetx-*.whl --repo MarcusKorinth/aionetx
+gh attestation verify aionetx-*.tar.gz --repo MarcusKorinth/aionetx
+gh attestation verify aionetx-sbom.spdx.json --repo MarcusKorinth/aionetx
+```
+
+The expected release identity is:
+
+- source repository: `MarcusKorinth/aionetx`
+- release workflow: `.github/workflows/release.yml`
+- publishing mechanism: GitHub Actions OIDC trusted publishing
+
+Reject artifacts whose attestations point to a different repository,
+workflow, or release version. The reproducible build recipe below is a
+secondary check that independent rebuilds produce the same wheel and
+source distribution for the tagged ref.
+
 ## Third-party verification recipe
 
 1. Check out the exact release ref.


### PR DESCRIPTION
## Summary

Hardens OpenSSF Baseline 2/3 readiness with focused governance, security-policy, release-verification, and CI supply-chain checks.

The PR is split into small DCO-compliant commits so each work package stays reviewable.

## Changes

- document DCO sign-off requirements for code contributions
- add a PR checklist item for DCO compliance
- document secrets and credential handling expectations
- document collaborator access review and least-privilege policy
- define SCA and SAST remediation thresholds
- add a threat model and attack surface summary
- document release tag, artifact, attestation, SBOM, and release identity verification
- add a pull-request dependency review gate for high and critical dependency vulnerabilities
- align CodeQL workflow behavior with the documented SAST blocking policy
- link security and release verification guidance from the README documentation map

## Related issue

Relates to OpenSSF Best Practices Baseline 2/3 self-certification.

## Notes

After this PR is merged, repository settings still need to enforce the new external checks where applicable:

- add the DCO check as a required status check
- add `Required - dependency review` as a required status check
- keep CodeQL/code-scanning enforcement aligned with the documented SAST policy

OpenSSF Baseline 3 human-review enforcement remains intentionally deferred until the project has a non-author reviewer available.

## Checklist

- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed). No runtime tests needed; this PR changes governance docs, release verification docs, and CI policy gates.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not needed; no runtime/package user behavior changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable; no public API changes.
