### PR TITLE
docs(project): polish contribution guidance and badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,10 +158,12 @@ A commit body is optional for:
 - small `test` changes
 - trivial `chore` or `ci` updates
 
-### Line length
+### Readability
 
 - header: max 72 characters
-- body: wrap at 72 characters per line
+- body: keep paragraphs readable in GitHub and terminal tools; avoid
+  very long lines, but wrap where it improves clarity rather than to
+  satisfy a fixed column count
 
 ### Footer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ git commit -s
 
 By signing off, you assert that you have the right to submit the
 contribution under the project license. Pull requests with unsigned
-commits are not accepted once the repository DCO check is enabled.
+commits are not accepted.
 
 ## Project-specific expectations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage gate](https://img.shields.io/badge/coverage%20gate-%E2%89%A585%25-brightgreen)](https://github.com/MarcusKorinth/aionetx/blob/main/.github/workflows/ci.yml)
 [![Typing](https://img.shields.io/badge/typing-py.typed-blueviolet)](https://github.com/MarcusKorinth/aionetx/blob/main/src/aionetx/py.typed)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12644/baseline)](https://www.bestpractices.dev/projects/12644)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/MarcusKorinth/aionetx/badge)](https://securityscorecards.dev/viewer/?uri=github.com/MarcusKorinth/aionetx)
 
 `aionetx` is an asyncio-first transport library for reusable TCP and UDP communication primitives.


### PR DESCRIPTION
## Summary

Polishes public documentation around contribution expectations and project health signals.

The PR keeps the scope intentionally small: it modernizes commit body readability guidance, adds the OpenSSF Baseline badge, and updates DCO wording now that DCO enforcement is active.

## Changes

- replace rigid 72-character commit body wrapping guidance with readability-focused wording
- add the OpenSSF Baseline badge to the README badge block
- clarify that unsigned commits are not accepted now that DCO enforcement is active

## Related issue

Relates to OpenSSF Best Practices badge publication and repository presentation polish.

## Checklist

- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed). No tests needed; this PR changes documentation only.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not needed; no runtime/package user behavior changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable; no public API changes.
