### PR TITLE
docs(openssf): document Silver readiness evidence

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,71 @@
+# Governance
+
+`aionetx` is currently governed as a single-maintainer open source
+project. The governance model is intentionally lightweight: decisions
+are made in public where practical, changes go through pull requests,
+and release/security authority remains with the maintainer until
+additional maintainers are explicitly added.
+
+## Decision model
+
+Project decisions are made by the maintainer after considering public
+issues, pull request discussion, CI results, security impact, and the
+project scope documented in `README.md`, `docs/architecture.md`, and
+`SECURITY.md`.
+
+The maintainer is responsible for:
+
+- accepting or rejecting pull requests
+- deciding whether a change fits the transport-only scope
+- deciding release timing and release contents
+- maintaining branch protection and required checks
+- triaging security reports and coordinating vulnerability disclosure
+- granting or removing elevated repository, release, or security access
+
+For routine changes, a passing CI result and a focused pull request are
+expected before merge. For behavior, lifecycle, API, or security changes,
+the maintainer may require additional tests, documentation, or design
+discussion before accepting the change.
+
+## Current roles
+
+| Role | Current holder | Responsibilities |
+| --- | --- | --- |
+| Maintainer | Marcus Korinth | Project direction, releases, repository settings, security triage, merge decisions |
+| Contributor | Anyone submitting issues or pull requests | Propose changes, follow `CONTRIBUTING.md`, sign commits with DCO |
+| Security reporter | Anyone reporting a vulnerability privately | Report suspected vulnerabilities through GitHub private vulnerability reporting |
+| CI/release automation | GitHub Actions | Run required checks, build artifacts, generate attestations, publish releases when a release tag is pushed |
+
+## Adding maintainers or elevated access
+
+Additional maintainers may be added after sustained, high-quality
+contributions and an explicit trust review. Before elevated access is
+granted, the maintainer reviews the access need, intended duration,
+least-privilege role, multi-factor authentication status, and recent
+project activity.
+
+Elevated access must be removed when it is no longer needed. Public code
+changes continue to go through pull requests, required checks, and DCO
+sign-off even when made by collaborators with repository access.
+
+## Scope and conflict resolution
+
+The project scope is raw asyncio transport primitives for TCP, UDP, and
+multicast. Protocol parsing, application-level authentication,
+authorization, encryption, business logic, framing, and serialization
+remain outside the core library.
+
+If there is disagreement about a change, the maintainer uses the
+documented project scope, lifecycle semantics, security policy, and
+test evidence as the decision basis. If a decision would materially
+change public API, lifecycle behavior, or security expectations, it
+should be documented in the pull request and reflected in user-facing
+documentation when accepted.
+
+## Current continuity limits
+
+`aionetx` is currently a single-maintainer project. The project does not
+yet claim a bus factor of two or a guaranteed one-week continuity plan
+if the maintainer becomes unavailable. The intended path to improve this
+is to add at least one trusted maintainer once the project has sustained
+external contribution and review history.

--- a/README.md
+++ b/README.md
@@ -825,7 +825,8 @@ Choose direct `asyncio` if you need very custom low-level control and are comfor
 - `docs/reproducible_build.md`: release artifact verification, provenance/SBOM checks, and reproducible rebuild recipe
 - `docs/breaking_changes/README.md`: compatibility-note format and expectations for supported upgrade-path changes
 - `CHANGELOG.md`: user-visible changes per release, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
-- `SECURITY.md`: supported versions, private vulnerability reporting, security-scope boundaries, secrets policy, SCA/SAST thresholds, and threat model
+- `SECURITY.md`: supported versions, private vulnerability reporting, security-scope boundaries, secrets policy, SCA/SAST thresholds, threat model, and security assurance case
+- `GOVERNANCE.md`: decision model, project roles, access review expectations, and current single-maintainer continuity limits
 - `SUPPORT.md`: how to get help, report issues, and ask questions
 - `CONTRIBUTING.md`: concise contribution workflow, DCO sign-off, and review expectations
 - `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1, community standards, and enforcement contact

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -130,6 +130,64 @@ event queues with configurable backpressure, no payload logging by
 default, CodeQL, Dependabot, release provenance checks, OIDC trusted
 publishing, artifact attestations, and branch protection rules.
 
+## Security Assurance Case
+
+The project's security assurance case is based on a deliberately narrow
+scope: `aionetx` provides transport primitives and lifecycle/event
+semantics, but does not provide authentication, authorization,
+encryption, message framing, payload validation, or application
+protocol security.
+
+Security requirements:
+
+- transport resources must be cleaned up deterministically after normal
+  shutdown, handler failure, cancellation, and startup rollback
+- event delivery must make backpressure behavior explicit instead of
+  silently growing unbounded queues
+- user payload bytes must not be logged by default
+- release artifacts must be built by the documented release workflow and
+  be traceable to the repository, workflow, and release version
+- dependency and static-analysis findings above the documented
+  thresholds must be triaged before release
+
+Trust boundaries:
+
+- remote peers are untrusted sources of bytes
+- user event handlers are application code and may fail, block, or
+  cancel
+- CI/release workflows are trusted only when running from the protected
+  repository and expected workflow identity
+- package consumers trust published artifacts only after checking the
+  release version, provenance, and attestations
+
+Secure design arguments:
+
+- the transport-only boundary avoids mixing network I/O with application
+  protocol, authentication, authorization, or business logic
+- lifecycle state transitions are explicit and covered by automated
+  tests, reducing ambiguity around startup, shutdown, and cleanup
+- event backpressure is configurable and bounded by default settings
+  rather than relying on unlimited memory growth
+- the package has no runtime dependencies outside the Python standard
+  library, reducing supply-chain exposure for installed users
+- releases use GitHub OIDC trusted publishing and artifact attestations
+  instead of long-lived PyPI upload tokens stored in the repository
+
+Common weakness mitigations:
+
+- resource leaks are countered with lifecycle and cleanup tests for
+  sockets, tasks, dispatcher shutdown, and startup rollback
+- unbounded event growth is countered with bounded dispatcher queues and
+  explicit backpressure policies
+- accidental sensitive payload logging is countered by avoiding raw
+  payload logging in library code
+- dependency and workflow drift are countered with Dependabot,
+  dependency review, pinned GitHub Actions, CodeQL, Ruff, mypy, and
+  required CI gates
+- release substitution risk is countered with version checks,
+  reproducible-build guidance, SBOM generation, artifact attestations,
+  and documented verification steps
+
 ## Out of Scope
 
 The following are **not** treated as security vulnerabilities because


### PR DESCRIPTION
## Summary

Documents the remaining OpenSSF Silver-readiness evidence that can be truthfully completed before the first public release.

This PR keeps the scope intentionally small: governance, project roles, security assurance, and README discoverability. It does not claim multi-maintainer continuity or bus-factor guarantees that the project does not currently have.

## Changes

- add lightweight project governance documentation
- document current roles and maintainer responsibilities
- state current single-maintainer continuity limits honestly
- add a security assurance case to `SECURITY.md`
- link governance and security assurance references from the README documentation map

## Related issue

Relates to OpenSSF Best Practices Silver self-certification.

## Checklist

- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed). No tests needed for documentation-only governance and security policy changes.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not needed; no runtime/package user behavior changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable; no public API changes.
