### PR TITLE
docs(release): align public availability messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable user-visible changes to `aionetx` are documented in this file.
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-04-24
-
-Initial public alpha release.
+Planned contents for the initial public alpha release (`0.1.0`).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Choose direct `asyncio` if you need very custom low-level control and are comfor
 
 ## Installation and local development
 
-Install the released package:
+After the first public release is published to PyPI, install it with:
 
 ```bash
 pip install aionetx


### PR DESCRIPTION
## Summary

Aligns release-facing documentation with the current public availability state.

The goal of this PR is narrow: keep public messaging truthful before the first real `v0.1.0` tag triggers the live release workflow and PyPI publish.

## Changes

- keep the planned `0.1.0` notes under `Unreleased` in `CHANGELOG.md`
- clarify in `README.md` that `pip install aionetx` applies after the first public release is published to PyPI

## Checklist

- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed). No tests needed for documentation-only release messaging updates.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not needed; no runtime/package user behavior changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable; no public API changes.
