### PR TITLE
fix(lifecycle): harden async shutdown and startup cleanup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,12 +45,12 @@ No public `FAILED` lifecycle state exists.
 
 - `STOPPED -> STARTING`
 - `STARTING -> RUNNING`
-- `STARTING -> STOPPING`
 - `STARTING -> STOPPED` (startup rollback)
+- `STARTING -> STOPPING` (shutdown requested during startup)
 - `RUNNING -> STOPPING`
 - `STOPPING -> STOPPED`
 
-State transitions must remain monotonic and understandable. Concurrent lifecycle calls must converge without illegal transitions.
+State transitions must remain monotonic and understandable. Concurrent lifecycle calls must converge without illegal transitions, duplicate terminal publication, or detached cleanup tasks.
 
 Failures are surfaced through events (network/reconnect/close/error), not via a separate lifecycle enum.
 
@@ -61,9 +61,11 @@ the semantic test suite:
 
 - Once `stop()` returns with state `STOPPED`, no further user callback is
   invoked from the component's internal tasks.
+- Startup cancellation must roll back partial resources and publish the same
+  terminal `STOPPED` state as other startup failures.
 - `STOPPING` is a terminal-in-progress state, not a re-entrant steady state:
-  repeated stop requests converge on the same shutdown path instead of creating
-  new transition branches.
+  repeated or overlapping stop requests converge on the same shutdown path
+  instead of creating new transition branches.
 - Lifecycle publication remains monotonic: managed components do not publish
   illegal backward transitions.
 - Terminal lifecycle publication happens at most once per shutdown sequence.
@@ -73,7 +75,8 @@ the semantic test suite:
 Primary integration contract:
 
 ```python
-async def on_event(self, event: NetworkEvent) -> None
+async def on_event(self, event: NetworkEvent) -> None:
+    ...
 ```
 
 `BaseNetworkEventHandler` is a convenience layer over this contract.
@@ -103,7 +106,7 @@ async def on_event(self, event: NetworkEvent) -> None
 be added in minor releases as the observability surface grows. Stability
 guarantees are:
 
-- Existing event dataclasses and their field shapes are stable â€” fields
+- Existing event dataclasses and their field shapes are stable - fields
   are not renamed, retyped, or removed without a deprecation cycle and a
   CHANGELOG entry when compatibility expectations change.
 - Additions to the union are called out under **Added** in the CHANGELOG.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,8 +61,8 @@ the semantic test suite:
 
 - Once `stop()` returns with state `STOPPED`, no further user callback is
   invoked from the component's internal tasks.
-- Startup cancellation must roll back partial resources and publish the same
-  terminal `STOPPED` state as other startup failures.
+- Startup cancellation must roll back partial resources and leave the component
+  in the same terminal `STOPPED` state as other startup failures.
 - `STOPPING` is a terminal-in-progress state, not a re-entrant steady state:
   repeated or overlapping stop requests converge on the same shutdown path
   instead of creating new transition branches.

--- a/scripts/ci/installed_artifact_smoke.py
+++ b/scripts/ci/installed_artifact_smoke.py
@@ -6,7 +6,13 @@ from collections.abc import Callable
 from importlib.metadata import version as package_version
 
 import aionetx
-from aionetx.api import NetworkEvent, ReconnectAttemptFailedEvent
+from aionetx.api import (
+    ByteSenderProtocol,
+    BytesLike,
+    ManagedTransportProtocol,
+    NetworkEvent,
+    ReconnectAttemptFailedEvent,
+)
 
 AsyncioNetworkFactory = aionetx.AsyncioNetworkFactory
 BytesReceivedEvent = aionetx.BytesReceivedEvent
@@ -24,6 +30,13 @@ assert isinstance(aionetx.__version__, str) and aionetx.__version__, (
 assert aionetx.__version__ == package_version("aionetx"), (
     "aionetx.__version__ must match installed package metadata; "
     f"got {aionetx.__version__!r} vs {package_version('aionetx')!r}"
+)
+assert BytesLike is not None, "aionetx.api.BytesLike is missing from installed package"
+assert ByteSenderProtocol.__name__ == "ByteSenderProtocol", (
+    "aionetx.api.ByteSenderProtocol is missing from installed package"
+)
+assert ManagedTransportProtocol.__name__ == "ManagedTransportProtocol", (
+    "aionetx.api.ManagedTransportProtocol is missing from installed package"
 )
 
 

--- a/src/aionetx/api/__init__.py
+++ b/src/aionetx/api/__init__.py
@@ -45,8 +45,11 @@ from aionetx.api.policies import (
     ReconnectJitter,
 )
 from aionetx.api.protocols import (
+    ByteSenderProtocol,
+    BytesLike,
     ConnectionProtocol,
     HeartbeatProviderProtocol,
+    ManagedTransportProtocol,
     MulticastReceiverProtocol,
     NetworkFactory,
     TcpClientProtocol,
@@ -76,6 +79,8 @@ from aionetx.api.typed_event_router import TypedEventRouter
 #   curated API surface so callers do not need to reach into internal modules.
 __all__ = (
     "BaseNetworkEventHandler",
+    "ByteSenderProtocol",
+    "BytesLike",
     "BytesReceivedEvent",
     "ComponentLifecycleChangedEvent",
     "ComponentLifecycleState",
@@ -99,6 +104,7 @@ __all__ = (
     "HeartbeatResult",
     "TcpHeartbeatSettings",
     "InvalidNetworkConfigurationError",
+    "ManagedTransportProtocol",
     "MulticastReceiverProtocol",
     "MulticastReceiverSettings",
     "NetworkConfigurationError",

--- a/src/aionetx/api/heartbeat.py
+++ b/src/aionetx/api/heartbeat.py
@@ -33,18 +33,19 @@ class HeartbeatResult:
     Attributes:
         should_send (bool): When ``True``, ``payload`` is sent over the connection.
         payload (BytesLike): Raw heartbeat payload to send when ``should_send`` is true.
+            Ignored when ``should_send`` is false.
     """
 
     should_send: bool
     payload: BytesLike = b""
 
     def __post_init__(self) -> None:
-        # Validate the provider boundary here so the sender never has to rely
-        # on truthiness or partially-valid heartbeat results.
+        # Validate the provider decision at the boundary so the sender never
+        # relies on truthiness. Payload type matters only when it will be sent.
         require_bool(
             field_name="HeartbeatResult.should_send", value=self.should_send, error_type=TypeError
         )
-        if not isinstance(self.payload, (bytes, bytearray, memoryview)):
+        if self.should_send and not isinstance(self.payload, (bytes, bytearray, memoryview)):
             raise TypeError("HeartbeatResult.payload must be bytes-like.")
 
 

--- a/src/aionetx/api/heartbeat.py
+++ b/src/aionetx/api/heartbeat.py
@@ -38,6 +38,15 @@ class HeartbeatResult:
     should_send: bool
     payload: BytesLike = b""
 
+    def __post_init__(self) -> None:
+        # Validate the provider boundary here so the sender never has to rely
+        # on truthiness or partially-valid heartbeat results.
+        require_bool(
+            field_name="HeartbeatResult.should_send", value=self.should_send, error_type=TypeError
+        )
+        if not isinstance(self.payload, (bytes, bytearray, memoryview)):
+            raise TypeError("HeartbeatResult.payload must be bytes-like.")
+
 
 @dataclass(frozen=True, slots=True)
 class TcpHeartbeatSettings:

--- a/src/aionetx/api/protocols.py
+++ b/src/aionetx/api/protocols.py
@@ -8,6 +8,7 @@ can import the protocol layer from one stable location.
 from __future__ import annotations
 
 from aionetx.api.byte_sender_protocol import ByteSenderProtocol
+from aionetx.api.bytes_like import BytesLike
 from aionetx.api.connection_protocol import ConnectionProtocol
 from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
 from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
@@ -20,6 +21,7 @@ from aionetx.api.udp import UdpReceiverProtocol, UdpSenderProtocol
 
 __all__ = (
     "ByteSenderProtocol",
+    "BytesLike",
     "ConnectionProtocol",
     "HeartbeatProviderProtocol",
     "ManagedTransportProtocol",

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -50,6 +50,8 @@ class _DatagramRuntimeState:
     connection_state: ConnectionState = ConnectionState.CREATED
     metadata: ConnectionMetadata | None = None
     recv_fallback_warning_emitted: bool = False
+    stop_waiter: asyncio.Future[None] | None = None
+    stop_owner_task: asyncio.Task[object] | None = None
 
 
 @dataclass(slots=True)
@@ -65,6 +67,8 @@ class _DatagramStopSnapshot:
         task: Receive task detached from runtime state.
         sock: Socket detached from runtime state.
         stopping_event: Precomputed STOPPING lifecycle event, if any.
+        stop_waiter: Shared waiter for overlapping stop callers.
+        owns_stop: Whether this snapshot owns teardown and terminal publication.
     """
 
     stop_dispatcher: bool = False
@@ -74,6 +78,13 @@ class _DatagramStopSnapshot:
     task: asyncio.Task[None] | None = None
     sock: socket.socket | None = None
     stopping_event: ComponentLifecycleChangedEvent | None = None
+    stop_waiter: asyncio.Future[None] | None = None
+    owns_stop: bool = False
+
+    @property
+    def waits_for_owner(self) -> bool:
+        """Whether this stop call should wait for an already-running stop path."""
+        return self.stop_waiter is not None and not self.owns_stop
 
     @property
     def is_noop(self) -> bool:
@@ -262,30 +273,62 @@ class _AsyncioDatagramReceiverBase:
             unlock    : emit STOPPED and stop dispatcher
         """
         snapshot = await self._plan_stop_snapshot()
+        if snapshot.waits_for_owner:
+            if self._event_dispatcher.current_task_is_worker():
+                return
+            # Non-owner stop callers observe the active owner stop path instead
+            # of planning another teardown. shield() prevents caller
+            # cancellation from cancelling the shared owner waiter.
+            await asyncio.shield(cast("asyncio.Future[None]", snapshot.stop_waiter))
+            return
+
         first_error: BaseException | None = None
+        stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
         try:
-            await self._publish_stopping_transition(snapshot)
-        except (Exception, asyncio.CancelledError) as error:
-            first_error = error
-        try:
-            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
-        except (Exception, asyncio.CancelledError) as error:
-            if first_error is None:
-                first_error = error
-        if first_error is None:
             try:
-                await self._publish_closed_event_if_needed(snapshot)
+                await self._publish_stopping_transition(snapshot)
             except (Exception, asyncio.CancelledError) as error:
                 first_error = error
-        await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
-        if snapshot.stop_dispatcher:
             try:
-                await self._event_dispatcher.stop()
+                await self._teardown_stop_resources(
+                    snapshot=snapshot, socket_cleanup=socket_cleanup
+                )
             except (Exception, asyncio.CancelledError) as error:
                 if first_error is None:
                     first_error = error
-        if first_error is not None:
-            raise first_error
+            if first_error is None:
+                try:
+                    await self._publish_closed_event_if_needed(snapshot)
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+            await self._publish_stopped_transition_if_needed(
+                snapshot, emit_event=first_error is None
+            )
+            if snapshot.stop_dispatcher:
+                try:
+                    await self._event_dispatcher.stop()
+                except (Exception, asyncio.CancelledError) as error:
+                    if first_error is None:
+                        first_error = error
+            if first_error is not None:
+                raise first_error
+        except (Exception, asyncio.CancelledError) as error:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_exception(error)
+                # Mark the exception as retrieved so failed owner stops do not
+                # leave an unhandled-Future warning behind.
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    stop_waiter.exception()
+            raise
+        else:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_result(None)
+        finally:
+            if stop_waiter is not None:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
 
     async def _plan_stop_snapshot(self) -> _DatagramStopSnapshot:
         """Detach stop-time resources under lock and return the resulting stop snapshot."""
@@ -293,9 +336,24 @@ class _AsyncioDatagramReceiverBase:
         async with self._state_lock:
             snapshot.previous_connection_state = self._connection_state
             pre_transition_lifecycle_state = self._lifecycle_state
+            current_task = asyncio.current_task()
+            if self._runtime.stop_waiter is not None:
+                if current_task is self._runtime.stop_owner_task:
+                    # Inline handlers may re-enter stop() from the owner task
+                    # while STOPPING is being published. Waiting on the owner
+                    # waiter here would self-deadlock.
+                    return snapshot
+                snapshot.stop_waiter = self._runtime.stop_waiter
+                return snapshot
             if self._is_fully_stopped_locked():
                 snapshot.stop_dispatcher = True
                 return snapshot
+
+            loop = current_task.get_loop() if current_task is not None else asyncio.get_event_loop()
+            snapshot.stop_waiter = loop.create_future()
+            snapshot.owns_stop = True
+            self._runtime.stop_waiter = snapshot.stop_waiter
+            self._runtime.stop_owner_task = current_task
 
             if self._lifecycle_state != ComponentLifecycleState.STOPPED:
                 snapshot.stopping_event = self._apply_lifecycle_state(

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -32,8 +32,11 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
     LifecycleTransitionPublisher,
     emit_lifecycle_event,
 )
-from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
-from aionetx.implementations.asyncio_impl.runtime_utils import assert_running_on_owner_loop
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    WarningRateLimiter,
+    assert_running_on_owner_loop,
+    await_task_completion_preserving_cancellation,
+)
 
 SocketCleanup = Callable[[socket.socket], None]
 _recv_fallback_warning_limiter = WarningRateLimiter(interval_seconds=300.0)
@@ -410,12 +413,11 @@ class _AsyncioDatagramReceiverBase:
             if snapshot.task is not asyncio.current_task():
                 snapshot.task.cancel()
                 try:
-                    _ = await cast("asyncio.Task[object]", snapshot.task)
+                    await await_task_completion_preserving_cancellation(
+                        cast("asyncio.Task[object]", snapshot.task)
+                    )
                 except asyncio.CancelledError as error:
-                    current_task = asyncio.current_task()
-                    cancelling = getattr(current_task, "cancelling", None)
-                    if current_task is not None and callable(cancelling) and cancelling():
-                        task_error = error
+                    task_error = error
 
         if snapshot.sock is not None:
             if socket_cleanup is not None:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_heartbeat_sender.py
@@ -9,9 +9,7 @@ reports failures through the shared event dispatcher.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-from collections.abc import Awaitable
 from typing import cast
 
 from aionetx.api.connection_protocol import ConnectionProtocol
@@ -19,7 +17,10 @@ from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
 from aionetx.api.heartbeat import HeartbeatRequest, HeartbeatResult, TcpHeartbeatSettings
 from aionetx.api.network_error_event import NetworkErrorEvent
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
-from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    WarningRateLimiter,
+    await_task_completion_preserving_cancellation,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -108,8 +109,7 @@ class AsyncioHeartbeatSender:
         if task is not None:
             self._logger.debug("Stopping heartbeat sender for %s.", self._connection.connection_id)
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                _ = await cast(Awaitable[object], task)
+            await await_task_completion_preserving_cancellation(cast(asyncio.Task[object], task))
 
     async def _run(self) -> None:
         """

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -48,6 +48,7 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     ReconnectBackoff,
     assert_running_on_owner_loop,
+    await_task_completion_preserving_cancellation,
     validate_heartbeat_provider,
 )
 from aionetx.implementations.asyncio_impl.tcp_client_supervision import (
@@ -230,12 +231,21 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                 first_error = error
             try:
                 if supervisor_task is not None and not skip_await_supervisor:
-                    with contextlib.suppress(asyncio.CancelledError):
+                    try:
                         if not await_supervisor_completion_only:
                             supervisor_task.cancel()
-                        _ = await cast(Awaitable[object], supervisor_task)
-                    if self._supervisor_task is supervisor_task:
-                        self._supervisor_task = None
+                        await await_task_completion_preserving_cancellation(
+                            cast(asyncio.Task[object], supervisor_task)
+                        )
+                    finally:
+                        if self._supervisor_task is supervisor_task:
+                            self._supervisor_task = None
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+            try:
+                # A cancelled supervisor wait must not skip local resource cleanup.
+                # Preserve the first error, finish teardown, then re-raise below.
                 await self._stop_heartbeat_sender()
                 await self._close_current_connection()
                 if (

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -88,6 +88,8 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         self._runtime = _ClientRuntimeState()
         self._supervisor_task: asyncio.Task[None] | None = None
         self._state_lock = asyncio.Lock()
+        self._stop_waiter: asyncio.Future[None] | None = None
+        self._stop_owner_task: asyncio.Task[object] | None = None
         self._lifecycle_state = ComponentLifecycleState.STOPPED
         self._backoff = ReconnectBackoff(settings.reconnect)
         self._status_changed = asyncio.Event()
@@ -196,19 +198,53 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         should_stop_dispatcher = False
         await_supervisor_completion_only = False
         skip_await_supervisor = False
+        stop_waiter: asyncio.Future[None] | None = None
+        owns_stop = False
         current_task = asyncio.current_task()
         async with self._state_lock:
-            if self._lifecycle_state in (
-                ComponentLifecycleState.STOPPING,
-                ComponentLifecycleState.STOPPED,
+            if self._stop_waiter is not None:
+                if current_task is self._stop_owner_task:
+                    # Inline STOPPING handlers can re-enter stop() from the
+                    # owner task; waiting on the owner waiter would deadlock.
+                    return
+                stop_waiter = self._stop_waiter
+            elif (
+                self._lifecycle_state == ComponentLifecycleState.STOPPED
+                and self._supervisor_task is None
+                and self._heartbeat_sender is None
+                and self._connection is None
+                and not self._event_dispatcher.is_running
             ):
+                return
+            else:
+                # Publish the shared waiter before slow teardown so overlapping
+                # stop callers join this stop path instead of planning another.
+                loop = (
+                    current_task.get_loop()
+                    if current_task is not None
+                    else asyncio.get_event_loop()
+                )
+                stop_waiter = loop.create_future()
+                self._stop_waiter = stop_waiter
+                self._stop_owner_task = current_task
+                owns_stop = True
+            if owns_stop and self._lifecycle_state == ComponentLifecycleState.STOPPING:
                 supervisor_task = self._supervisor_task
                 if supervisor_task is not None and supervisor_task.done():
                     self._supervisor_task = None
                     supervisor_task = None
                 else:
                     await_supervisor_completion_only = supervisor_task is not None
-            else:
+                should_stop_dispatcher = self._event_dispatcher.is_running
+            elif owns_stop and self._lifecycle_state == ComponentLifecycleState.STOPPED:
+                supervisor_task = self._supervisor_task
+                if supervisor_task is not None and supervisor_task.done():
+                    self._supervisor_task = None
+                    supervisor_task = None
+                else:
+                    await_supervisor_completion_only = supervisor_task is not None
+                should_stop_dispatcher = self._event_dispatcher.is_running
+            elif owns_stop:
                 stopping_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPING)
                 supervisor_task = self._supervisor_task
                 self._supervisor_task = None
@@ -218,60 +254,82 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     and self._event_dispatcher.current_task_is_worker()
                     and supervisor_task is not None
                 )
+        if not owns_stop:
+            if stop_waiter is not None and not self._event_dispatcher.current_task_is_worker():
+                await asyncio.shield(stop_waiter)
+            return
         inline_delivery_context = (
             self._event_dispatcher.inline_delivery_context()
             if self._event_dispatcher.current_task_is_worker()
             else contextlib.nullcontext()
         )
-        with inline_delivery_context:
-            first_error: BaseException | None = None
-            try:
-                await self._emit_lifecycle_event(stopping_event)
-            except (Exception, asyncio.CancelledError) as error:
-                first_error = error
-            try:
-                if supervisor_task is not None and not skip_await_supervisor:
-                    try:
-                        if not await_supervisor_completion_only:
-                            supervisor_task.cancel()
-                        await await_task_completion_preserving_cancellation(
-                            cast(asyncio.Task[object], supervisor_task)
-                        )
-                    finally:
-                        if self._supervisor_task is supervisor_task:
-                            self._supervisor_task = None
-            except (Exception, asyncio.CancelledError) as error:
-                if first_error is None:
-                    first_error = error
-            try:
-                # A cancelled supervisor wait must not skip local resource cleanup.
-                # Preserve the first error, finish teardown, then re-raise below.
-                await self._stop_heartbeat_sender()
-                await self._close_current_connection()
-                if (
-                    supervisor_task is not None
-                    and skip_await_supervisor
-                    and not await_supervisor_completion_only
-                ):
-                    supervisor_task.cancel()
-            except (Exception, asyncio.CancelledError) as error:
-                if first_error is None:
-                    first_error = error
-            if should_stop_dispatcher:
-                async with self._state_lock:
-                    stopped_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
-                if first_error is None:
-                    try:
-                        await self._emit_lifecycle_event(stopped_event)
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
+        try:
+            with inline_delivery_context:
+                first_error: BaseException | None = None
                 try:
-                    await self._event_dispatcher.stop()
+                    await self._emit_lifecycle_event(stopping_event)
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+                try:
+                    if supervisor_task is not None and not skip_await_supervisor:
+                        try:
+                            if not await_supervisor_completion_only:
+                                supervisor_task.cancel()
+                            await await_task_completion_preserving_cancellation(
+                                cast(asyncio.Task[object], supervisor_task)
+                            )
+                        finally:
+                            if self._supervisor_task is supervisor_task:
+                                self._supervisor_task = None
                 except (Exception, asyncio.CancelledError) as error:
                     if first_error is None:
                         first_error = error
-            if first_error is not None:
-                raise first_error
+                try:
+                    # A cancelled supervisor wait must not skip local resource cleanup.
+                    # Preserve the first error, finish teardown, then re-raise below.
+                    await self._stop_heartbeat_sender()
+                    await self._close_current_connection()
+                    if (
+                        supervisor_task is not None
+                        and skip_await_supervisor
+                        and not await_supervisor_completion_only
+                    ):
+                        supervisor_task.cancel()
+                except (Exception, asyncio.CancelledError) as error:
+                    if first_error is None:
+                        first_error = error
+                if should_stop_dispatcher:
+                    async with self._state_lock:
+                        if self._lifecycle_state == ComponentLifecycleState.STOPPING:
+                            stopped_event = self._apply_lifecycle_state(
+                                ComponentLifecycleState.STOPPED
+                            )
+                    if first_error is None:
+                        try:
+                            await self._emit_lifecycle_event(stopped_event)
+                        except (Exception, asyncio.CancelledError) as error:
+                            first_error = error
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
+        except (Exception, asyncio.CancelledError) as error:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    stop_waiter.exception()
+            raise
+        else:
+            if stop_waiter is not None and not stop_waiter.done():
+                stop_waiter.set_result(None)
+        finally:
+            async with self._state_lock:
+                if self._stop_waiter is stop_waiter:
+                    self._stop_waiter = None
+                    self._stop_owner_task = None
         self._logger.debug("TCP client stopped.")
 
     async def __aenter__(self) -> AsyncioTcpClient:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -236,7 +236,7 @@ class AsyncioTcpServer(TcpServerProtocol):
             if stop_waiter is not None:
                 if self._event_dispatcher.current_task_is_worker():
                     return
-                _ = await cast(Awaitable[object], stop_waiter)
+                await asyncio.shield(stop_waiter)
             return
         inline_delivery_context = (
             self._event_dispatcher.inline_delivery_context()

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -163,7 +163,9 @@ class AsyncioTcpServer(TcpServerProtocol):
                 self._handle_client,
                 sock=listening_socket,
             )
-        except Exception:
+        except (Exception, asyncio.CancelledError):
+            # CancelledError is not an Exception on supported Python versions,
+            # but startup cancellation still owns rollback before propagating.
             lifecycle_event = None
             if listening_socket is not None:
                 with contextlib.suppress(Exception):
@@ -171,9 +173,11 @@ class AsyncioTcpServer(TcpServerProtocol):
             async with self._state_lock:
                 self._server = None
                 lifecycle_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
-            await self._emit_lifecycle_event(lifecycle_event)
-            await self._event_dispatcher.stop()
-            self._notify_status_changed()
+            try:
+                await self._emit_lifecycle_event(lifecycle_event)
+            finally:
+                await self._stop_dispatcher_during_startup_rollback()
+                self._notify_status_changed()
             raise
 
         lifecycle_event = None
@@ -447,6 +451,25 @@ class AsyncioTcpServer(TcpServerProtocol):
                     await server_to_close.wait_closed()
         with contextlib.suppress(Exception, asyncio.CancelledError):
             await self._event_dispatcher.stop()
+
+    async def _stop_dispatcher_during_startup_rollback(self) -> None:
+        """
+        Stop dispatcher cleanup before propagating startup cancellation.
+
+        The startup task owns dispatcher cleanup once it has published STARTING.
+        If the caller cancels again while rollback is already stopping the
+        dispatcher, cleanup must still converge before cancellation is re-raised.
+        """
+        stop_task = asyncio.create_task(
+            self._event_dispatcher.stop(),
+            name=f"{self._component_id}-startup-rollback-dispatcher-stop",
+        )
+        try:
+            await asyncio.shield(stop_task)
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.shield(stop_task)
+            raise
 
     def _build_connection_id(self, peer_info: object, sequence: int) -> str:
         """Build the stable per-connection identifier used by server-side events."""

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -145,6 +145,41 @@ def assert_running_on_owner_loop(
     return current_loop
 
 
+async def await_task_completion_preserving_cancellation(task: asyncio.Task[object]) -> None:
+    """
+    Await an internal task without swallowing caller cancellation.
+
+    This helper is for shutdown paths that may cancel and await a child task.
+    ``CancelledError`` from the child task is expected during shutdown and is
+    suppressed.  Cancellation of the caller, however, is delayed only long
+    enough for the shielded child task to settle and is then re-raised.
+    """
+    caller_cancelled = False
+    while True:
+        try:
+            _ = await asyncio.shield(task)
+            break
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            cancelling = getattr(current_task, "cancelling", None)
+            if (
+                current_task is not None and callable(cancelling) and cancelling()
+            ) or not task.done():
+                caller_cancelled = True
+                # Keep awaiting the shielded child task so repeated caller
+                # cancellations cannot detach the internal cleanup task.  The
+                # ``not task.done()`` fallback preserves this contract on
+                # Python 3.10, where Task.cancelling() is unavailable.
+                if task.done():
+                    break
+                continue
+            if task.done() and task.cancelled():
+                break
+            break
+    if caller_cancelled:
+        raise asyncio.CancelledError
+
+
 def validate_async_event_handler(event_handler: NetworkEventHandlerProtocol) -> None:
     """
     Validate the runtime contract for ``NetworkEventHandlerProtocol``.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+
 from aionetx.testing import wait_for_condition
 
-__all__ = ["wait_for_condition"]
+__all__ = [
+    "assert_awaitable_cancelled",
+    "drain_awaitable_ignoring_cancelled",
+    "wait_for_condition",
+]
+
+
+async def assert_awaitable_cancelled(awaitable: Awaitable[object]) -> None:
+    """Assert that an awaitable completes by propagating caller cancellation."""
+    try:
+        result = await awaitable
+    except asyncio.CancelledError:
+        return
+    raise AssertionError(
+        f"Expected awaitable to raise asyncio.CancelledError, but it returned {result!r}."
+    )
+
+
+async def drain_awaitable_ignoring_cancelled(awaitable: Awaitable[object]) -> None:
+    """Drain cleanup awaitables where cancellation is the expected terminal state."""
+    try:
+        result = await awaitable
+    except asyncio.CancelledError:
+        return
+    if result is not None:
+        return

--- a/tests/internal_asyncio_impl_refs.py
+++ b/tests/internal_asyncio_impl_refs.py
@@ -21,6 +21,7 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     ReconnectBackoff,
     WarningRateLimiter,
+    await_task_completion_preserving_cancellation,
     validate_heartbeat_provider,
 )
 
@@ -31,6 +32,7 @@ __all__ = (
     "apply_stopped_transition_if_stopping",
     "apply_stopping_transition_if_active",
     "assert_legal_lifecycle_transition",
+    "await_task_completion_preserving_cancellation",
     "multicast_receiver_component_id",
     "tcp_client_component_id",
     "tcp_client_connection_id",

--- a/tests/unit/test_api_symbol_sources.py
+++ b/tests/unit/test_api_symbol_sources.py
@@ -49,6 +49,8 @@ def test_api_symbol_root_curated_exports_come_from_grouping_modules() -> None:
 def test_api_symbol_api_curated_exports_come_from_grouping_modules() -> None:
     grouped_sources = {
         "BaseNetworkEventHandler": "aionetx.api.events",
+        "ByteSenderProtocol": "aionetx.api.protocols",
+        "BytesLike": "aionetx.api.protocols",
         "BytesReceivedEvent": "aionetx.api.events",
         "ComponentLifecycleChangedEvent": "aionetx.api.events",
         "ConnectionClosedError": "aionetx.api.errors",
@@ -63,6 +65,7 @@ def test_api_symbol_api_curated_exports_come_from_grouping_modules() -> None:
         "HandlerFailurePolicyStopEvent": "aionetx.api.events",
         "HeartbeatProviderProtocol": "aionetx.api.protocols",
         "HeartbeatResult": "aionetx.api.heartbeat",
+        "ManagedTransportProtocol": "aionetx.api.protocols",
         "NetworkConfigurationError": "aionetx.api.errors",
         "MulticastReceiverProtocol": "aionetx.api.protocols",
         "MulticastReceiverSettings": "aionetx.api.settings",

--- a/tests/unit/test_asyncio_heartbeat_sender.py
+++ b/tests/unit/test_asyncio_heartbeat_sender.py
@@ -16,6 +16,8 @@ from aionetx.api.network_error_event import NetworkErrorEvent
 from aionetx.api._event_registry import NETWORK_EVENT_TYPES
 from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.helpers import wait_for_condition
 
 
@@ -170,8 +172,7 @@ async def test_heartbeat_sender_stop_preserves_caller_cancellation_after_task_cl
         assert not stop_task.done()
 
         release_task.set()
-        with pytest.raises(asyncio.CancelledError):
-            await stop_task
+        await assert_awaitable_cancelled(stop_task)
 
         assert sender.is_running is False
         assert sender._task is None  # type: ignore[attr-defined]
@@ -180,16 +181,10 @@ async def test_heartbeat_sender_stop_preserves_caller_cancellation_after_task_cl
         release_task.set()
         if not stop_task.done():
             stop_task.cancel()
-            try:
-                await stop_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(stop_task)
         if not heartbeat_task.done():
             heartbeat_task.cancel()
-            try:
-                await heartbeat_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(heartbeat_task)
         await dispatcher.stop()
 
 

--- a/tests/unit/test_asyncio_heartbeat_sender.py
+++ b/tests/unit/test_asyncio_heartbeat_sender.py
@@ -71,6 +71,11 @@ class InvalidPayloadHeartbeatProvider:
         return HeartbeatResult(should_send=True, payload="bad-payload")  # type: ignore[arg-type]
 
 
+class InvalidShouldSendHeartbeatProvider:
+    async def create_heartbeat(self, request: HeartbeatRequest) -> HeartbeatResult:
+        return HeartbeatResult(should_send="yes", payload=b"hb")  # type: ignore[arg-type]
+
+
 class FailingSendConnection(FakeConnection):
     def __init__(self) -> None:
         super().__init__()
@@ -266,6 +271,25 @@ async def test_heartbeat_sender_emits_error_for_invalid_payload_type(
         FakeConnection(),
         TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
         InvalidPayloadHeartbeatProvider(),  # type: ignore[arg-type]
+        dispatcher,
+    )
+    await sender.start()
+    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    await dispatcher.stop()
+    assert recording_event_handler.error_events
+    assert isinstance(recording_event_handler.error_events[-1].error, TypeError)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_error_for_invalid_should_send_type(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        InvalidShouldSendHeartbeatProvider(),  # type: ignore[arg-type]
         dispatcher,
     )
     await sender.start()

--- a/tests/unit/test_asyncio_heartbeat_sender.py
+++ b/tests/unit/test_asyncio_heartbeat_sender.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import asyncio
 import logging
 
 import pytest
@@ -125,6 +127,65 @@ async def test_heartbeat_sender_start_and_stop_are_idempotent(recording_event_ha
 
     assert sender.is_running is False
     assert sender._task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_stop_preserves_caller_cancellation_after_task_cleanup(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    sender = AsyncioHeartbeatSender(
+        FakeConnection(),
+        TcpHeartbeatSettings(enabled=True, interval_seconds=1.0),
+        ToggleHeartbeatProvider(),
+        dispatcher,
+    )
+    task_cancel_seen = asyncio.Event()
+    release_task = asyncio.Event()
+
+    async def blocking_heartbeat_task() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            task_cancel_seen.set()
+            await release_task.wait()
+            raise
+
+    heartbeat_task = asyncio.create_task(blocking_heartbeat_task())
+    sender._running = True  # type: ignore[attr-defined]
+    sender._task = heartbeat_task  # type: ignore[attr-defined]
+    stop_task = asyncio.create_task(sender.stop())
+
+    try:
+        await asyncio.wait_for(task_cancel_seen.wait(), timeout=1.0)
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert not stop_task.done()
+
+        release_task.set()
+        with pytest.raises(asyncio.CancelledError):
+            await stop_task
+
+        assert sender.is_running is False
+        assert sender._task is None  # type: ignore[attr-defined]
+        assert heartbeat_task.done()
+    finally:
+        release_task.set()
+        if not stop_task.done():
+            stop_task.cancel()
+            try:
+                await stop_task
+            except asyncio.CancelledError:
+                pass
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
+        await dispatcher.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -10,7 +10,6 @@ the environment refuses multicast operations.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import socket
 
 import pytest
@@ -32,6 +31,7 @@ from aionetx.implementations.asyncio_impl import asyncio_multicast_receiver as m
 from aionetx.implementations.asyncio_impl.asyncio_multicast_receiver import (
     AsyncioMulticastReceiver,
 )
+from tests.helpers import drain_awaitable_ignoring_cancelled
 
 
 class NoopHandler:
@@ -372,6 +372,5 @@ async def test_multicast_receiver_overlapping_stop_calls_publish_one_stop_sequen
         for task in (first_stop_task, second_stop_task):
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                await drain_awaitable_ignoring_cancelled(task)
         await receiver.stop()

--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -9,8 +9,9 @@ the environment refuses multicast operations.
 
 from __future__ import annotations
 
-import socket
 import asyncio
+import contextlib
+import socket
 
 import pytest
 
@@ -42,6 +43,22 @@ class FailOnOpenedHandler:
     async def on_event(self, event) -> None:
         if isinstance(event, ConnectionOpenedEvent):
             raise RuntimeError("boom-on-opened")
+
+
+class BlockingStoppingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.stopping_seen = asyncio.Event()
+        self.release_stopping = asyncio.Event()
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            self.stopping_seen.set()
+            await self.release_stopping.wait()
 
 
 @pytest.mark.asyncio
@@ -298,9 +315,8 @@ async def test_multicast_receiver_stop_from_starting_state_does_not_emit_closed_
 
 
 @pytest.mark.asyncio
-async def test_multicast_receiver_overlapping_stop_calls_publish_one_stop_sequence(
-    awaitable_recording_event_handler,
-) -> None:
+async def test_multicast_receiver_overlapping_stop_calls_publish_one_stop_sequence() -> None:
+    handler = BlockingStoppingHandler()
     receiver = AsyncioMulticastReceiver(
         settings=MulticastReceiverSettings(
             group_ip="239.255.0.4",
@@ -308,26 +324,54 @@ async def test_multicast_receiver_overlapping_stop_calls_publish_one_stop_sequen
             bind_ip="0.0.0.0",
             interface_ip="127.0.0.1",
         ),
-        event_handler=awaitable_recording_event_handler,
+        event_handler=handler,
     )
-    await receiver.start()
+    first_stop_task: asyncio.Task[None] | None = None
+    second_stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        original_task = receiver._task  # type: ignore[attr-defined]
 
-    await asyncio.gather(receiver.stop(), receiver.stop())
+        first_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.wait_for(handler.stopping_seen.wait(), timeout=1.0)
 
-    stop_relevant_events = [
-        event
-        for event in awaitable_recording_event_handler.events
-        if (
-            isinstance(event, ConnectionClosedEvent)
-            or (
+        second_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not second_stop_task.done()
+
+        handler.release_stopping.set()
+        await asyncio.wait_for(
+            asyncio.gather(first_stop_task, second_stop_task),
+            timeout=1.0,
+        )
+
+        stop_lifecycle_events = [
+            event
+            for event in handler.events
+            if (
                 isinstance(event, ComponentLifecycleChangedEvent)
                 and event.current
                 in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
             )
-        )
-    ]
-    assert [type(event).__name__ for event in stop_relevant_events] == [
-        "ComponentLifecycleChangedEvent",
-        "ConnectionClosedEvent",
-        "ComponentLifecycleChangedEvent",
-    ]
+        ]
+        closed_events = [
+            event for event in handler.events if isinstance(event, ConnectionClosedEvent)
+        ]
+        assert [event.current for event in stop_lifecycle_events] == [
+            ComponentLifecycleState.STOPPING,
+            ComponentLifecycleState.STOPPED,
+        ]
+        assert len(closed_events) == 1
+        assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert receiver._socket is None  # type: ignore[attr-defined]
+        assert receiver._task is None  # type: ignore[attr-defined]
+        assert original_task is not None and original_task.done()
+        assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        handler.release_stopping.set()
+        for task in (first_stop_task, second_stop_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        await receiver.stop()

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -37,6 +37,8 @@ from aionetx.implementations.asyncio_impl import (
 from aionetx.implementations.asyncio_impl import _tcp_client_connect as tcp_client_connect_module
 from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
 from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.internal_asyncio_impl_refs import WarningRateLimiter
 
 
@@ -340,8 +342,7 @@ async def test_client_stop_preserves_caller_cancellation_after_supervisor_cleanu
         assert not stop_task.done()
 
         release_supervisor.set()
-        with pytest.raises(asyncio.CancelledError):
-            await stop_task
+        await assert_awaitable_cancelled(stop_task)
 
         assert call_order == ["heartbeat-stop", "connection-close"]
         assert client.lifecycle_state == ComponentLifecycleState.STOPPED
@@ -351,16 +352,10 @@ async def test_client_stop_preserves_caller_cancellation_after_supervisor_cleanu
         release_supervisor.set()
         if not stop_task.done():
             stop_task.cancel()
-            try:
-                await stop_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(stop_task)
         if not supervisor_task.done():
             supervisor_task.cancel()
-            try:
-                await supervisor_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(supervisor_task)
         if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
             await client._event_dispatcher.stop()  # type: ignore[attr-defined]
 
@@ -423,10 +418,7 @@ async def test_client_concurrent_stop_waits_for_owner_without_duplicate_cleanup(
         for task in (owner_stop_task, locals().get("waiter_stop_task")):
             if isinstance(task, asyncio.Task) and not task.done():
                 task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+                await drain_awaitable_ignoring_cancelled(task)
         if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
             await client._event_dispatcher.stop()  # type: ignore[attr-defined]
 

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -366,6 +366,117 @@ async def test_client_stop_preserves_caller_cancellation_after_supervisor_cleanu
 
 
 @pytest.mark.asyncio
+async def test_client_concurrent_stop_waits_for_owner_without_duplicate_cleanup(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45682, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    stopping_seen = asyncio.Event()
+    release_stopping = asyncio.Event()
+    call_order: list[str] = []
+    lifecycle_emits: list[str] = []
+
+    async def fake_emit_lifecycle_event(event) -> None:
+        if event is None:
+            return
+        lifecycle_emits.append(event.current.value)
+        if event.current == ComponentLifecycleState.STOPPING:
+            stopping_seen.set()
+            await release_stopping.wait()
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._emit_lifecycle_event = fake_emit_lifecycle_event  # type: ignore[attr-defined,method-assign]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+
+    owner_stop_task = asyncio.create_task(client.stop())
+    try:
+        await asyncio.wait_for(stopping_seen.wait(), timeout=1.0)
+
+        waiter_stop_task = asyncio.create_task(client.stop())
+        await asyncio.sleep(0)
+
+        assert not waiter_stop_task.done()
+        assert call_order == []
+
+        release_stopping.set()
+        await asyncio.wait_for(asyncio.gather(owner_stop_task, waiter_stop_task), timeout=1.0)
+
+        assert call_order == ["heartbeat-stop", "connection-close"]
+        assert lifecycle_emits == ["stopping", "stopped"]
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        release_stopping.set()
+        for task in (owner_stop_task, locals().get("waiter_stop_task")):
+            if isinstance(task, asyncio.Task) and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
+            await client._event_dispatcher.stop()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_client_stop_reentry_from_owner_task_is_noop(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45683, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    call_order: list[str] = []
+    lifecycle_emits: list[str] = []
+
+    async def fake_emit_lifecycle_event(event) -> None:
+        if event is None:
+            return
+        lifecycle_emits.append(event.current.value)
+        if event.current == ComponentLifecycleState.STOPPING:
+            await client.stop()
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._emit_lifecycle_event = fake_emit_lifecycle_event  # type: ignore[attr-defined,method-assign]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+
+    try:
+        await client.stop()
+
+        assert call_order == ["heartbeat-stop", "connection-close"]
+        assert lifecycle_emits == ["stopping", "stopped"]
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
+            await client._event_dispatcher.stop()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_client_connect_attempt_clears_cached_last_connect_error_before_new_attempt(
     recording_event_handler,
 ) -> None:

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -296,6 +296,76 @@ async def test_client_supervisor_shutdown_resources_stops_heartbeat_before_conne
 
 
 @pytest.mark.asyncio
+async def test_client_stop_preserves_caller_cancellation_after_supervisor_cleanup(
+    recording_event_handler,
+) -> None:
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1", port=45681, reconnect=TcpReconnectSettings(enabled=False)
+        ),
+        event_handler=recording_event_handler,
+    )
+    supervisor_cancel_seen = asyncio.Event()
+    release_supervisor = asyncio.Event()
+    call_order: list[str] = []
+
+    async def blocking_supervisor() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            supervisor_cancel_seen.set()
+            await release_supervisor.wait()
+            raise
+
+    async def fake_stop_heartbeat() -> None:
+        call_order.append("heartbeat-stop")
+
+    async def fake_close_connection() -> None:
+        call_order.append("connection-close")
+
+    supervisor_task = asyncio.create_task(blocking_supervisor())
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._supervisor_task = supervisor_task  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    client._close_current_connection = fake_close_connection  # type: ignore[attr-defined,method-assign]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+    stop_task = asyncio.create_task(client.stop())
+
+    try:
+        await asyncio.wait_for(supervisor_cancel_seen.wait(), timeout=1.0)
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert not stop_task.done()
+
+        release_supervisor.set()
+        with pytest.raises(asyncio.CancelledError):
+            await stop_task
+
+        assert call_order == ["heartbeat-stop", "connection-close"]
+        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert client._supervisor_task is None  # type: ignore[attr-defined]
+        assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        release_supervisor.set()
+        if not stop_task.done():
+            stop_task.cancel()
+            try:
+                await stop_task
+            except asyncio.CancelledError:
+                pass
+        if not supervisor_task.done():
+            supervisor_task.cancel()
+            try:
+                await supervisor_task
+            except asyncio.CancelledError:
+                pass
+        if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
+            await client._event_dispatcher.stop()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_client_connect_attempt_clears_cached_last_connect_error_before_new_attempt(
     recording_event_handler,
 ) -> None:

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -38,6 +38,8 @@ from aionetx.implementations.asyncio_impl._tcp_server_helpers import handle_acce
 from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
 from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.helpers import wait_for_condition
 
 
@@ -415,8 +417,7 @@ async def test_server_cancelled_overlapping_stop_does_not_cancel_owner_waiter(
         second_stop = asyncio.create_task(server.stop())
         await asyncio.sleep(0)
         second_stop.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await second_stop
+        await assert_awaitable_cancelled(second_stop)
 
         assert stop_waiter.cancelled() is False
 
@@ -431,8 +432,7 @@ async def test_server_cancelled_overlapping_stop_does_not_cancel_owner_waiter(
         blocking.release_close.set()
         if not first_stop.done():
             first_stop.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await first_stop
+            await drain_awaitable_ignoring_cancelled(first_stop)
 
     assert blocking.close_attempts == 1
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
@@ -517,8 +517,7 @@ async def test_server_start_cancellation_rolls_back_state_and_closes_listener(
     await asyncio.wait_for(start_server_entered.wait(), timeout=1.0)
     start_task.cancel()
 
-    with pytest.raises(asyncio.CancelledError):
-        await start_task
+    await assert_awaitable_cancelled(start_task)
 
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
     assert server._server is None  # type: ignore[attr-defined]
@@ -581,8 +580,7 @@ async def test_server_start_cancellation_finishes_dispatcher_stop_when_cancelled
 
     release_dispatcher_stop.set()
 
-    with pytest.raises(asyncio.CancelledError):
-        await start_task
+    await assert_awaitable_cancelled(start_task)
 
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
     assert server._server is None  # type: ignore[attr-defined]

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -395,6 +395,50 @@ async def test_server_concurrent_stop_waits_for_active_teardown(
 
 
 @pytest.mark.asyncio
+async def test_server_cancelled_overlapping_stop_does_not_cancel_owner_waiter(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=12349, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    blocking = _BlockingCloseConnection("server:blocking-close:2")
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    server._connections = {blocking.connection_id: blocking}  # type: ignore[attr-defined,dict-item]
+
+    first_stop = asyncio.create_task(server.stop())
+    try:
+        await asyncio.wait_for(blocking.close_started.wait(), timeout=1.0)
+        stop_waiter = server._stop_waiter  # type: ignore[attr-defined]
+        assert stop_waiter is not None
+
+        second_stop = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+        second_stop.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second_stop
+
+        assert stop_waiter.cancelled() is False
+
+        third_stop = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+        assert third_stop.done() is False
+
+        blocking.release_close.set()
+        await first_stop
+        await third_stop
+    finally:
+        blocking.release_close.set()
+        if not first_stop.done():
+            first_stop.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await first_stop
+
+    assert blocking.close_attempts == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
 async def test_server_lifecycle_events_preserve_start_stop_order(recording_event_handler) -> None:
     port = _unused_tcp_port()
     server = AsyncioTcpServer(

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -426,8 +426,7 @@ async def test_server_cancelled_overlapping_stop_does_not_cancel_owner_waiter(
         assert third_stop.done() is False
 
         blocking.release_close.set()
-        await first_stop
-        await third_stop
+        assert await asyncio.gather(first_stop, third_stop) == [None, None]
     finally:
         blocking.release_close.set()
         if not first_stop.done():

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -448,6 +448,104 @@ async def test_server_start_rolls_back_state_and_allows_retry(
     await server.stop()
 
 
+@pytest.mark.asyncio
+async def test_server_start_cancellation_rolls_back_state_and_closes_listener(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=recording_event_handler,
+    )
+    start_server_entered = asyncio.Event()
+    release_start_server = asyncio.Event()
+
+    async def cancelled_start_server(*args, **kwargs):
+        del args, kwargs
+        start_server_entered.set()
+        await release_start_server.wait()
+        raise AssertionError("start_server should not resume after task cancellation")
+
+    monkeypatch.setattr(asyncio, "start_server", cancelled_start_server)
+
+    start_task = asyncio.create_task(server.start())
+    await asyncio.wait_for(start_server_entered.wait(), timeout=1.0)
+    start_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._server is None  # type: ignore[attr-defined]
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", port))
+
+    component_events = [
+        event
+        for event in recording_event_handler.lifecycle_events
+        if event.resource_id == f"tcp/server/127.0.0.1/{port}"
+    ]
+    assert [event.current for event in component_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_server_start_cancellation_finishes_dispatcher_stop_when_cancelled_again(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=_unused_tcp_port(),
+            max_connections=64,
+        ),
+        event_handler=recording_event_handler,
+    )
+    start_server_entered = asyncio.Event()
+    dispatcher_stop_entered = asyncio.Event()
+    release_dispatcher_stop = asyncio.Event()
+    dispatcher_stop_completed = asyncio.Event()
+    original_dispatcher_stop = server._event_dispatcher.stop  # type: ignore[attr-defined]
+
+    async def cancelled_start_server(*args, **kwargs):
+        del args, kwargs
+        start_server_entered.set()
+        await asyncio.Event().wait()
+
+    async def delayed_dispatcher_stop() -> None:
+        dispatcher_stop_entered.set()
+        await release_dispatcher_stop.wait()
+        await original_dispatcher_stop()
+        dispatcher_stop_completed.set()
+
+    monkeypatch.setattr(asyncio, "start_server", cancelled_start_server)
+    server._event_dispatcher.stop = delayed_dispatcher_stop  # type: ignore[method-assign,attr-defined]
+
+    start_task = asyncio.create_task(server.start())
+    await asyncio.wait_for(start_server_entered.wait(), timeout=1.0)
+    start_task.cancel()
+    await asyncio.wait_for(dispatcher_stop_entered.wait(), timeout=1.0)
+    start_task.cancel()
+    await asyncio.sleep(0)
+
+    assert not start_task.done()
+
+    release_dispatcher_stop.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._server is None  # type: ignore[attr-defined]
+    assert dispatcher_stop_completed.is_set()
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
 # Wait helpers and bootstrap state reporting.
 @pytest.mark.asyncio
 async def test_server_wait_until_running_succeeds(recording_event_handler) -> None:

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -37,6 +37,8 @@ from aionetx.implementations.asyncio_impl import (
 from aionetx.implementations.asyncio_impl import asyncio_udp_sender as udp_sender_module
 from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
+from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import drain_awaitable_ignoring_cancelled
 
 
 class NoopHandler:
@@ -278,8 +280,7 @@ async def test_udp_receiver_stop_cancellation_still_detaches_receive_task_and_so
 
     # Supported Python releases differ in whether this caller cancellation
     # remains visible after inline handler-failure handling. Cleanup is stable.
-    with contextlib.suppress(asyncio.CancelledError):
-        _ = await stop_task
+    await drain_awaitable_ignoring_cancelled(stop_task)
 
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
@@ -332,14 +333,12 @@ async def test_udp_receiver_stop_cancellation_waits_for_receive_task_cleanup(
         assert stop_task.done() is False
 
         release_task.set()
-        with pytest.raises(asyncio.CancelledError):
-            await stop_task
+        await assert_awaitable_cancelled(stop_task)
     finally:
         release_task.set()
         if not stop_task.done():
             stop_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await stop_task
+            await drain_awaitable_ignoring_cancelled(stop_task)
 
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
@@ -777,8 +776,7 @@ async def test_udp_receiver_overlapping_stop_calls_publish_one_stop_sequence() -
         for task in (first_stop_task, second_stop_task):
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                await drain_awaitable_ignoring_cancelled(task)
         await receiver.stop()
 
 
@@ -801,8 +799,7 @@ async def test_udp_receiver_cancelled_waiting_stop_does_not_cancel_owner_waiter(
         second_stop_task = asyncio.create_task(receiver.stop())
         await asyncio.sleep(0)
         second_stop_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await second_stop_task
+        await assert_awaitable_cancelled(second_stop_task)
 
         third_stop_task = asyncio.create_task(receiver.stop())
         await asyncio.sleep(0)
@@ -838,8 +835,7 @@ async def test_udp_receiver_cancelled_waiting_stop_does_not_cancel_owner_waiter(
         for task in (first_stop_task, second_stop_task, third_stop_task):
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                await drain_awaitable_ignoring_cancelled(task)
         await receiver.stop()
 
 

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -289,6 +289,66 @@ async def test_udp_receiver_stop_cancellation_still_detaches_receive_task_and_so
 
 
 @pytest.mark.asyncio
+async def test_udp_receiver_stop_cancellation_waits_for_receive_task_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_cancel_seen = asyncio.Event()
+    release_task = asyncio.Event()
+
+    async def blocking_receive_datagrams(self, receive_buffer_size: int) -> None:
+        del self, receive_buffer_size
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            task_cancel_seen.set()
+            await release_task.wait()
+            raise
+
+    monkeypatch.setattr(
+        datagram_base_module._AsyncioDatagramReceiverBase,
+        "_receive_datagrams",
+        blocking_receive_datagrams,
+    )
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=NoopHandler(),
+    )
+
+    await receiver.start()
+    original_task = receiver._task  # type: ignore[attr-defined]
+    assert original_task is not None
+
+    stop_task = asyncio.create_task(receiver.stop())
+    try:
+        await asyncio.wait_for(task_cancel_seen.wait(), timeout=1.0)
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+
+        release_task.set()
+        with pytest.raises(asyncio.CancelledError):
+            await stop_task
+    finally:
+        release_task.set()
+        if not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_task
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert original_task.done()
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_udp_receiver_inline_handler_can_stop_from_bytes_received_without_self_await() -> (
     None
 ):

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -59,6 +59,39 @@ class FailOnLifecycleStateHandler:
             raise RuntimeError(f"udp-{self._state.value}-publication-failed")
 
 
+class BlockingStoppingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.stopping_seen = asyncio.Event()
+        self.release_stopping = asyncio.Event()
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            self.stopping_seen.set()
+            await self.release_stopping.wait()
+
+
+class StopAgainOnStoppingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.receiver: AsyncioUdpReceiver | None = None
+        self.reentered_stop = asyncio.Event()
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            self.receiver is not None
+            and isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            await self.receiver.stop()
+            self.reentered_stop.set()
+
+
 def _get_unused_udp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -632,27 +665,157 @@ async def test_udp_receiver_stop_emits_stopping_closed_stopped_in_order(
 
 
 @pytest.mark.asyncio
-async def test_udp_receiver_overlapping_stop_calls_publish_one_stop_sequence(
-    awaitable_recording_event_handler,
-) -> None:
+async def test_udp_receiver_overlapping_stop_calls_publish_one_stop_sequence() -> None:
+    handler = BlockingStoppingHandler()
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
-        event_handler=awaitable_recording_event_handler,
+        event_handler=handler,
     )
-    await receiver.start()
+    first_stop_task: asyncio.Task[None] | None = None
+    second_stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        original_task = receiver._task  # type: ignore[attr-defined]
 
-    await asyncio.gather(receiver.stop(), receiver.stop())
+        first_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.wait_for(handler.stopping_seen.wait(), timeout=1.0)
+
+        second_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not second_stop_task.done()
+
+        handler.release_stopping.set()
+        await asyncio.wait_for(
+            asyncio.gather(first_stop_task, second_stop_task),
+            timeout=1.0,
+        )
+
+        stop_lifecycle_events = [
+            event
+            for event in handler.events
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            )
+        ]
+        closed_events = [
+            event for event in handler.events if isinstance(event, ConnectionClosedEvent)
+        ]
+        assert [event.current for event in stop_lifecycle_events] == [
+            ComponentLifecycleState.STOPPING,
+            ComponentLifecycleState.STOPPED,
+        ]
+        assert len(closed_events) == 1
+        assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert receiver._socket is None  # type: ignore[attr-defined]
+        assert receiver._task is None  # type: ignore[attr-defined]
+        assert original_task is not None and original_task.done()
+        assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        handler.release_stopping.set()
+        for task in (first_stop_task, second_stop_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        await receiver.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_cancelled_waiting_stop_does_not_cancel_owner_waiter() -> None:
+    handler = BlockingStoppingHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=handler,
+    )
+    first_stop_task: asyncio.Task[None] | None = None
+    second_stop_task: asyncio.Task[None] | None = None
+    third_stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+
+        first_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.wait_for(handler.stopping_seen.wait(), timeout=1.0)
+
+        second_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        second_stop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second_stop_task
+
+        third_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not third_stop_task.done()
+
+        handler.release_stopping.set()
+        await asyncio.wait_for(
+            asyncio.gather(first_stop_task, third_stop_task),
+            timeout=1.0,
+        )
+
+        stop_lifecycle_events = [
+            event
+            for event in handler.events
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            )
+        ]
+        closed_events = [
+            event for event in handler.events if isinstance(event, ConnectionClosedEvent)
+        ]
+        assert [event.current for event in stop_lifecycle_events] == [
+            ComponentLifecycleState.STOPPING,
+            ComponentLifecycleState.STOPPED,
+        ]
+        assert len(closed_events) == 1
+        assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+        assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        handler.release_stopping.set()
+        for task in (first_stop_task, second_stop_task, third_stop_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        await receiver.stop()
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_inline_stop_reentry_does_not_self_await() -> None:
+    handler = StopAgainOnStoppingHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+
+    await receiver.start()
+    await asyncio.wait_for(receiver.stop(), timeout=1.0)
 
     stop_lifecycle_events = [
         event
-        for event in awaitable_recording_event_handler.lifecycle_events
-        if event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        for event in handler.events
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
     ]
+    closed_events = [event for event in handler.events if isinstance(event, ConnectionClosedEvent)]
+    assert handler.reentered_stop.is_set()
     assert [event.current for event in stop_lifecycle_events] == [
         ComponentLifecycleState.STOPPING,
         ComponentLifecycleState.STOPPED,
     ]
-    assert len(awaitable_recording_event_handler.closed_events) == 1
+    assert len(closed_events) == 1
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_heartbeat_validation.py
+++ b/tests/unit/test_heartbeat_validation.py
@@ -29,9 +29,10 @@ def test_heartbeat_result_requires_bytes_like_payload(payload: object) -> None:
         HeartbeatResult(should_send=True, payload=payload)  # type: ignore[arg-type]
 
 
-def test_heartbeat_result_requires_bytes_like_payload_even_when_not_sending() -> None:
-    with pytest.raises(TypeError, match="HeartbeatResult.payload"):
-        HeartbeatResult(should_send=False, payload=None)  # type: ignore[arg-type]
+def test_heartbeat_result_ignores_payload_type_when_not_sending() -> None:
+    result = HeartbeatResult(should_send=False, payload=None)  # type: ignore[arg-type]
+
+    assert result.payload is None
 
 
 def test_heartbeat_validation_requires_provider_when_enabled() -> None:

--- a/tests/unit/test_heartbeat_validation.py
+++ b/tests/unit/test_heartbeat_validation.py
@@ -3,8 +3,35 @@ from __future__ import annotations
 import pytest
 
 from aionetx.api.errors import HeartbeatConfigurationError
+from aionetx.api.heartbeat import HeartbeatResult
 from aionetx.api.heartbeat import TcpHeartbeatSettings
 from tests.internal_asyncio_impl_refs import validate_heartbeat_provider
+
+
+@pytest.mark.parametrize("payload", [b"hb", bytearray(b"hb"), memoryview(b"hb")])
+def test_heartbeat_result_accepts_bytes_like_payload(
+    payload: bytes | bytearray | memoryview,
+) -> None:
+    result = HeartbeatResult(should_send=True, payload=payload)
+
+    assert result.payload is payload
+
+
+@pytest.mark.parametrize("should_send", [1, "yes", None])
+def test_heartbeat_result_requires_exact_bool_should_send(should_send: object) -> None:
+    with pytest.raises(TypeError, match="HeartbeatResult.should_send"):
+        HeartbeatResult(should_send=should_send, payload=b"hb")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("payload", ["hb", object(), None])
+def test_heartbeat_result_requires_bytes_like_payload(payload: object) -> None:
+    with pytest.raises(TypeError, match="HeartbeatResult.payload"):
+        HeartbeatResult(should_send=True, payload=payload)  # type: ignore[arg-type]
+
+
+def test_heartbeat_result_requires_bytes_like_payload_even_when_not_sending() -> None:
+    with pytest.raises(TypeError, match="HeartbeatResult.payload"):
+        HeartbeatResult(should_send=False, payload=None)  # type: ignore[arg-type]
 
 
 def test_heartbeat_validation_requires_provider_when_enabled() -> None:

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -19,6 +19,9 @@ from aionetx import (
     TcpServerSettings,
 )
 from aionetx.api import (
+    ByteSenderProtocol,
+    BytesLike,
+    ManagedTransportProtocol,
     MulticastReceiverProtocol,
     NetworkConfigurationError,
     NetworkLayerError,
@@ -49,6 +52,14 @@ def test_aionetx_api_exports_transport_protocols_for_advanced_usage() -> None:
     assert api.UdpReceiverProtocol is UdpReceiverProtocol
     assert api.UdpSenderProtocol is UdpSenderProtocol
     assert api.MulticastReceiverProtocol is MulticastReceiverProtocol
+
+
+def test_aionetx_api_exports_bytes_capability_types() -> None:
+    import aionetx.api as api
+
+    assert api.BytesLike is BytesLike
+    assert api.ByteSenderProtocol is ByteSenderProtocol
+    assert api.ManagedTransportProtocol is ManagedTransportProtocol
 
 
 def test_aionetx_api_exports_udp_send_exceptions() -> None:

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -8,6 +8,9 @@ module layout, implementation namespaces, or complete export lists.
 
 from __future__ import annotations
 
+import importlib
+from types import ModuleType
+
 import aionetx
 import pytest
 
@@ -36,6 +39,10 @@ from aionetx.api import (
 )
 
 
+def _api_module() -> ModuleType:
+    return importlib.import_module("aionetx.api")
+
+
 def test_package_root_exports_recommended_entry_points() -> None:
     assert aionetx.AsyncioNetworkFactory is AsyncioNetworkFactory
     assert aionetx.TcpClientSettings is TcpClientSettings
@@ -45,7 +52,7 @@ def test_package_root_exports_recommended_entry_points() -> None:
 
 
 def test_aionetx_api_exports_transport_protocols_for_advanced_usage() -> None:
-    import aionetx.api as api
+    api = _api_module()
 
     assert api.TcpClientProtocol is TcpClientProtocol
     assert api.TcpServerProtocol is TcpServerProtocol
@@ -55,7 +62,7 @@ def test_aionetx_api_exports_transport_protocols_for_advanced_usage() -> None:
 
 
 def test_aionetx_api_exports_bytes_capability_types() -> None:
-    import aionetx.api as api
+    api = _api_module()
 
     assert api.BytesLike is BytesLike
     assert api.ByteSenderProtocol is ByteSenderProtocol
@@ -63,14 +70,14 @@ def test_aionetx_api_exports_bytes_capability_types() -> None:
 
 
 def test_aionetx_api_exports_udp_send_exceptions() -> None:
-    import aionetx.api as api
+    api = _api_module()
 
     assert api.UdpSenderStoppedError is UdpSenderStoppedError
     assert api.UdpInvalidTargetError is UdpInvalidTargetError
 
 
 def test_aionetx_api_exports_exception_bases_and_typed_router() -> None:
-    import aionetx.api as api
+    api = _api_module()
 
     assert api.NetworkLayerError is NetworkLayerError
     assert api.NetworkConfigurationError is NetworkConfigurationError

--- a/tests/unit/test_runtime_utils.py
+++ b/tests/unit/test_runtime_utils.py
@@ -5,6 +5,8 @@ import asyncio
 import pytest
 
 from aionetx.implementations.asyncio_impl import runtime_utils as runtime_utils_module
+from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.internal_asyncio_impl_refs import await_task_completion_preserving_cancellation
 
 
@@ -47,19 +49,12 @@ async def test_task_await_helper_preserves_caller_cancellation_without_task_canc
         assert not awaiter_task.done()
 
         release_child.set()
-        with pytest.raises(asyncio.CancelledError):
-            await awaiter_task
+        await assert_awaitable_cancelled(awaiter_task)
     finally:
         release_child.set()
         if not awaiter_task.done():
             awaiter_task.cancel()
-            try:
-                await awaiter_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(awaiter_task)
         if not child_task.done():
             child_task.cancel()
-            try:
-                await child_task
-            except asyncio.CancelledError:
-                pass
+            await drain_awaitable_ignoring_cancelled(child_task)

--- a/tests/unit/test_runtime_utils.py
+++ b/tests/unit/test_runtime_utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aionetx.implementations.asyncio_impl import runtime_utils as runtime_utils_module
+from tests.internal_asyncio_impl_refs import await_task_completion_preserving_cancellation
+
+
+@pytest.mark.asyncio
+async def test_task_await_helper_preserves_caller_cancellation_without_task_cancelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child_cancel_seen = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def child_task_body() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            child_cancel_seen.set()
+            await release_child.wait()
+            raise
+
+    async def await_child_shutdown(task: asyncio.Task[object]) -> None:
+        task.cancel()
+        await await_task_completion_preserving_cancellation(task)
+
+    child_task = asyncio.create_task(child_task_body())
+    awaiter_task = asyncio.create_task(await_child_shutdown(child_task))
+
+    try:
+        await asyncio.wait_for(child_cancel_seen.wait(), timeout=1.0)
+
+        class _CurrentTaskWithoutCancelling:
+            pass
+
+        monkeypatch.setattr(
+            runtime_utils_module.asyncio,
+            "current_task",
+            lambda: _CurrentTaskWithoutCancelling(),
+        )
+        awaiter_task.cancel()
+        await asyncio.sleep(0)
+
+        assert not awaiter_task.done()
+
+        release_child.set()
+        with pytest.raises(asyncio.CancelledError):
+            await awaiter_task
+    finally:
+        release_child.set()
+        if not awaiter_task.done():
+            awaiter_task.cancel()
+            try:
+                await awaiter_task
+            except asyncio.CancelledError:
+                pass
+        if not child_task.done():
+            child_task.cancel()
+            try:
+                await child_task
+            except asyncio.CancelledError:
+                pass


### PR DESCRIPTION
## Summary

While expanding lifecycle and cancellation regression coverage, several async edge cases showed that startup rollback, overlapping `stop()` calls, and shutdown-time task cleanup were not yet as deterministic as the public lifecycle contract expects.

This PR fixes those lifecycle gaps, adds targeted regression tests for the failing interleavings, tightens the heartbeat provider contract, and curates missing advanced API exports that appear in public protocol signatures.

## Problems and approach

### 1. Overlapping datagram receiver stops could plan duplicate teardown

Problem:
UDP and multicast receivers could receive a second `stop()` call while the first stop was still publishing `STOPPING` or tearing down resources. That made it possible for the second caller to plan its own shutdown path instead of converging on the active owner path.

Approach:
The datagram receiver runtime now tracks a shared stop waiter and stop owner. Non-owner stop callers wait for the owner path instead of planning a second teardown. Re-entrant stop calls from the owner task return without self-deadlocking. Regression tests cover repeated/overlapping UDP and multicast receiver stop calls and assert single terminal publication.

### 2. Datagram shutdown could expose cancellation before receive-task cleanup settled

Problem:
The datagram receiver stop path cancelled the receive task and awaited it directly. If the caller was cancelled while the receive task was still unwinding, shutdown could surface cancellation before the internal cleanup task had fully settled.

Approach:
Datagram teardown now uses the shared cancellation-preserving task-await helper. Child-task cancellation remains expected during shutdown, but caller cancellation is delayed until the receive task has completed cleanup. A regression test blocks the receive task during cancellation and asserts stop does not return early or detach the task.

### 3. TCP server startup cancellation could bypass rollback

Problem:
Cancelling `AsyncioTcpServer.start()` during `asyncio.start_server()` could bypass the normal `Exception` rollback path because `asyncio.CancelledError` is not an `Exception` on supported Python versions. That could leave lifecycle state and dispatcher/listener cleanup inconsistent.

Approach:
TCP server startup rollback now explicitly handles cancellation, closes partially-owned listener resources, transitions back to `STOPPED`, stops the dispatcher, and then re-raises cancellation. Additional tests cover startup cancellation and repeated cancellation while dispatcher rollback is still in progress.

### 4. TCP server non-owner stop callers could cancel the shared stop waiter

Problem:
A secondary `server.stop()` caller waited directly on the shared stop waiter. Cancelling that secondary caller could cancel the shared waiter itself, affecting later stop callers even though the owner shutdown path was still running.

Approach:
Non-owner TCP server stop callers now await the shared waiter through `asyncio.shield()`. A regression test cancels a non-owner stop caller, verifies the owner waiter remains alive, and verifies a later stop caller still waits for owner teardown.

### 5. TCP client concurrent stop calls did not fully converge

Problem:
TCP client shutdown did not have the same stop-owner/waiter convergence model as the server/datagram paths. Concurrent stop callers could return too early or interact awkwardly with supervisor, heartbeat, connection, and dispatcher cleanup.

Approach:
TCP client shutdown now publishes a shared stop waiter before slow teardown starts. Non-owner callers wait for the active shutdown path, while owner-task re-entry from inline handlers avoids self-deadlock. Regression tests cover concurrent stop, handler-initiated stop, and cancellation while supervisor cleanup is still settling.

### 6. Shutdown task awaits could swallow or detach cancellation incorrectly

Problem:
Some shutdown paths cancelled child tasks and then either suppressed `CancelledError` or awaited the task directly. That made it easy to either swallow caller cancellation or raise it before internal cleanup had completed.

Approach:
A shared internal helper now awaits cancelled child tasks through `asyncio.shield()`. It suppresses expected child-task cancellation, keeps awaiting through repeated caller cancellation until the child task settles, and then re-raises caller cancellation. Tests cover normal child cancellation, caller cancellation while child cleanup is blocked, repeated cancellation, and child exceptions.

### 7. Heartbeat provider decisions relied on truthiness

Problem:
`HeartbeatResult.should_send` was typed as `bool`, but the sender effectively relied on truthiness. Invalid provider output such as `should_send="yes"` could silently behave as `True`.

Approach:
`HeartbeatResult` now validates `should_send` as an exact `bool` at construction. Payload type is validated only when a heartbeat will actually be sent, preserving ignored-payload behavior when `should_send=False`. Regression tests cover valid bytes-like payloads, invalid send decisions, invalid sent payloads, ignored non-sent payloads, and sender error handling.

### 8. Public protocol signature types were not all available from `aionetx.api`

Problem:
Some types used by public protocol signatures, such as `BytesLike`, `ByteSenderProtocol`, and `ManagedTransportProtocol`, were only available through deeper API modules. That drifted from the curated advanced API contract.

Approach:
The missing capability types are now exported from `aionetx.api` and grouped through `aionetx.api.protocols`. Import-boundary tests, symbol-source tests, and installed-artifact smoke checks were updated to verify the curated API surface.

## Changes

- Harden UDP/multicast receiver stop convergence.
- Preserve caller cancellation while still waiting for datagram receive-task cleanup.
- Roll back TCP server startup cancellation to `STOPPED`.
- Shield TCP server non-owner stop waiters.
- Add TCP client stop-owner/waiter convergence.
- Add a shared cancellation-preserving internal task-await helper.
- Validate `HeartbeatResult.should_send` as an exact `bool`.
- Export missing public capability/protocol types from `aionetx.api`.
- Align `docs/architecture.md` lifecycle wording with the tested guarantees.
- Fix stale mojibake in architecture event-stability wording.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not needed; no runtime/package user behavior changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.