### PR TITLE
fix(tcp): bound connection send drains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Planned contents for the initial public alpha release (`0.1.0`).
 - asyncio-first TCP client and server transport primitives
 - UDP sender, UDP receiver, and IPv4 multicast receiver primitives
 - explicit lifecycle events, event delivery settings, and backpressure policies
+- bounded TCP send flushes with configurable per-connection send timeouts
 - optional TCP client reconnect and heartbeat support
 - tests, examples, typing metadata, and CI/release verification gates

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Protocol framing, parsing, and business logic remain in your application.
   - [Lifecycle model](#lifecycle-model)
   - [Unified event integration](#unified-event-integration)
   - [Event delivery and backpressure](#event-delivery-and-backpressure)
+  - [TCP send timeout behavior](#tcp-send-timeout-behavior)
 - [Practical examples](#practical-examples)
   - [Buffer TCP chunks into fixed-size frames (1359 bytes)](#1-buffer-tcp-chunks-into-fixed-size-frames-1359-bytes)
   - [Receive bytes with one handler](#2-receive-bytes-with-one-handler)
@@ -458,6 +459,14 @@ deterministic-shutdown cutoffs.
 
 For lifecycle/cancellation/shutdown contract details, see `docs/architecture.md` and the runtime/integration tests in `tests/`.
 
+### TCP send timeout behavior
+
+TCP `ConnectionProtocol.send()` writes bytes and waits for the underlying `asyncio.StreamWriter.drain()` to complete. TCP client and server connections limit that drain wait by default with `connection_send_timeout_seconds=30.0`.
+
+Set `connection_send_timeout_seconds=None` only when you intentionally want OS/backpressure-controlled sends that may wait indefinitely behind a slow or non-reading peer. When the configured timeout expires, direct `send()` raises `asyncio.TimeoutError`; managed heartbeat sends emit `NetworkErrorEvent` and stop the heartbeat sender, while server broadcast closes the failed recipient connection.
+
+For TCP servers, `broadcast_send_timeout_seconds` is an outer per-recipient broadcast wrapper. Setting it to `None` disables only that broadcast wrapper; accepted connections can still time out via `connection_send_timeout_seconds`.
+
 ---
 
 ## Practical examples
@@ -704,7 +713,7 @@ Verification interpretation summary is provided here; architecture-level rationa
 aionetx runs on Linux, macOS, and Windows. Some runtime behavior differs per platform, and timing guarantees are explicitly best-effort. Before deploying to latency-sensitive or regulated contexts, review:
 
 - [`docs/platform_notes.md`](docs/platform_notes.md) - socket bind reuse/exclusivity semantics, multicast binding notes, and the UDP `sock_sendto()` / `sock_recvfrom()` fallback on Windows `ProactorEventLoop` (per-operation wake latency up to ~20 ms)
-- [`docs/timing_and_latency.md`](docs/timing_and_latency.md) - what aionetx does and does not guarantee about reconnect, heartbeat, and datagram timing; suitability and non-suitability guidance for regulated, safety-adjacent, and latency-sensitive contexts
+- [`docs/timing_and_latency.md`](docs/timing_and_latency.md) - what aionetx does and does not guarantee about TCP send flushes, reconnect, heartbeat, and datagram timing; suitability and non-suitability guidance for regulated, safety-adjacent, and latency-sensitive contexts
 - [`docs/logging.md`](docs/logging.md) - logger hierarchy, structured context keys, warnings to alert on, and a minimal `dictConfig` snippet
 
 ### How to read CI at a glance
@@ -886,6 +895,7 @@ For the full logger hierarchy, structured context keys, recommended levels, and 
 - choose `EventDeliverySettings` intentionally (`BACKGROUND + BLOCK` is a solid default)
 - keep handler code non-blocking; offload slow work
 - implement explicit TCP framing (length-prefix, delimiter, or fixed-size)
+- choose TCP connect/send/idle timeouts deliberately; disable `connection_send_timeout_seconds` only when indefinite backpressure waits are intentional
 - set reconnect and heartbeat parameters deliberately for your environment
 - enable debug logs during integration, then lower verbosity in steady state
 - add app-level integration tests for framing, reconnect, and shutdown behavior

--- a/docs/timing_and_latency.md
+++ b/docs/timing_and_latency.md
@@ -36,6 +36,16 @@ of the system under test.
 
 ## Observed envelopes
 
+### TCP send flushes
+
+TCP `ConnectionProtocol.send()` completes after the underlying `asyncio.StreamWriter.drain()` completes. TCP client and server connections default to `connection_send_timeout_seconds=30.0`, so a slow or non-reading peer cannot stall a send forever unless that timeout is explicitly disabled.
+
+If the send timeout expires, direct `send()` raises `asyncio.TimeoutError`. Managed heartbeat sends emit a `NetworkErrorEvent` and stop the heartbeat sender; server broadcast emits a `NetworkErrorEvent` and closes the failed recipient connection.
+
+Setting `connection_send_timeout_seconds=None` disables this connection-level enforcement and allows `drain()` to wait indefinitely under OS/socket backpressure. For TCP servers, `broadcast_send_timeout_seconds` is a separate outer per-recipient broadcast wrapper; disabling it does not disable the accepted connection's own send timeout.
+
+The configured timeout is a best-effort asyncio deadline, not a hard real-time guarantee. Actual wake-up timing still depends on event-loop scheduling and system load.
+
 ### TCP reconnect backoff
 
 Source: `ReconnectBackoff` in

--- a/src/aionetx/api/connection_protocol.py
+++ b/src/aionetx/api/connection_protocol.py
@@ -62,6 +62,8 @@ class ConnectionProtocol(ByteSenderProtocol, Protocol):
             TypeError: If ``data`` is not bytes-like.
             OSError: When the underlying transport accepts the write but later
                 reports a socket or stream failure while flushing.
+            asyncio.TimeoutError: When the connection has a configured send
+                timeout and the write buffer does not drain in time.
         """
         raise NotImplementedError
 

--- a/src/aionetx/api/tcp_client.py
+++ b/src/aionetx/api/tcp_client.py
@@ -49,6 +49,10 @@ class TcpClientSettings:
         connect_timeout_seconds: Optional per-attempt connect timeout. Must
             be ``> 0`` when set. ``None`` (default) waits for the OS-level
             connect to resolve.
+        connection_send_timeout_seconds: Optional timeout applied to
+            per-connection ``send()`` flushes, including direct connection
+            sends and heartbeat sends. Must be ``> 0`` when set. ``None``
+            disables send-timeout enforcement. Defaults to 30.0.
         event_delivery: Dispatch mode, buffering, and handler-failure policy
             controls for events emitted by this client.
     """
@@ -60,6 +64,7 @@ class TcpClientSettings:
     error_policy: ErrorPolicy | None = None
     receive_buffer_size: int = 4096
     connect_timeout_seconds: float | None = None
+    connection_send_timeout_seconds: float | None = 30.0
     event_delivery: EventDeliverySettings = field(default_factory=EventDeliverySettings)
 
     def __post_init__(self) -> None:
@@ -87,6 +92,10 @@ class TcpClientSettings:
         require_optional_positive_finite_number(
             field_name="TcpClientSettings.connect_timeout_seconds",
             value=self.connect_timeout_seconds,
+        )
+        require_optional_positive_finite_number(
+            field_name="TcpClientSettings.connection_send_timeout_seconds",
+            value=self.connection_send_timeout_seconds,
         )
         if self.error_policy is not None:
             require_enum_member(

--- a/src/aionetx/api/tcp_server.py
+++ b/src/aionetx/api/tcp_server.py
@@ -39,8 +39,14 @@ class TcpServerSettings:
             ``None`` disables idle-timeout enforcement.
         broadcast_concurrency_limit: Maximum number of concurrent per-connection
             broadcast sends. Must be ``> 0``.
-        broadcast_send_timeout_seconds: Optional timeout applied to each individual
-            per-connection broadcast send. ``None`` disables the timeout.
+        broadcast_send_timeout_seconds: Optional outer timeout applied to each
+            individual per-connection broadcast send. ``None`` disables only
+            this broadcast-specific wrapper; ``connection_send_timeout_seconds``
+            may still bound the underlying connection ``send()``.
+        connection_send_timeout_seconds: Optional timeout applied to accepted
+            connection ``send()`` flushes, including direct connection sends,
+            heartbeat sends, and broadcast delivery. Must be ``> 0`` when set.
+            ``None`` disables send-timeout enforcement. Defaults to 30.0.
         heartbeat: Server-side TCP keep-alive scheduling policy. When
             ``enabled=True`` the configured ``HeartbeatProviderProtocol`` is
             asked every interval whether to send a heartbeat payload to each
@@ -59,6 +65,7 @@ class TcpServerSettings:
     connection_idle_timeout_seconds: float | None = None
     broadcast_concurrency_limit: int = 64
     broadcast_send_timeout_seconds: float | None = None
+    connection_send_timeout_seconds: float | None = 30.0
     heartbeat: TcpHeartbeatSettings = field(default_factory=TcpHeartbeatSettings)
     receive_buffer_size: int = 4096
     backlog: int = 100
@@ -96,6 +103,10 @@ class TcpServerSettings:
         require_optional_positive_finite_number(
             field_name="TcpServerSettings.broadcast_send_timeout_seconds",
             value=self.broadcast_send_timeout_seconds,
+        )
+        require_optional_positive_finite_number(
+            field_name="TcpServerSettings.connection_send_timeout_seconds",
+            value=self.connection_send_timeout_seconds,
         )
         require_positive_int(
             field_name="TcpServerSettings.receive_buffer_size",

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
@@ -73,9 +73,7 @@ async def connect_once(
         event_dispatcher=event_dispatcher,
         receive_buffer_size=settings.receive_buffer_size,
         on_closed_callback=on_closed_callback,
-        # Public client settings do not expose send timeouts yet; keep the
-        # managed-client behavior unchanged until that contract exists.
-        send_timeout_seconds=None,
+        send_timeout_seconds=settings.connection_send_timeout_seconds,
     )
     try:
         await connection.start()

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_connect.py
@@ -73,6 +73,9 @@ async def connect_once(
         event_dispatcher=event_dispatcher,
         receive_buffer_size=settings.receive_buffer_size,
         on_closed_callback=on_closed_callback,
+        # Public client settings do not expose send timeouts yet; keep the
+        # managed-client behavior unchanged until that contract exists.
+        send_timeout_seconds=None,
     )
     try:
         await connection.start()

--- a/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
@@ -258,6 +258,7 @@ async def handle_accepted_client(
     max_connections: int,
     receive_buffer_size: int,
     idle_timeout_seconds: float | None,
+    connection_send_timeout_seconds: float | None,
     on_closed_callback: ConnectionClosedCallback,
     heartbeat_settings: TcpHeartbeatSettings,
     heartbeat_provider: HeartbeatProviderProtocol | None,
@@ -305,9 +306,7 @@ async def handle_accepted_client(
                 receive_buffer_size=receive_buffer_size,
                 idle_timeout_seconds=idle_timeout_seconds,
                 on_closed_callback=on_closed_callback,
-                # Public server settings do not expose send timeouts yet; keep
-                # accepted-connection behavior unchanged until that contract exists.
-                send_timeout_seconds=None,
+                send_timeout_seconds=connection_send_timeout_seconds,
             )
             connections[connection_id] = connection
     if should_reject:

--- a/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_server_helpers.py
@@ -305,6 +305,9 @@ async def handle_accepted_client(
                 receive_buffer_size=receive_buffer_size,
                 idle_timeout_seconds=idle_timeout_seconds,
                 on_closed_callback=on_closed_callback,
+                # Public server settings do not expose send timeouts yet; keep
+                # accepted-connection behavior unchanged until that contract exists.
+                send_timeout_seconds=None,
             )
             connections[connection_id] = connection
     if should_reject:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -7,6 +7,7 @@ import contextlib
 import logging
 from typing import Awaitable, Callable, cast
 
+from aionetx.api._validation import require_optional_positive_finite_number
 from aionetx.api.bytes_like import BytesLike
 from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.errors import ConnectionClosedError
@@ -49,6 +50,8 @@ class AsyncioTcpConnection(ConnectionProtocol):
         receive_buffer_size: int,
         idle_timeout_seconds: float | None = None,
         on_closed_callback: ConnectionClosedCallback | None = None,
+        *,
+        send_timeout_seconds: float | None = 30.0,
     ) -> None:
         if not connection_id:
             raise ValueError("connection_id must not be empty.")
@@ -56,6 +59,11 @@ class AsyncioTcpConnection(ConnectionProtocol):
             raise ValueError("receive_buffer_size must be > 0.")
         if idle_timeout_seconds is not None and idle_timeout_seconds <= 0:
             raise ValueError("idle_timeout_seconds must be > 0 when provided.")
+        send_timeout_seconds = require_optional_positive_finite_number(
+            field_name="send_timeout_seconds",
+            value=send_timeout_seconds,
+            error_type=ValueError,
+        )
         self._connection_id = connection_id
         self._role = role
         self._reader = reader
@@ -63,6 +71,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
         self._event_dispatcher = event_dispatcher
         self._receive_buffer_size = receive_buffer_size
         self._idle_timeout_seconds = idle_timeout_seconds
+        self._send_timeout_seconds = send_timeout_seconds
         self._on_closed_callback = on_closed_callback
         self._state = ConnectionState.CREATED
         self._metadata = self._build_metadata()
@@ -135,13 +144,18 @@ class AsyncioTcpConnection(ConnectionProtocol):
             TypeError: If ``data`` is not bytes-like.
             OSError: If the underlying stream reports a socket failure while
                 flushing the write buffer.
+            asyncio.TimeoutError: If the write buffer does not drain within
+                the configured send timeout.
         """
         if self._state != ConnectionState.CONNECTED:
             raise ConnectionClosedError(f"Connection '{self._connection_id}' is not connected.")
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError("send expects bytes-like data.")
         self._writer.write(bytes(data))
-        await self._writer.drain()
+        if self._send_timeout_seconds is None:
+            await self._writer.drain()
+            return
+        await asyncio.wait_for(self._writer.drain(), timeout=self._send_timeout_seconds)
 
     async def close(self) -> None:
         """

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -388,6 +388,7 @@ class AsyncioTcpServer(TcpServerProtocol):
             max_connections=self._settings.max_connections,
             receive_buffer_size=self._settings.receive_buffer_size,
             idle_timeout_seconds=self._settings.connection_idle_timeout_seconds,
+            connection_send_timeout_seconds=self._settings.connection_send_timeout_seconds,
             on_closed_callback=self._on_connection_closed,
             heartbeat_settings=self._settings.heartbeat,
             heartbeat_provider=self._heartbeat_provider,

--- a/tests/unit/test_asyncio_heartbeat_sender.py
+++ b/tests/unit/test_asyncio_heartbeat_sender.py
@@ -88,6 +88,12 @@ class FailingSendConnection(FakeConnection):
         raise RuntimeError("send-failed")
 
 
+class TimeoutSendConnection(FailingSendConnection):
+    async def send(self, data: bytes) -> None:
+        self.send_calls += 1
+        raise asyncio.TimeoutError("send-timeout")
+
+
 def make_dispatcher(handler) -> AsyncioEventDispatcher:
     return AsyncioEventDispatcher(handler, EventDeliverySettings(), logging.getLogger("test"))
 
@@ -318,10 +324,41 @@ async def test_heartbeat_sender_emits_error_and_stops_when_connection_send_fails
         AlwaysSendHeartbeatProvider(),
         dispatcher,
     )
-    await sender.start()
-    await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
-    await dispatcher.stop()
+
+    try:
+        await sender.start()
+        await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    finally:
+        await sender.stop()
+        await dispatcher.stop()
 
     assert connection.send_calls == 1
     assert recording_event_handler.error_events
     assert isinstance(recording_event_handler.error_events[-1].error, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sender_emits_timeout_error_and_stops_when_send_times_out(
+    recording_event_handler,
+) -> None:
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = TimeoutSendConnection()
+    sender = AsyncioHeartbeatSender(
+        connection,
+        TcpHeartbeatSettings(enabled=True, interval_seconds=0.01),
+        AlwaysSendHeartbeatProvider(),
+        dispatcher,
+    )
+
+    try:
+        await sender.start()
+        await wait_for_condition(lambda: sender.is_running is False, timeout_seconds=1.0)
+    finally:
+        await sender.stop()
+        await dispatcher.stop()
+
+    assert connection.send_calls == 1
+    assert recording_event_handler.error_events
+    error = recording_event_handler.error_events[-1].error
+    assert isinstance(error, (TimeoutError, asyncio.TimeoutError))

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -64,6 +64,39 @@ class _WriterWithPeerInfo:
         return None
 
 
+class _BlockingDrainWriter:
+    """Writer double whose drain can either block indefinitely or be released."""
+
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+        self.drain_started = asyncio.Event()
+        self.release_drain = asyncio.Event()
+        self.closed = False
+
+    def get_extra_info(self, key: str, default=None):
+        if key == "peername":
+            return ("127.0.0.1", 45678)
+        if key == "sockname":
+            return ("127.0.0.1", 12345)
+        if key == "socket":
+            return None
+        return default
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        self.drain_started.set()
+        await self.release_drain.wait()
+
+    def close(self) -> None:
+        self.closed = True
+        self.release_drain.set()
+
+    async def wait_closed(self) -> None:
+        self.closed = True
+
+
 class _WriterProxy:
     """Wrap a real writer while overriding metadata used by client internals."""
 
@@ -180,29 +213,29 @@ async def test_client_connection_uses_fallback_id_when_peer_info_invalid_and_mis
             await client.stop()
 
 
-@pytest.mark.asyncio
-async def test_connect_once_keeps_managed_send_timeout_unbounded(
+async def _connect_once_with_blocking_writer(
+    *,
     recording_event_handler,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    connection_send_timeout_seconds: float | None,
+) -> tuple[AsyncioTcpConnection, _BlockingDrainWriter, AsyncioEventDispatcher]:
+    writer = _BlockingDrainWriter()
+
     async def _open_connection(*, host: str, port: int):
         del host, port
-        return asyncio.StreamReader(), _WriterWithPeerInfo(("127.0.0.1", 45678))
+        return asyncio.StreamReader(), writer
 
-    async def _noop_start(self: AsyncioTcpConnection) -> None:
-        return None
-
-    monkeypatch.setattr(AsyncioTcpConnection, "start", _noop_start)
     dispatcher = AsyncioEventDispatcher(
         recording_event_handler,
         EventDeliverySettings(),
         logging.getLogger("test"),
     )
+    await dispatcher.start()
     connection = await tcp_client_connect_module.connect_once(
         settings=TcpClientSettings(
             host="127.0.0.1",
             port=12345,
             reconnect=TcpReconnectSettings(enabled=False),
+            connection_send_timeout_seconds=connection_send_timeout_seconds,
         ),
         connection_opener=_open_connection,
         event_dispatcher=dispatcher,
@@ -210,8 +243,54 @@ async def test_connect_once_keeps_managed_send_timeout_unbounded(
         logger=logging.getLogger("test"),
         component_id="tcp/client/127.0.0.1/12345",
     )
+    return connection, writer, dispatcher
 
-    assert connection._send_timeout_seconds is None  # type: ignore[attr-defined]
+
+@pytest.mark.asyncio
+async def test_connect_once_applies_connection_send_timeout_to_managed_connection(
+    recording_event_handler,
+) -> None:
+    connection, writer, dispatcher = await _connect_once_with_blocking_writer(
+        recording_event_handler=recording_event_handler,
+        connection_send_timeout_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await connection.send(b"payload")
+
+        assert writer.writes == [b"payload"]
+        assert writer.drain_started.is_set()
+    finally:
+        await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_connect_once_disabled_connection_send_timeout_waits_for_drain_completion(
+    recording_event_handler,
+) -> None:
+    connection, writer, dispatcher = await _connect_once_with_blocking_writer(
+        recording_event_handler=recording_event_handler,
+        connection_send_timeout_seconds=None,
+    )
+    send_task = asyncio.create_task(connection.send(b"payload"))
+
+    try:
+        await asyncio.wait_for(writer.drain_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert send_task.done() is False
+
+        writer.release_drain.set()
+        assert await asyncio.wait_for(send_task, timeout=1.0) is None
+        assert writer.writes == [b"payload"]
+    finally:
+        writer.release_drain.set()
+        if not send_task.done():
+            send_task.cancel()
+        await connection.close()
+        await dispatcher.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -37,6 +37,7 @@ from aionetx.implementations.asyncio_impl import (
 from aionetx.implementations.asyncio_impl import _tcp_client_connect as tcp_client_connect_module
 from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
 from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.internal_asyncio_impl_refs import WarningRateLimiter
@@ -177,6 +178,40 @@ async def test_client_connection_uses_fallback_id_when_peer_info_invalid_and_mis
             assert connection.connection_id == f"tcp/client/127.0.0.1/{port}/connection"
         finally:
             await client.stop()
+
+
+@pytest.mark.asyncio
+async def test_connect_once_keeps_managed_send_timeout_unbounded(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _open_connection(*, host: str, port: int):
+        del host, port
+        return asyncio.StreamReader(), _WriterWithPeerInfo(("127.0.0.1", 45678))
+
+    async def _noop_start(self: AsyncioTcpConnection) -> None:
+        return None
+
+    monkeypatch.setattr(AsyncioTcpConnection, "start", _noop_start)
+    dispatcher = AsyncioEventDispatcher(
+        recording_event_handler,
+        EventDeliverySettings(),
+        logging.getLogger("test"),
+    )
+    connection = await tcp_client_connect_module.connect_once(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        connection_opener=_open_connection,
+        event_dispatcher=dispatcher,
+        on_closed_callback=lambda _connection: None,
+        logger=logging.getLogger("test"),
+        component_id="tcp/client/127.0.0.1/12345",
+    )
+
+    assert connection._send_timeout_seconds is None  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -220,8 +220,7 @@ async def _connect_once_with_blocking_writer(
 ) -> tuple[AsyncioTcpConnection, _BlockingDrainWriter, AsyncioEventDispatcher]:
     writer = _BlockingDrainWriter()
 
-    async def _open_connection(*, host: str, port: int):
-        del host, port
+    async def _open_connection(**_kwargs: object):
         return asyncio.StreamReader(), writer
 
     dispatcher = AsyncioEventDispatcher(

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -251,6 +251,182 @@ async def test_tcp_connection_send_surfaces_writer_drain_failure(recording_event
     await dispatcher.stop()
 
 
+@pytest.mark.asyncio
+async def test_tcp_connection_send_times_out_when_writer_drain_stalls(
+    recording_event_handler,
+) -> None:
+    drain_started = asyncio.Event()
+
+    class BlockingDrainWriter:
+        def __init__(self) -> None:
+            self.writes: list[bytes] = []
+
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def drain(self) -> None:
+            drain_started.set()
+            await asyncio.Event().wait()
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    writer = BlockingDrainWriter()
+    connection = AsyncioTcpConnection(
+        "client:send-timeout",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+        send_timeout_seconds=0.01,
+    )
+    await connection.start()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await connection.send(b"payload")
+
+    assert writer.writes == [b"payload"]
+    assert drain_started.is_set()
+    await connection.close()
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_send_timeout_none_waits_for_drain_completion(
+    recording_event_handler,
+) -> None:
+    drain_started = asyncio.Event()
+    release_drain = asyncio.Event()
+
+    class BlockingDrainWriter:
+        def __init__(self) -> None:
+            self.writes: list[bytes] = []
+
+        def get_extra_info(self, key: str):
+            if key == "sockname":
+                return ("127.0.0.1", 10001)
+            if key == "peername":
+                return ("127.0.0.1", 10002)
+            return None
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def drain(self) -> None:
+            drain_started.set()
+            await release_drain.wait()
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    writer = BlockingDrainWriter()
+    connection = AsyncioTcpConnection(
+        "client:send-timeout-disabled",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+        send_timeout_seconds=None,
+    )
+    await connection.start()
+    send_task = asyncio.create_task(connection.send(b"payload"))
+
+    try:
+        await asyncio.wait_for(drain_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert send_task.done() is False
+
+        release_drain.set()
+        assert await asyncio.wait_for(send_task, timeout=1.0) is None
+        assert writer.writes == [b"payload"]
+    finally:
+        release_drain.set()
+        if not send_task.done():
+            send_task.cancel()
+        await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.parametrize(
+    "send_timeout_seconds",
+    [
+        0,
+        -1,
+        float("nan"),
+        float("inf"),
+        True,
+        "1.0",
+        pytest.param(object(), id="object"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tcp_connection_rejects_invalid_send_timeout(
+    recording_event_handler,
+    send_timeout_seconds: object,
+) -> None:
+    with pytest.raises(ValueError, match="send_timeout_seconds"):
+        AsyncioTcpConnection(
+            "client:invalid-send-timeout",
+            ConnectionRole.CLIENT,
+            asyncio.StreamReader(),
+            _FakeWriter(),  # type: ignore[arg-type]
+            make_dispatcher(recording_event_handler),
+            1024,
+            send_timeout_seconds=send_timeout_seconds,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_keeps_positional_on_closed_callback_compatibility(
+    recording_event_handler,
+) -> None:
+    callback_called = asyncio.Event()
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        callback_called.set()
+
+    dispatcher = make_dispatcher(recording_event_handler)
+    await dispatcher.start()
+    connection = AsyncioTcpConnection(
+        "client:positional-close-callback",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _FakeWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        1024,
+        None,
+        on_closed,
+    )
+
+    try:
+        await connection.start()
+        await connection.close()
+        await asyncio.wait_for(callback_called.wait(), timeout=1.0)
+    finally:
+        await connection.close()
+        await dispatcher.stop()
+
+
 # Metadata parsing and read-loop failure handling.
 def test_tcp_connection_metadata_parsing_tolerates_non_integer_port_values(
     recording_event_handler,

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -96,6 +96,14 @@ class _FailingTrackedConnection(_FailingConnection):
         await super().close()
 
 
+class _TimeoutConnection(_FailingTrackedConnection):
+    """Failing sender that models an inner connection-level send timeout."""
+
+    async def send(self, data: bytes) -> None:
+        del data
+        raise TimeoutError("connection-send-timeout")
+
+
 class _FakeWriter:
     """StreamWriter-shaped test double for accepted-connection helper tests."""
 
@@ -114,6 +122,27 @@ class _FakeWriter:
 
     async def wait_closed(self) -> None:
         self.closed = True
+
+
+class _BlockingDrainWriter(_FakeWriter):
+    """StreamWriter-shaped double whose drain can stall or be released."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.writes: list[bytes] = []
+        self.drain_started = asyncio.Event()
+        self.release_drain = asyncio.Event()
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        self.drain_started.set()
+        await self.release_drain.wait()
+
+    def close(self) -> None:
+        super().close()
+        self.release_drain.set()
 
 
 class _BlockingConnection(_GoodConnection):
@@ -307,6 +336,31 @@ async def test_server_broadcast_timeout_closes_stalled_connection_and_emits_erro
 
     assert stalled.state == ConnectionState.CLOSED
     assert stalled.close_calls == 1
+    assert recording_event_handler.error_events
+    assert _is_timeout_error(recording_event_handler.error_events[-1].error)
+
+
+@pytest.mark.asyncio
+async def test_server_broadcast_without_broadcast_timeout_still_observes_connection_timeout(
+    recording_event_handler,
+) -> None:
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12345,
+            max_connections=64,
+            broadcast_send_timeout_seconds=None,
+            connection_send_timeout_seconds=0.01,
+        ),
+        event_handler=recording_event_handler,
+    )
+    timed_out = _TimeoutConnection(connection_id="server:timeout:1")
+    server._connections = {timed_out.connection_id: timed_out}  # type: ignore[attr-defined,dict-item]
+
+    await server.broadcast(b"fanout")
+
+    assert timed_out.state == ConnectionState.CLOSED
+    assert timed_out.close_calls == 1
     assert recording_event_handler.error_events
     assert _is_timeout_error(recording_event_handler.error_events[-1].error)
 
@@ -978,6 +1032,7 @@ async def test_accepted_connection_start_cancelled_error_cleans_registered_conne
             max_connections=64,
             receive_buffer_size=4096,
             idle_timeout_seconds=None,
+            connection_send_timeout_seconds=None,
             on_closed_callback=on_closed,
             heartbeat_settings=TcpHeartbeatSettings(enabled=False),
             heartbeat_provider=None,
@@ -990,26 +1045,22 @@ async def test_accepted_connection_start_cancelled_error_cleans_registered_conne
     assert writer.closed is True
 
 
-@pytest.mark.asyncio
-async def test_accepted_connection_keeps_managed_send_timeout_unbounded(
+async def _accept_connection_with_blocking_writer(
+    *,
     recording_event_handler,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    connection_send_timeout_seconds: float | None,
+) -> tuple[AsyncioTcpConnection, _BlockingDrainWriter, AsyncioEventDispatcher]:
     connections: dict[str, AsyncioTcpConnection] = {}
-    writer = _FakeWriter()
+    writer = _BlockingDrainWriter()
     dispatcher = AsyncioEventDispatcher(
         recording_event_handler,
         EventDeliverySettings(),
         logging.getLogger("test"),
     )
-
-    async def noop_start(self: AsyncioTcpConnection) -> None:
-        return None
+    await dispatcher.start()
 
     def on_closed(connection: AsyncioTcpConnection) -> None:
         connections.pop(connection.connection_id, None)
-
-    monkeypatch.setattr(AsyncioTcpConnection, "start", noop_start)
 
     await handle_accepted_client(
         reader=asyncio.StreamReader(),
@@ -1022,6 +1073,7 @@ async def test_accepted_connection_keeps_managed_send_timeout_unbounded(
         max_connections=64,
         receive_buffer_size=4096,
         idle_timeout_seconds=None,
+        connection_send_timeout_seconds=connection_send_timeout_seconds,
         on_closed_callback=on_closed,
         heartbeat_settings=TcpHeartbeatSettings(enabled=False),
         heartbeat_provider=None,
@@ -1029,9 +1081,54 @@ async def test_accepted_connection_keeps_managed_send_timeout_unbounded(
         component_id="tcp/server/127.0.0.1/12345",
         logger=logging.getLogger("test"),
     )
+    return connections["server:accepted:send-timeout"], writer, dispatcher
 
-    connection = connections["server:accepted:send-timeout"]
-    assert connection._send_timeout_seconds is None  # type: ignore[attr-defined]
+
+@pytest.mark.asyncio
+async def test_accepted_connection_applies_connection_send_timeout(
+    recording_event_handler,
+) -> None:
+    connection, writer, dispatcher = await _accept_connection_with_blocking_writer(
+        recording_event_handler=recording_event_handler,
+        connection_send_timeout_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await connection.send(b"payload")
+
+        assert writer.writes == [b"payload"]
+        assert writer.drain_started.is_set()
+    finally:
+        await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_accepted_connection_disabled_send_timeout_waits_for_drain_completion(
+    recording_event_handler,
+) -> None:
+    connection, writer, dispatcher = await _accept_connection_with_blocking_writer(
+        recording_event_handler=recording_event_handler,
+        connection_send_timeout_seconds=None,
+    )
+    send_task = asyncio.create_task(connection.send(b"payload"))
+
+    try:
+        await asyncio.wait_for(writer.drain_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert send_task.done() is False
+
+        writer.release_drain.set()
+        assert await asyncio.wait_for(send_task, timeout=1.0) is None
+        assert writer.writes == [b"payload"]
+    finally:
+        writer.release_drain.set()
+        if not send_task.done():
+            send_task.cancel()
+        await connection.close()
+        await dispatcher.stop()
 
 
 @pytest.mark.asyncio
@@ -1069,6 +1166,7 @@ async def test_accepted_connection_error_event_failure_still_closes_connection(
         max_connections=64,
         receive_buffer_size=4096,
         idle_timeout_seconds=None,
+        connection_send_timeout_seconds=None,
         on_closed_callback=on_closed,
         heartbeat_settings=TcpHeartbeatSettings(enabled=False),
         heartbeat_provider=None,

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -991,6 +991,50 @@ async def test_accepted_connection_start_cancelled_error_cleans_registered_conne
 
 
 @pytest.mark.asyncio
+async def test_accepted_connection_keeps_managed_send_timeout_unbounded(
+    recording_event_handler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connections: dict[str, AsyncioTcpConnection] = {}
+    writer = _FakeWriter()
+    dispatcher = AsyncioEventDispatcher(
+        recording_event_handler,
+        EventDeliverySettings(),
+        logging.getLogger("test"),
+    )
+
+    async def noop_start(self: AsyncioTcpConnection) -> None:
+        return None
+
+    def on_closed(connection: AsyncioTcpConnection) -> None:
+        connections.pop(connection.connection_id, None)
+
+    monkeypatch.setattr(AsyncioTcpConnection, "start", noop_start)
+
+    await handle_accepted_client(
+        reader=asyncio.StreamReader(),
+        writer=writer,  # type: ignore[arg-type]
+        state_lock=asyncio.Lock(),
+        get_lifecycle_state=lambda: ComponentLifecycleState.RUNNING,
+        get_connection_id=lambda: "server:accepted:send-timeout",
+        connections=connections,
+        event_dispatcher=dispatcher,
+        max_connections=64,
+        receive_buffer_size=4096,
+        idle_timeout_seconds=None,
+        on_closed_callback=on_closed,
+        heartbeat_settings=TcpHeartbeatSettings(enabled=False),
+        heartbeat_provider=None,
+        heartbeat_senders={},
+        component_id="tcp/server/127.0.0.1/12345",
+        logger=logging.getLogger("test"),
+    )
+
+    connection = connections["server:accepted:send-timeout"]
+    assert connection._send_timeout_seconds is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_accepted_connection_error_event_failure_still_closes_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -99,8 +99,7 @@ class _FailingTrackedConnection(_FailingConnection):
 class _TimeoutConnection(_FailingTrackedConnection):
     """Failing sender that models an inner connection-level send timeout."""
 
-    async def send(self, data: bytes) -> None:
-        del data
+    async def send(self, _data: bytes) -> None:
         raise TimeoutError("connection-send-timeout")
 
 

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -366,6 +366,40 @@ async def test_server_broadcast_without_broadcast_timeout_still_observes_connect
 
 
 @pytest.mark.asyncio
+async def test_server_broadcast_without_broadcast_timeout_closes_real_stalled_connection(
+    recording_event_handler,
+) -> None:
+    connection, writer, dispatcher = await _accept_connection_with_blocking_writer(
+        recording_event_handler=recording_event_handler,
+        connection_send_timeout_seconds=0.01,
+    )
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12345,
+            max_connections=64,
+            broadcast_send_timeout_seconds=None,
+            connection_send_timeout_seconds=0.01,
+        ),
+        event_handler=recording_event_handler,
+    )
+    server._connections = {connection.connection_id: connection}  # type: ignore[attr-defined]
+
+    try:
+        await asyncio.wait_for(server.broadcast(b"fanout"), timeout=1.0)
+
+        assert writer.writes == [b"fanout"]
+        assert writer.drain_started.is_set()
+        assert connection.state == ConnectionState.CLOSED
+        assert recording_event_handler.error_events
+        assert _is_timeout_error(recording_event_handler.error_events[-1].error)
+    finally:
+        writer.release_drain.set()
+        await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
 async def test_server_start_raises_when_heartbeat_enabled_without_provider(
     recording_event_handler,
 ) -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -133,6 +133,22 @@ def test_tcp_client_settings_validate_failure_for_negative_connect_timeout() -> 
         TcpClientSettings(host="127.0.0.1", port=1234, connect_timeout_seconds=-1.0)
 
 
+def test_tcp_client_settings_default_connection_send_timeout() -> None:
+    settings = TcpClientSettings(host="127.0.0.1", port=1234)
+
+    assert settings.connection_send_timeout_seconds == 30.0
+
+
+def test_tcp_client_settings_allow_disabled_connection_send_timeout() -> None:
+    settings = TcpClientSettings(
+        host="127.0.0.1",
+        port=1234,
+        connection_send_timeout_seconds=None,
+    )
+
+    assert settings.connection_send_timeout_seconds is None
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -144,6 +160,12 @@ def test_tcp_client_settings_validate_failure_for_negative_connect_timeout() -> 
         {"connect_timeout_seconds": float("nan")},
         {"connect_timeout_seconds": float("inf")},
         {"connect_timeout_seconds": "1"},
+        {"connection_send_timeout_seconds": 0},
+        {"connection_send_timeout_seconds": -1},
+        {"connection_send_timeout_seconds": float("nan")},
+        {"connection_send_timeout_seconds": float("inf")},
+        {"connection_send_timeout_seconds": True},
+        {"connection_send_timeout_seconds": "1"},
         {"error_policy": "retry"},
     ],
 )
@@ -211,6 +233,23 @@ def test_tcp_server_settings_validate_failure_for_non_positive_broadcast_send_ti
         )
 
 
+def test_tcp_server_settings_default_connection_send_timeout() -> None:
+    settings = TcpServerSettings(host="127.0.0.1", port=1, max_connections=64)
+
+    assert settings.connection_send_timeout_seconds == 30.0
+
+
+def test_tcp_server_settings_allow_disabled_connection_send_timeout() -> None:
+    settings = TcpServerSettings(
+        host="127.0.0.1",
+        port=1,
+        max_connections=64,
+        connection_send_timeout_seconds=None,
+    )
+
+    assert settings.connection_send_timeout_seconds is None
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -221,6 +260,12 @@ def test_tcp_server_settings_validate_failure_for_non_positive_broadcast_send_ti
         {"connection_idle_timeout_seconds": float("inf")},
         {"broadcast_concurrency_limit": True},
         {"broadcast_send_timeout_seconds": float("nan")},
+        {"connection_send_timeout_seconds": 0},
+        {"connection_send_timeout_seconds": -1},
+        {"connection_send_timeout_seconds": float("nan")},
+        {"connection_send_timeout_seconds": float("inf")},
+        {"connection_send_timeout_seconds": True},
+        {"connection_send_timeout_seconds": "1"},
         {"receive_buffer_size": 4096.0},
         {"backlog": "100"},
     ],


### PR DESCRIPTION
## Summary

While hardening TCP send-timeout behavior, the direct connection `send()` path showed that `StreamWriter.drain()` could still wait indefinitely behind a slow or non-reading peer.

This PR bounds TCP send flushes by default, exposes the timeout through managed TCP client/server settings, adds targeted regression coverage for direct sends, heartbeat sends, and server broadcast delivery, and documents the new public timeout contract.

## Problems and approach

### 1. Direct TCP connection sends could wait indefinitely

Problem:
`AsyncioTcpConnection.send()` wrote bytes and then awaited `StreamWriter.drain()` without a timeout. If the peer stopped reading or the OS write buffer remained backpressured, direct callers could remain blocked indefinitely.

Approach:
TCP connection sends now use a configurable `send_timeout_seconds` value. The default is `30.0` seconds, and `None` explicitly disables send-timeout enforcement for callers that intentionally want indefinite OS/backpressure-controlled waits. When the configured timeout expires, direct `send()` raises `asyncio.TimeoutError`. Regression tests cover default timeout behavior, disabled timeout behavior, invalid timeout values, and compatibility for existing keyword-only construction.

### 2. Managed TCP clients had no public send-timeout setting

Problem:
After bounding direct connection sends, managed TCP clients needed a public configuration surface. Without one, users of `TcpClientSettings` could not tune or intentionally disable the new timeout behavior.

Approach:
`TcpClientSettings` now exposes `connection_send_timeout_seconds`, validates it as an optional positive finite number, and passes it into managed client connection creation. Tests cover the default value, `None` opt-out, invalid values, and behavior through an actual managed client connection with a stalled writer drain.

### 3. Managed TCP servers had no public send-timeout setting

Problem:
Accepted TCP server connections also use `ConnectionProtocol.send()`, including per-connection sends, heartbeat sends, and broadcast delivery. Server users needed the same public timeout control as client users.

Approach:
`TcpServerSettings` now exposes `connection_send_timeout_seconds`, validates it as an optional positive finite number, and passes it into accepted server connections. Tests cover the default value, `None` opt-out, invalid values, and behavior through an accepted `AsyncioTcpConnection` whose writer drain stalls.

### 4. Server broadcast had two timeout layers that needed clear behavior

Problem:
TCP server broadcast already had `broadcast_send_timeout_seconds`, but the new connection-level timeout introduced a second relevant timeout layer. Disabling the broadcast wrapper should not accidentally disable the accepted connection's own send timeout.

Approach:
The server settings docs now distinguish `broadcast_send_timeout_seconds` as an outer per-recipient broadcast wrapper from `connection_send_timeout_seconds` as the underlying accepted connection send timeout. Regression tests cover both the fake timeout path and a real stalled `AsyncioTcpConnection` path, asserting that timed-out broadcast recipients are reported and closed.

### 5. Heartbeat sends needed explicit timeout coverage

Problem:
Heartbeat sends use the connection `send()` path, so the new timeout policy also affects heartbeat delivery. No runtime bug was found in this path, but the behavior is user-visible and needed regression evidence.

Approach:
Heartbeat tests now cover timeout-flavored connection send failures. The tests assert that heartbeat send timeouts emit `NetworkErrorEvent` and stop the heartbeat sender. The async test cleanup is defensive so failed assertions do not leak dispatcher tasks.

## Changes

- Bound direct TCP connection `send()` drain waits by default.
- Add `send_timeout_seconds` to `AsyncioTcpConnection`.
- Add `connection_send_timeout_seconds` to `TcpClientSettings`.
- Add `connection_send_timeout_seconds` to `TcpServerSettings`.
- Propagate managed client and accepted server timeout settings into connections.
- Clarify server broadcast wrapper timeout semantics.
- Add regression tests for direct connection send timeout behavior.
- Add managed client and accepted server stalled-drain timeout coverage.
- Add heartbeat send-timeout failure coverage.
- Add server broadcast coverage using a real stalled `AsyncioTcpConnection`.
- Document TCP send timeout behavior in `README.md`.
- Document TCP send flush timing in `docs/timing_and_latency.md`.
- Update `CHANGELOG.md` for the user-visible timeout behavior.
- Remove CodeQL-prone no-op cleanup statements from test helpers.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `ruff format --check .` passes locally.
- [x] `mypy src` passes locally.
- [x] `python -m pytest -q` passes locally.
- [x] `py -3.10 -m pytest -q` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
