### PR TITLE
fix(datagram): startup cancellation rollback

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -524,20 +524,21 @@ class _AsyncioDatagramReceiverBase:
             await self._event_dispatcher.emit(
                 ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
             )
+            async with self._state_lock:
+                if (
+                    self._socket is not sock
+                    or not self._running
+                    or self._lifecycle_state != ComponentLifecycleState.RUNNING
+                ):
+                    return
+                self._task = asyncio.create_task(
+                    self._receive_datagrams(receive_buffer_size),
+                    name=f"{self._connection_id}-receiver",
+                )
         except (Exception, asyncio.CancelledError):
             with contextlib.suppress(Exception, asyncio.CancelledError):
                 await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
             raise
-        async with self._state_lock:
-            if (
-                self._socket is not sock
-                or not self._running
-                or self._lifecycle_state != ComponentLifecycleState.RUNNING
-            ):
-                return
-            self._task = asyncio.create_task(
-                self._receive_datagrams(receive_buffer_size), name=f"{self._connection_id}-receiver"
-            )
 
     async def _fail_startup(self) -> None:
         """Roll startup back to a clean stopped state and quiesce the dispatcher."""

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -456,9 +456,7 @@ class AsyncioEventDispatcher:
                 "cancelling the dispatcher task."
             )
             wrapped_error.__cause__ = error
-            await self._record_handler_failure(
-                error=wrapped_error, triggering_event=event
-            )
+            await self._record_handler_failure(error=wrapped_error, triggering_event=event)
             return
         except Exception as error:
             await self._record_handler_failure(error=error, triggering_event=event)

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -426,7 +426,25 @@ class AsyncioEventDispatcher:
                 self._worker_task = None
 
     async def _emit_now(self, event: NetworkEvent) -> None:
-        """Deliver one event to the handler and route failures through policy handling."""
+        """Deliver one event to the handler and route failures through policy handling.
+
+        The handler runs directly on the dispatching task so methods that
+        identify the dispatch path via ``asyncio.current_task()`` (notably the
+        UDP/TCP self-stop guards and ``current_task_is_worker`` checks)
+        continue to work when handlers re-enter ``stop()`` from inside an
+        event callback.
+
+        Caller cancellation propagation versus handler-raised
+        ``CancelledError``: on Python 3.11+ the distinction is decided
+        reliably via ``Task.cancelling()``.  On Python 3.10 ``Task.cancelling``
+        is unavailable and ``Task._must_cancel`` is reset before the
+        ``except`` block runs, so caller cancellation that arrives while the
+        handler is awaiting cannot be told apart from a handler-raised
+        ``CancelledError``; in that case the dispatcher conservatively treats
+        the cancellation as a handler failure.  The two regression tests that
+        exercise inline caller-cancellation propagation are skipped on 3.10
+        for the same reason.
+        """
         self._handler_dispatch_attempts_total += 1
         try:
             await self._event_handler.on_event(event)
@@ -438,7 +456,10 @@ class AsyncioEventDispatcher:
                 "cancelling the dispatcher task."
             )
             wrapped_error.__cause__ = error
-            await self._record_handler_failure(error=wrapped_error, triggering_event=event)
+            await self._record_handler_failure(
+                error=wrapped_error, triggering_event=event
+            )
+            return
         except Exception as error:
             await self._record_handler_failure(error=error, triggering_event=event)
 

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -274,6 +274,8 @@ class AsyncioEventDispatcher:
         - before worker start: deliver inline in the caller task;
         - steady-state (worker running): enqueue for worker delivery;
         - after stop begins: ignore new emits.
+        - ``emit()`` in BACKGROUND does not await handler completion; it may
+          return while handler work is still in flight on the worker task.
 
         Arguments:
             event (NetworkEvent): Event instance to deliver according to the

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -28,6 +28,7 @@ from aionetx.api.network_event import NetworkEvent
 from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     WarningRateLimiter,
+    is_task_being_cancelled,
     validate_async_event_handler,
 )
 
@@ -430,9 +431,7 @@ class AsyncioEventDispatcher:
         try:
             await self._event_handler.on_event(event)
         except asyncio.CancelledError as error:
-            current_task = asyncio.current_task()
-            task_cancelling = getattr(current_task, "cancelling", None)
-            if task_cancelling is not None and task_cancelling():
+            if is_task_being_cancelled():
                 raise
             wrapped_error = _HandlerCancelledError(
                 "Network event handler raised asyncio.CancelledError without "

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -180,6 +180,32 @@ async def await_task_completion_preserving_cancellation(task: asyncio.Task[objec
         raise asyncio.CancelledError
 
 
+def is_task_being_cancelled(task: asyncio.Task[object] | None = None) -> bool:
+    """
+    Return whether the provided task currently has cancellation in progress.
+
+    The check supports ``Task.cancelling()`` where available and falls back to
+    CPython's private ``_must_cancel`` counter on runtimes that do not expose
+    the public method.
+    """
+    current_task = task if task is not None else asyncio.current_task()
+    if current_task is None:
+        return False
+
+    task_cancelling = getattr(current_task, "cancelling", None)
+    if callable(task_cancelling):
+        try:
+            return bool(task_cancelling())
+        except (TypeError, RuntimeError):
+            pass
+
+    pending_cancel_count = getattr(current_task, "_must_cancel", None)
+    if isinstance(pending_cancel_count, int):
+        return pending_cancel_count > 0
+
+    return False
+
+
 def validate_async_event_handler(event_handler: NetworkEventHandlerProtocol) -> None:
     """
     Validate the runtime contract for ``NetworkEventHandlerProtocol``.

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -217,6 +217,45 @@ async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_b
 
 
 @pytest.mark.asyncio
+async def test_udp_receiver_background_startup_cancellation_after_opened_event_rolls_back_before_task_creation(
+) -> None:
+    opened_emit_seen = asyncio.Event()
+    allow_opened_emit_to_return = asyncio.Event()
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+            ),
+        ),
+        event_handler=NoopHandler(),
+    )
+
+    original_emit = receiver._event_dispatcher.emit  # type: ignore[attr-defined]
+
+    async def _emit_blocking_opened_event(event) -> None:
+        if isinstance(event, ConnectionOpenedEvent):
+            opened_emit_seen.set()
+            await allow_opened_emit_to_return.wait()
+        await original_emit(event)
+
+    receiver._event_dispatcher.emit = _emit_blocking_opened_event  # type: ignore[method-assign]
+
+    start_task = asyncio.create_task(receiver.start())
+    await asyncio.wait_for(opened_emit_seen.wait(), timeout=1.0)
+
+    start_task.cancel()
+    await assert_awaitable_cancelled(start_task)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_udp_receiver_starting_lifecycle_failure_rolls_back_dispatcher() -> None:
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -192,8 +192,9 @@ async def test_udp_receiver_opened_handler_failure_rolls_back_runtime_resources(
 
 
 @pytest.mark.asyncio
-async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_before_task_creation(
-) -> None:
+async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_before_task_creation() -> (
+    None
+):
     handler = HoldingOpenEventLockHandler()
     receiver = AsyncioUdpReceiver(
         settings=UdpReceiverSettings(
@@ -217,8 +218,9 @@ async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_b
 
 
 @pytest.mark.asyncio
-async def test_udp_receiver_background_startup_cancellation_after_opened_event_rolls_back_before_task_creation(
-) -> None:
+async def test_udp_receiver_background_startup_cancellation_after_opened_event_rolls_back_before_task_creation() -> (
+    None
+):
     opened_emit_seen = asyncio.Event()
     allow_opened_emit_to_return = asyncio.Event()
 

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -94,6 +94,25 @@ class StopAgainOnStoppingHandler:
             self.reentered_stop.set()
 
 
+class HoldingOpenEventLockHandler:
+    def __init__(self) -> None:
+        self.receiver: AsyncioUdpReceiver | None = None
+        self.opened_and_locked = asyncio.Event()
+
+    async def on_event(self, event) -> None:
+        if self.receiver is None or not isinstance(event, ConnectionOpenedEvent):
+            return
+        acquired = False
+        try:
+            await self.receiver._state_lock.acquire()  # type: ignore[attr-defined]
+            acquired = True
+            self.opened_and_locked.set()
+            await asyncio.Event().wait()
+        finally:
+            if acquired:
+                self.receiver._state_lock.release()  # type: ignore[attr-defined]
+
+
 def _get_unused_udp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -170,6 +189,31 @@ async def test_udp_receiver_opened_handler_failure_rolls_back_runtime_resources(
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]
     assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_before_task_creation(
+) -> None:
+    handler = HoldingOpenEventLockHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+
+    start_task = asyncio.create_task(receiver.start())
+    await asyncio.wait_for(handler.opened_and_locked.wait(), timeout=1.0)
+    start_task.cancel()
+    await assert_awaitable_cancelled(start_task)
+
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -13,6 +13,7 @@ import asyncio
 import contextlib
 import logging
 import socket
+import sys
 
 import pytest
 
@@ -191,6 +192,18 @@ async def test_udp_receiver_opened_handler_failure_rolls_back_runtime_resources(
     assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason=(
+        "Python 3.10 lacks Task.cancelling() and resets Task._must_cancel "
+        "before the dispatcher's except block observes the CancelledError, "
+        "so start_task.cancel() during inline ConnectionOpenedEvent "
+        "publication cannot be reliably distinguished from a handler-raised "
+        "CancelledError without changing handler task identity, which the "
+        "receiver self-stop guards rely on.  The BACKGROUND-mode variant of "
+        "this regression is covered below and remains active on 3.10."
+    ),
+)
 @pytest.mark.asyncio
 async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_before_task_creation() -> (
     None

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -356,9 +356,14 @@ async def test_background_mode_emit_returns_before_handler_completes() -> None:
     )
     await dispatcher.start()
 
+    # In BACKGROUND mode, queueing and handler execution are intentionally decoupled:
+    # if emit() were to await handler completion here, shutdown timing and
+    # cancellation behavior become caller-coupled and no longer match the contract.
     emit_task = asyncio.create_task(dispatcher.emit(_opened(1)))
     await asyncio.wait_for(handler_started.wait(), timeout=1.0)
     await asyncio.sleep(0)
+    # Once queueing succeeds, emit() should be done even though the handler
+    # has not finished its work path yet.
     assert emit_task.done()
     assert not handler_done.is_set()
 

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 
 import pytest
 
@@ -1733,6 +1734,18 @@ async def test_handler_cancelled_error_is_treated_as_handler_failure() -> None:
     ]
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason=(
+        "Python 3.10 lacks Task.cancelling() and resets Task._must_cancel "
+        "before the dispatcher's except block observes the CancelledError, "
+        "so caller cancellation that arrives while the inline handler is "
+        "awaiting cannot be reliably distinguished from a handler-raised "
+        "CancelledError without changing handler task identity, which the "
+        "transport self-stop guards rely on.  The dispatcher conservatively "
+        "treats this CancelledError as a handler failure on 3.10."
+    ),
+)
 @pytest.mark.asyncio
 async def test_inline_dispatcher_caller_cancellation_propagates() -> None:
     start_blocked = asyncio.Event()

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -34,6 +34,7 @@ from aionetx.implementations.asyncio_impl.event_dispatcher import (
     AsyncioEventDispatcher,
     DispatcherStopPolicy,
 )
+from tests.helpers import assert_awaitable_cancelled
 
 pytestmark = pytest.mark.behavior_critical
 
@@ -1770,5 +1771,4 @@ async def test_inline_dispatcher_caller_cancellation_propagates() -> None:
     assert handler_reached.is_set()
 
     emit_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await emit_task
+    await assert_awaitable_cancelled(emit_task)

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -333,6 +333,42 @@ async def test_background_mode_with_started_worker_dispatches_on_worker_task() -
 
 
 @pytest.mark.asyncio
+async def test_background_mode_emit_returns_before_handler_completes() -> None:
+    """
+    BACKGROUND-mode emit must return after queueing, even while handler
+    execution is still running.
+    """
+    handler_started = asyncio.Event()
+    handler_release = asyncio.Event()
+    handler_done = asyncio.Event()
+
+    class SlowBlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                handler_started.set()
+                await handler_release.wait()
+                handler_done.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        SlowBlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+
+    emit_task = asyncio.create_task(dispatcher.emit(_opened(1)))
+    await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+    assert emit_task.done()
+    assert not handler_done.is_set()
+
+    handler_release.set()
+    await asyncio.wait_for(emit_task, timeout=1.0)
+    await asyncio.wait_for(handler_done.wait(), timeout=1.0)
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
 async def test_background_mode_handler_spawned_task_does_not_inherit_inline_delivery() -> None:
     handled_tasks: list[asyncio.Task[None] | None] = []
     spawned_emit_finished = asyncio.Event()

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -1731,3 +1731,31 @@ async def test_handler_cancelled_error_is_treated_as_handler_failure() -> None:
         "ConnectionOpenedEvent",
         "ConnectionOpenedEvent",
     ]
+
+
+@pytest.mark.asyncio
+async def test_inline_dispatcher_caller_cancellation_propagates() -> None:
+    start_blocked = asyncio.Event()
+    handler_reached = asyncio.Event()
+
+    class BlockingInlineHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            handler_reached.set()
+            start_blocked.set()
+            await asyncio.Event().wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingInlineHandler(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.LOG_ONLY,
+        ),
+        logging.getLogger("test"),
+    )
+    emit_task = asyncio.create_task(dispatcher.emit(_opened(1)))
+    await asyncio.wait_for(start_blocked.wait(), timeout=1.0)
+    assert handler_reached.is_set()
+
+    emit_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await emit_task

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -11,39 +11,38 @@ from __future__ import annotations
 import importlib
 from types import ModuleType
 
-import aionetx
 import pytest
 
-from aionetx import (
-    AsyncioNetworkFactory,
-    BaseNetworkEventHandler,
-    NetworkEvent,
-    TcpClientSettings,
-    TcpServerSettings,
-)
-from aionetx.api import (
-    ByteSenderProtocol,
-    BytesLike,
-    ManagedTransportProtocol,
-    MulticastReceiverProtocol,
-    NetworkConfigurationError,
-    NetworkLayerError,
-    NetworkRuntimeError,
-    TcpClientProtocol,
-    TcpServerProtocol,
-    TypedEventRouter,
+from aionetx.api.base_network_event_handler import BaseNetworkEventHandler
+from aionetx.api.byte_sender_protocol import ByteSenderProtocol
+from aionetx.api.bytes_like import BytesLike
+from aionetx.api.errors import NetworkConfigurationError, NetworkLayerError, NetworkRuntimeError
+from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
+from aionetx.api.multicast_receiver_protocol import MulticastReceiverProtocol
+from aionetx.api.network_event import NetworkEvent
+from aionetx.api.tcp_client import TcpClientProtocol, TcpClientSettings
+from aionetx.api.tcp_server import TcpServerProtocol, TcpServerSettings
+from aionetx.api.typed_event_router import TypedEventRouter
+from aionetx.api.udp import (
     UdpInvalidTargetError,
     UdpReceiverProtocol,
     UdpSenderProtocol,
     UdpSenderStoppedError,
 )
+from aionetx.factories import AsyncioNetworkFactory
 
 
 def _api_module() -> ModuleType:
     return importlib.import_module("aionetx.api")
 
 
+def _root_module() -> ModuleType:
+    return importlib.import_module("aionetx")
+
+
 def test_package_root_exports_recommended_entry_points() -> None:
+    aionetx = _root_module()
+
     assert aionetx.AsyncioNetworkFactory is AsyncioNetworkFactory
     assert aionetx.TcpClientSettings is TcpClientSettings
     assert aionetx.TcpServerSettings is TcpServerSettings
@@ -86,6 +85,8 @@ def test_aionetx_api_exports_exception_bases_and_typed_router() -> None:
 
 
 def test_recording_event_handler_is_available_only_from_testing_namespace() -> None:
+    aionetx = _root_module()
+
     from aionetx.testing import RecordingEventHandler
 
     assert RecordingEventHandler.__name__ == "RecordingEventHandler"


### PR DESCRIPTION
## Summary

While expanding lifecycle regression coverage for UDP start/shutdown behavior, several startup-cancellation edge cases showed that the datagram receiver startup path was not explicit enough around the `ConnectionOpenedEvent` transition window.

This PR hardens datagram startup rollback before receive-task ownership is published, adds targeted regression coverage for the affected interleavings, and documents the dispatcher semantics that those lifecycle paths depend on.

## Problems and approach

### 1. Datagram startup cancellation after OPENED publication could leave partial runtime state

Problem:
If cancellation happened after the receiver published `ConnectionOpenedEvent` but before the receive task was assigned, startup rollback could pass through a fragile transition window where socket ownership, dispatcher state, lifecycle state, and receive-task ownership were not tied together tightly enough.

Approach:
Receive-task creation is now kept inside the protected post-publication startup section that verifies lifecycle state before task ownership is published. The rollback path closes detached socket state, stops the dispatcher, and restores terminal lifecycle state when startup is cancelled in that window.

Regression coverage now blocks startup after `ConnectionOpenedEvent` publication and asserts the rollback invariants:

- lifecycle returns to `STOPPED`
- `_socket is None`
- `_task is None`
- dispatcher is no longer running

### 2. BACKGROUND dispatch mode needed equivalent startup rollback coverage

Problem:
The startup cancellation window also matters in BACKGROUND delivery mode, but that mode uses a different event-delivery timing path. Without explicit coverage, regressions could hide behind INLINE-only tests.

Approach:
A BACKGROUND-mode regression test now blocks `ConnectionOpenedEvent` publication, cancels `start()` in that same transition window, and asserts the same rollback invariants. This keeps the datagram startup contract covered for the dispatch mode that remains active on Python 3.10.

### 3. Inline caller-cancellation semantics needed an explicit Python-version boundary

Problem:
Inline event dispatch runs the handler directly on the dispatching task because transport self-stop guards depend on `asyncio.current_task()` identity. On Python 3.11+, `Task.cancelling()` lets the dispatcher distinguish caller cancellation from a handler-raised `CancelledError`.

On Python 3.10, that distinction is not reliable: `Task.cancelling()` is unavailable, and `_must_cancel` is reset before the dispatcher observes the `CancelledError`. A child-task/shield implementation was rejected because it changes handler task identity and breaks existing stop/re-entry contracts.

Approach:
The dispatcher now keeps direct inline handler execution and uses the existing cancellation-state helper where the runtime can provide reliable cancellation state. The limitation is documented directly in `_emit_now()`, and the inline caller-cancellation tests are active on Python 3.11+ while explicitly skipped on Python 3.10 with the runtime reason stated in the test.

### 4. BACKGROUND emit completion semantics needed contract coverage

Problem:
BACKGROUND dispatch relies on queue-based semantics: `emit()` should return after queueing and should not wait for user-handler completion in steady state. That behavior affects shutdown and cancellation timing, but it was not directly locked down.

Approach:
A dispatcher contract test now proves that BACKGROUND `emit()` returns while handler work is still in flight on the worker task. The dispatcher docstring was updated to make that behavior explicit for future maintainers.

## Changes

- Harden datagram startup rollback before receive-task ownership is published.
- Add regression coverage for cancellation after `ConnectionOpenedEvent` publication.
- Add BACKGROUND-mode coverage for the same datagram startup rollback window.
- Preserve inline handler task identity while documenting Python 3.10 cancellation-detection limits.
- Add Python 3.11+ inline caller-cancellation regression coverage.
- Add explicit BACKGROUND emit completion contract coverage.
- Document BACKGROUND emit and inline cancellation semantics in dispatcher code comments/docstrings.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed: this is lifecycle hardening and regression coverage without public API changes.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Dispatcher runtime semantics are documented in the code-level dispatcher contract.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface changes introduced.
