### PR TITLE
breaking-change(python): drop Python 3.10 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,6 @@ body:
       label: Python version
       description: If the bug is specific to a version, note it here; otherwise pick the one you reproduced with.
       options:
-        - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -132,7 +132,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -168,7 +168,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -189,7 +189,7 @@ jobs:
     needs: [required_behavior_tests]
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -210,7 +210,7 @@ jobs:
     needs: [required_behavior_tests]
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -230,7 +230,7 @@ jobs:
     needs: [required_behavior_tests]
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -250,7 +250,7 @@ jobs:
     needs: [required_behavior_tests]
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -310,7 +310,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -210,7 +210,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -230,7 +230,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -250,7 +250,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -310,7 +310,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -392,7 +392,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Capture deterministic build timestamp
         id: build_epoch
@@ -419,7 +419,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Capture deterministic build timestamp
         id: build_epoch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ Planned contents for the initial public alpha release (`0.1.0`).
 - bounded TCP send flushes with configurable per-connection send timeouts
 - optional TCP client reconnect and heartbeat support
 - tests, examples, typing metadata, and CI/release verification gates
+
+### Changed
+
+- require Python 3.11 or newer for the initial public alpha release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aionetx
 
 [![CI](https://img.shields.io/github/actions/workflow/status/MarcusKorinth/aionetx/ci.yml?branch=main&label=ci)](https://github.com/MarcusKorinth/aionetx/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/MarcusKorinth/aionetx/blob/main/pyproject.toml)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/MarcusKorinth/aionetx/blob/main/pyproject.toml)
 [![Coverage gate](https://img.shields.io/badge/coverage%20gate-%E2%89%A585%25-brightgreen)](https://github.com/MarcusKorinth/aionetx/blob/main/.github/workflows/ci.yml)
 [![Typing](https://img.shields.io/badge/typing-py.typed-blueviolet)](https://github.com/MarcusKorinth/aionetx/blob/main/src/aionetx/py.typed)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)

--- a/docs/platform_notes.md
+++ b/docs/platform_notes.md
@@ -49,8 +49,8 @@ aionetx's UDP receive and send paths prefer the event loop's
 `sock_recvfrom()` / `sock_sendto()` awaitables, which deliver non-blocking
 socket I/O integrated with the selector. These APIs are available on
 `asyncio.SelectorEventLoop` (the default on Linux and macOS). On Windows,
-Python 3.8+ defaults to `asyncio.ProactorEventLoop`, which does **not**
-expose `sock_recvfrom()` / `sock_sendto()`.
+supported Python versions default to `asyncio.ProactorEventLoop`, which
+does **not** expose `sock_recvfrom()` / `sock_sendto()`.
 
 ### Fallback behaviour
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Reusable raw-byte network layer for TCP, UDP sender/receiver, and multicast"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "Marcus Korinth"},
 ]
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -46,7 +45,6 @@ dev = [
     "coverage>=7.0",
     "ruff>=0.5",
     "mypy>=1.10",
-    "tomli>=2.0; python_version < '3.11'",
 ]
 dev-hypothesis = [
     "aionetx[dev]",
@@ -85,10 +83,10 @@ markers = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 packages = ["aionetx"]
 mypy_path = "src"

--- a/scripts/ci/validate_release_provenance.py
+++ b/scripts/ci/validate_release_provenance.py
@@ -3,26 +3,13 @@ from __future__ import annotations
 import os
 import pathlib
 import re
-
-try:
-    import tomllib
-except ModuleNotFoundError:
-    try:
-        import tomli as tomllib
-    except ModuleNotFoundError:
-        tomllib = None
+import tomllib
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[a-zA-Z0-9.\-+]+)?$")
 
 
 def read_pyproject_version(pyproject_path: pathlib.Path = pathlib.Path("pyproject.toml")) -> str:
-    if tomllib is None:
-        raise RuntimeError(
-            "validate_release_provenance.py requires the stdlib tomllib module or the "
-            "'tomli' backport to parse pyproject.toml. Use Python 3.11+ or install "
-            "'tomli' when running on Python 3.10."
-        )
     with pyproject_path.open("rb") as fh:
         data = tomllib.load(fh)
     try:

--- a/src/aionetx/implementations/asyncio_impl/_tcp_connection_helpers.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_connection_helpers.py
@@ -37,8 +37,7 @@ async def await_read_task_shutdown(
         await asyncio.wait_for(read_task, timeout=timeout_seconds)
     except asyncio.CancelledError:
         current_task = asyncio.current_task()
-        cancelling = getattr(current_task, "cancelling", None)
-        if current_task is not None and callable(cancelling) and cancelling():
+        if current_task is not None and current_task.cancelling():
             raise
     except TimeoutError:
         if warning_limiter.should_log(f"tcp-connection-read-task-timeout:{connection_id}"):

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -435,15 +435,10 @@ class AsyncioEventDispatcher:
         event callback.
 
         Caller cancellation propagation versus handler-raised
-        ``CancelledError``: on Python 3.11+ the distinction is decided
-        reliably via ``Task.cancelling()``.  On Python 3.10 ``Task.cancelling``
-        is unavailable and ``Task._must_cancel`` is reset before the
-        ``except`` block runs, so caller cancellation that arrives while the
-        handler is awaiting cannot be told apart from a handler-raised
-        ``CancelledError``; in that case the dispatcher conservatively treats
-        the cancellation as a handler failure.  The two regression tests that
-        exercise inline caller-cancellation propagation are skipped on 3.10
-        for the same reason.
+        ``CancelledError`` is decided via ``Task.cancelling()`` on the
+        dispatching task.  That keeps true caller cancellation observable
+        while still routing handler-originated ``CancelledError`` through the
+        configured handler-failure policy.
         """
         self._handler_dispatch_attempts_total += 1
         try:

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -161,15 +161,10 @@ async def await_task_completion_preserving_cancellation(task: asyncio.Task[objec
             break
         except asyncio.CancelledError:
             current_task = asyncio.current_task()
-            cancelling = getattr(current_task, "cancelling", None)
-            if (
-                current_task is not None and callable(cancelling) and cancelling()
-            ) or not task.done():
+            if current_task is not None and current_task.cancelling():
                 caller_cancelled = True
                 # Keep awaiting the shielded child task so repeated caller
-                # cancellations cannot detach the internal cleanup task.  The
-                # ``not task.done()`` fallback preserves this contract on
-                # Python 3.10, where Task.cancelling() is unavailable.
+                # cancellations cannot detach the internal cleanup task.
                 if task.done():
                     break
                 continue
@@ -181,29 +176,11 @@ async def await_task_completion_preserving_cancellation(task: asyncio.Task[objec
 
 
 def is_task_being_cancelled(task: asyncio.Task[object] | None = None) -> bool:
-    """
-    Return whether the provided task currently has cancellation in progress.
-
-    The check supports ``Task.cancelling()`` where available and falls back to
-    CPython's private ``_must_cancel`` counter on runtimes that do not expose
-    the public method.
-    """
+    """Return whether the provided task currently has cancellation in progress."""
     current_task = task if task is not None else asyncio.current_task()
     if current_task is None:
         return False
-
-    task_cancelling = getattr(current_task, "cancelling", None)
-    if callable(task_cancelling):
-        try:
-            return bool(task_cancelling())
-        except (TypeError, RuntimeError):
-            pass
-
-    pending_cancel_count = getattr(current_task, "_must_cancel", None)
-    if isinstance(pending_cancel_count, int):
-        return pending_cancel_count > 0
-
-    return False
+    return bool(current_task.cancelling())
 
 
 def validate_async_event_handler(event_handler: NetworkEventHandlerProtocol) -> None:

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -13,7 +13,6 @@ import asyncio
 import contextlib
 import logging
 import socket
-import sys
 
 import pytest
 
@@ -192,18 +191,6 @@ async def test_udp_receiver_opened_handler_failure_rolls_back_runtime_resources(
     assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason=(
-        "Python 3.10 lacks Task.cancelling() and resets Task._must_cancel "
-        "before the dispatcher's except block observes the CancelledError, "
-        "so start_task.cancel() during inline ConnectionOpenedEvent "
-        "publication cannot be reliably distinguished from a handler-raised "
-        "CancelledError without changing handler task identity, which the "
-        "receiver self-stop guards rely on.  The BACKGROUND-mode variant of "
-        "this regression is covered below and remains active on 3.10."
-    ),
-)
 @pytest.mark.asyncio
 async def test_udp_receiver_startup_cancellation_after_opened_event_rolls_back_before_task_creation() -> (
     None

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 
 import pytest
 
@@ -1735,18 +1734,6 @@ async def test_handler_cancelled_error_is_treated_as_handler_failure() -> None:
     ]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason=(
-        "Python 3.10 lacks Task.cancelling() and resets Task._must_cancel "
-        "before the dispatcher's except block observes the CancelledError, "
-        "so caller cancellation that arrives while the inline handler is "
-        "awaiting cannot be reliably distinguished from a handler-raised "
-        "CancelledError without changing handler task identity, which the "
-        "transport self-stop guards rely on.  The dispatcher conservatively "
-        "treats this CancelledError as a handler failure on 3.10."
-    ),
-)
 @pytest.mark.asyncio
 async def test_inline_dispatcher_caller_cancellation_propagates() -> None:
     start_blocked = asyncio.Event()

--- a/tests/unit/test_runtime_utils.py
+++ b/tests/unit/test_runtime_utils.py
@@ -4,16 +4,13 @@ import asyncio
 
 import pytest
 
-from aionetx.implementations.asyncio_impl import runtime_utils as runtime_utils_module
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
 from tests.internal_asyncio_impl_refs import await_task_completion_preserving_cancellation
 
 
 @pytest.mark.asyncio
-async def test_task_await_helper_preserves_caller_cancellation_without_task_cancelling(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_task_await_helper_preserves_caller_cancellation_until_child_settles() -> None:
     child_cancel_seen = asyncio.Event()
     release_child = asyncio.Event()
 
@@ -35,14 +32,6 @@ async def test_task_await_helper_preserves_caller_cancellation_without_task_canc
     try:
         await asyncio.wait_for(child_cancel_seen.wait(), timeout=1.0)
 
-        class _CurrentTaskWithoutCancelling:
-            pass
-
-        monkeypatch.setattr(
-            runtime_utils_module.asyncio,
-            "current_task",
-            lambda: _CurrentTaskWithoutCancelling(),
-        )
         awaiter_task.cancel()
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary

This PR intentionally raises aionetx's Python support floor from Python 3.10 to Python 3.11.

This is a support-policy decision: aionetx's core value proposition is deterministic asyncio lifecycle behavior, especially around startup, shutdown, event delivery, and cancellation. Supporting Python 3.10 would require carrying runtime-specific compatibility code and test skips in exactly those cancellation paths. For the initial public alpha, the cleaner and safer trade-off is to support Python versions where the lifecycle contract can be implemented and tested consistently.

## Why drop Python 3.10?

aionetx relies on distinguishing two very different situations:

- the caller cancelled the transport operation and cancellation must propagate;
- user handler code raised `asyncio.CancelledError` internally and should be handled through the configured event-handler failure policy.

That distinction matters in several core paths:

- `AsyncioEventDispatcher._emit_now()` catches `asyncio.CancelledError` from inline event handlers and must decide whether to re-raise caller cancellation or route a handler-originated cancellation through handler-failure policy.
- `await_task_completion_preserving_cancellation()` waits for internal cleanup tasks to settle without swallowing caller cancellation or detaching child cleanup.
- `await_read_task_shutdown()` tolerates expected read-task cancellation during TCP close, but must still propagate cancellation of the caller performing the close.

On Python 3.11+, these decisions can rely on the public `Task.cancelling()` state. On Python 3.10, keeping equivalent behavior would require one of the following compromises:

- private or best-effort task-state introspection;
- runtime-specific fallback behavior;
- skipped regression tests for inline cancellation behavior;
- a broader architectural workaround, such as dispatching handlers through child tasks and carrying logical task identity across shutdown guards.

Those options all add complexity near the most sensitive part of the library: async lifecycle and cancellation correctness.

## Why this trade-off is worth it

The downside is straightforward: users still on Python 3.10 cannot install or run aionetx releases after this support-floor change.

The upside is also important:

- the public support statement matches the behavior we can reliably test;
- cancellation code no longer needs Python-version-specific shims;
- CI no longer spends time validating an unsupported runtime;
- regression tests for inline cancellation can run on every supported Python version;
- runtime code can use public Python 3.11+ asyncio semantics instead of compatibility heuristics;
- the initial public alpha starts with a smaller and more honest support surface.

For a general-purpose utility package, keeping Python 3.10 might be worth the complexity. For a transport library whose central promise is lifecycle correctness under cancellation, the extra compatibility layer would weaken the part of the project we most need to keep simple and trustworthy.

## What changed

- Package metadata now requires Python 3.11 or newer.
- Python 3.10 was removed from package classifiers.
- Ruff and mypy target versions now align with Python 3.11.
- The Python `<3.11` `tomli` development dependency was removed.
- The README Python support badge now advertises Python 3.11 through 3.14.
- CI and release matrices now test Python 3.11 through 3.14.
- Lower-bound CI coverage moved to Python 3.11.
- The bug report issue template no longer offers Python 3.10.
- Python 3.10-specific cancellation test skips were removed.
- Runtime cancellation helpers now rely directly on supported Python `Task.cancelling()` behavior.
- Release provenance parsing now uses stdlib `tomllib`.
- Windows platform notes were reworded to avoid unsupported-version lower-bound wording.
- `CHANGELOG.md` documents the Python 3.11 support floor for the initial public alpha.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable; no public API symbols changed.