### PR TITLE
chore(github): add infrastructure issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,0 +1,76 @@
+name: Infrastructure / maintenance
+description: Propose a change to CI, build tooling, linting, packaging, developer workflow, project configuration, or general housekeeping.
+title: "[infra] "
+labels: ["infrastructure", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for improvements to developer infrastructure, project tooling, and general maintenance: CI pipelines, linters, formatters, Makefiles, packaging metadata, test configuration, documentation builds, dependency updates, repository housekeeping, and similar concerns.
+
+        If your proposal changes **transport runtime behavior** (lifecycle, events, backpressure, reconnect, multicast), please use the [Feature request](https://github.com/MarcusKorinth/aionetx/issues/new?template=feature_request.yml) template instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What friction, gap, or risk does this address? Describe the current pain point.
+      placeholder: e.g. "There is no way to run the full lint + type-check + test suite in one command without remembering three separate invocations."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What specifically should change? Include tool names, configuration snippets, or CI job definitions where helpful.
+      render: yaml
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this touch?
+      multiple: true
+      options:
+        - CI / GitHub Actions
+        - Linting / formatting
+        - Type checking
+        - Test configuration / fixtures
+        - Packaging / pyproject.toml
+        - Dependency management
+        - Makefile / task runner
+        - Documentation build
+        - Developer environment setup
+        - Repository housekeeping (dead code, typos, license headers, etc.)
+        - Other (please specify below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Considered alternatives
+      description: Other approaches you weighed and why you prefer the proposal above.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to relevant tool documentation, related issues, or examples from other projects.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: I have searched existing issues and confirmed this is not already proposed.
+          required: true
+        - label: This proposal concerns project infrastructure, tooling, or maintenance, not transport runtime behavior.
+          required: true

--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -24,7 +24,6 @@ body:
     attributes:
       label: Proposed change
       description: What specifically should change? Include tool names, configuration snippets, or CI job definitions where helpful.
-      render: yaml
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

Add a dedicated issue template for infrastructure, tooling, and maintenance proposals so contributors can propose repository upkeep without using the transport runtime feature-request template.

## Changes

- Add `.github/ISSUE_TEMPLATE/infrastructure.yml`.
- Cover CI, linting/formatting, type checking, test configuration, packaging, dependency management, developer setup, documentation builds, and repository housekeeping.
- Keep the proposed-change field neutral so it works for prose, shell commands, TOML, YAML, and other maintenance details.

## Related issue

Relates to #11.

## Checklist

- [ ] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
  - Remaining blocker: the original contributor commit still needs a DCO sign-off from the original author.
- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed).
  - Not needed: issue-template-only change; YAML syntax/content validated locally.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed: repository issue-template maintenance only.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not applicable: no public runtime contract changes.
- [ ] `ruff check .` passes locally.
  - Not run for this issue-template-only change.
- [ ] `mypy src` passes locally.
  - Not run for this issue-template-only change.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API changes.