### PR TITLE
fix(events): preserve lifecycle dispatch ordering

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -73,6 +73,13 @@ class DispatcherRuntimeStats:
     queue_peak: int
 
 
+@dataclass(slots=True)
+class _QueuedEvent:
+    event: NetworkEvent
+    handled: asyncio.Future[None] | None = None
+    drop_on_backpressure: bool = True
+
+
 @dataclass(frozen=True, slots=True)
 class DispatcherStopPolicy:
     """
@@ -167,7 +174,7 @@ class AsyncioEventDispatcher:
         self._stop_policy_enabled = stop_policy.enabled
         self._stop_component_callback = stop_policy.callback
         self._worker_task: asyncio.Task[None] | None = None
-        self._queue: deque[NetworkEvent] = deque()
+        self._queue: deque[_QueuedEvent] = deque()
         self._queue_not_empty = asyncio.Condition()
         self._queue_not_full = asyncio.Condition()
         self._stopping = False
@@ -262,9 +269,11 @@ class AsyncioEventDispatcher:
         # it must not await the worker it is currently unwinding.
         if current_task is worker_task:
             self._dropped_stop_phase_total += len(self._queue)
+            for queued_event in self._queue:
+                self._drop_queued_event(queued_event, reason="dropped because dispatcher stopped")
             self._queue.clear()
             return
-        _ = await cast(Awaitable[object], worker_task)
+        _ = await asyncio.shield(cast(Awaitable[object], worker_task))
 
     async def emit(self, event: NetworkEvent) -> None:
         """
@@ -301,22 +310,83 @@ class AsyncioEventDispatcher:
             self._inline_fallback_total += 1
             await self._emit_now(event)
             return
-        await self._enqueue(event)
+        await self._enqueue(_QueuedEvent(event=event))
 
-    async def _enqueue(self, event: NetworkEvent) -> None:
+    async def emit_and_wait(
+        self, event: NetworkEvent, *, drop_on_backpressure: bool = True
+    ) -> None:
+        """
+        Emit an event and wait until handler execution has completed.
+
+        This preserves normal ``emit()`` behavior for callers that only need
+        queue acceptance, while giving lifecycle-sensitive transports a narrow
+        internal hook for event-completion barriers.
+        """
+        self._emit_calls_total += 1
+        if self._delivery.dispatch_mode == EventDispatchMode.INLINE:
+            await self._emit_now(event)
+            return
+        if self._is_in_inline_dispatch_context():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        if not self._accepting_background_events():
+            self._record_stop_phase_drop(event)
+            raise RuntimeError("Queued event was dropped because dispatcher stopped.")
+        if self.current_task_is_worker():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        if not self._has_background_worker():
+            self._inline_fallback_total += 1
+            await self._emit_now(event)
+            return
+        current_task = asyncio.current_task()
+        worker_task = cast(asyncio.Task[None], self._worker_task)
+        loop = current_task.get_loop() if current_task is not None else worker_task.get_loop()
+        handled = loop.create_future()
+        await self._enqueue(
+            _QueuedEvent(
+                event=event,
+                handled=handled,
+                drop_on_backpressure=drop_on_backpressure,
+            )
+        )
+        caller_cancelled = False
+        while True:
+            try:
+                await asyncio.shield(handled)
+                break
+            except asyncio.CancelledError:
+                caller_cancelled = True
+                if handled.done():
+                    break
+                continue
+        if handled.cancelled():
+            raise asyncio.CancelledError
+        if error := handled.exception():
+            raise error
+        if caller_cancelled:
+            raise asyncio.CancelledError
+
+    async def _enqueue(self, queued_event: _QueuedEvent) -> None:
         """
         Queue one event for background delivery under backpressure rules.
 
         The method keeps shutdown predictable: once stop begins, blocked
         producers are released and no additional background work is accepted.
         """
+        event = queued_event.event
         while True:
             async with self._queue_not_full:
                 if not self._accepting_background_events():
                     self._record_stop_phase_drop(event)
+                    self._drop_queued_event(
+                        queued_event, reason="dropped because dispatcher stopped"
+                    )
                     return
                 if len(self._queue) < self._delivery.max_pending_events:
-                    self._queue.append(event)
+                    self._queue.append(queued_event)
                     self._enqueued_total += 1
                     self._queue_peak = max(self._queue_peak, len(self._queue))
                     break
@@ -325,15 +395,37 @@ class AsyncioEventDispatcher:
                     await self._queue_not_full.wait()
                     continue
                 if policy == EventBackpressurePolicy.DROP_OLDEST:
-                    self._queue.popleft()
-                    self._queue.append(event)
+                    droppable_index = next(
+                        (
+                            index
+                            for index, pending in enumerate(self._queue)
+                            if pending.drop_on_backpressure
+                        ),
+                        None,
+                    )
+                    if droppable_index is None:
+                        if not queued_event.drop_on_backpressure:
+                            await self._queue_not_full.wait()
+                            continue
+                        self._dropped_backpressure_newest_total += 1
+                        self._warn_backpressure_drop(policy=EventBackpressurePolicy.DROP_NEWEST)
+                        self._drop_queued_event(queued_event, reason="dropped by backpressure")
+                        return
+                    dropped_event = self._queue[droppable_index]
+                    del self._queue[droppable_index]
+                    self._drop_queued_event(dropped_event, reason="dropped by backpressure")
+                    self._queue.append(queued_event)
                     self._dropped_backpressure_oldest_total += 1
                     self._enqueued_total += 1
                     self._queue_peak = max(self._queue_peak, len(self._queue))
                     self._warn_backpressure_drop(policy=policy)
                     break
+                if not queued_event.drop_on_backpressure:
+                    await self._queue_not_full.wait()
+                    continue
                 self._dropped_backpressure_newest_total += 1
                 self._warn_backpressure_drop(policy=policy)
+                self._drop_queued_event(queued_event, reason="dropped by backpressure")
                 return
 
         async with self._queue_not_empty:
@@ -407,23 +499,54 @@ class AsyncioEventDispatcher:
     async def _run(self) -> None:
         """Drain the background queue until shutdown begins and queued work is exhausted."""
         current_task = asyncio.current_task()
+        termination_error: BaseException | None = None
         try:
             while True:
-                event: NetworkEvent | None = None
+                queued_event: _QueuedEvent | None = None
                 async with self._queue_not_empty:
                     while not self._queue and not self._stopping:
                         await self._queue_not_empty.wait()
                     if self._stopping and not self._queue:
                         return
                     if self._queue:
-                        event = self._queue.popleft()
+                        queued_event = self._queue.popleft()
                 async with self._queue_not_full:
                     self._queue_not_full.notify()
-                if event is not None:
-                    await self._emit_now(event)
+                if queued_event is not None:
+                    try:
+                        await self._emit_now(queued_event.event)
+                    except BaseException as delivery_error:
+                        termination_error = delivery_error
+                        self._fail_queued_event(queued_event, delivery_error)
+                        raise
+                    else:
+                        self._complete_queued_event(queued_event)
         finally:
+            if self._queue:
+                pending_error = termination_error or asyncio.CancelledError()
+                for queued_event in self._queue:
+                    self._fail_queued_event(queued_event, pending_error)
+                self._queue.clear()
             if self._worker_task is current_task:
                 self._worker_task = None
+
+    def _complete_queued_event(self, queued_event: _QueuedEvent) -> None:
+        """Wake an emit-and-wait caller after successful handling or intentional drop."""
+        handled = queued_event.handled
+        if handled is not None and not handled.done():
+            handled.set_result(None)
+
+    def _drop_queued_event(self, queued_event: _QueuedEvent, *, reason: str) -> None:
+        """Wake an emit-and-wait caller when its barrier event was dropped."""
+        handled = queued_event.handled
+        if handled is not None and not handled.done():
+            handled.set_exception(RuntimeError(f"Queued event was {reason}."))
+
+    def _fail_queued_event(self, queued_event: _QueuedEvent, error: BaseException) -> None:
+        """Wake an emit-and-wait caller when worker delivery fails unexpectedly."""
+        handled = queued_event.handled
+        if handled is not None and not handled.done():
+            handled.set_exception(error)
 
     async def _emit_now(self, event: NetworkEvent) -> None:
         """Deliver one event to the handler and route failures through policy handling.

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import cast
 
+from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.event_delivery_settings import (
     EventBackpressurePolicy,
     EventDeliverySettings,
@@ -34,8 +35,17 @@ from aionetx.implementations.asyncio_impl.runtime_utils import (
 
 _stop_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
 _backpressure_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
-_inline_dispatcher_context: contextvars.ContextVar[frozenset[int]] = contextvars.ContextVar(
-    "aionetx_inline_dispatcher_context", default=frozenset()
+_inline_dispatcher_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
+    contextvars.ContextVar("aionetx_inline_dispatcher_context", default=frozenset())
+)
+_stop_await_bypass_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
+    contextvars.ContextVar("aionetx_stop_await_bypass_context", default=frozenset())
+)
+_handler_dispatch_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
+    contextvars.ContextVar("aionetx_handler_dispatch_context", default=frozenset())
+)
+_handler_origin_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
+    contextvars.ContextVar("aionetx_handler_origin_context", default=frozenset())
 )
 
 
@@ -187,6 +197,16 @@ class AsyncioEventDispatcher:
         self._dropped_backpressure_newest_total = 0
         self._dropped_stop_phase_total = 0
         self._queue_peak = 0
+        self._active_inline_delivery_tokens: set[int] = set()
+        self._next_inline_delivery_token = 0
+        self._active_handler_origin_tokens: set[int] = set()
+        self._active_handler_origin_resources: dict[int, str | None] = {}
+        self._active_handler_origin_owner_tasks: dict[int, int | None] = {}
+        self._active_handler_origin_child_provenance_tokens: set[int] = set()
+        self._next_handler_origin_token = 0
+        self._active_stop_await_bypass_tokens: set[int] = set()
+        self._active_stop_await_bypass_owner_tasks: dict[int, int] = {}
+        self._next_stop_await_bypass_token = 0
 
     def _has_background_worker(self) -> bool:
         return self._worker_task is not None
@@ -267,13 +287,18 @@ class AsyncioEventDispatcher:
         # In background mode, handlers run on the worker task. If a handler
         # triggers component shutdown, stop() may execute on that same task, so
         # it must not await the worker it is currently unwinding.
-        if current_task is worker_task:
+        if current_task is worker_task or self._is_in_stop_await_bypass_context():
             self._dropped_stop_phase_total += len(self._queue)
             for queued_event in self._queue:
                 self._drop_queued_event(queued_event, reason="dropped because dispatcher stopped")
             self._queue.clear()
             return
         _ = await asyncio.shield(cast(Awaitable[object], worker_task))
+
+    async def stop_from_handler_origin(self) -> None:
+        """Begin dispatcher stop without awaiting the active handler worker."""
+        with self._stop_await_bypass_context():
+            await self.stop()
 
     async def emit(self, event: NetworkEvent) -> None:
         """
@@ -369,6 +394,30 @@ class AsyncioEventDispatcher:
         if caller_cancelled:
             raise asyncio.CancelledError
 
+    async def drop_queued_events_for_resource(self, resource_id: str) -> int:
+        """Drop queued payload events for one resource and release any waiters."""
+        dropped_events: list[_QueuedEvent] = []
+        kept_events: deque[_QueuedEvent] = deque()
+        for queued_event in self._queue:
+            if (
+                isinstance(queued_event.event, BytesReceivedEvent)
+                and queued_event.event.resource_id == resource_id
+            ):
+                dropped_events.append(queued_event)
+            else:
+                kept_events.append(queued_event)
+        if not dropped_events:
+            return 0
+        self._queue = kept_events
+        self._dropped_stop_phase_total += len(dropped_events)
+        for queued_event in dropped_events:
+            self._drop_queued_event(
+                queued_event, reason=f"dropped because resource {resource_id} closed"
+            )
+        async with self._queue_not_full:
+            self._queue_not_full.notify_all()
+        return len(dropped_events)
+
     async def _enqueue(self, queued_event: _QueuedEvent) -> None:
         """
         Queue one event for background delivery under backpressure rules.
@@ -460,7 +509,193 @@ class AsyncioEventDispatcher:
         those tasks, so this lets terminal internal events avoid re-entering the
         same background queue that the initiating handler is currently blocking.
         """
-        return id(self) in _inline_dispatcher_context.get()
+        dispatcher_id = id(self)
+        return any(
+            origin_dispatcher_id == dispatcher_id
+            and origin_token in self._active_inline_delivery_tokens
+            for origin_dispatcher_id, origin_token in _inline_dispatcher_context.get()
+        )
+
+    def current_task_has_inline_delivery_context(self) -> bool:
+        """
+        Return whether the caller inherited this dispatcher's inline-delivery context.
+
+        This is used by shutdown helper tasks created from handler-originated
+        stop paths. They are not the dispatcher worker task, but they must still
+        avoid queueing terminal events behind the handler currently unwinding.
+        """
+        return self._is_in_inline_dispatch_context()
+
+    def current_task_is_dispatching_handler(self, resource_id: str | None = None) -> bool:
+        """Return whether the current task is directly running this dispatcher's handler."""
+        current_task = asyncio.current_task()
+        if current_task is None:
+            return False
+        if (id(self), id(current_task)) not in _handler_dispatch_context.get():
+            return False
+        if resource_id is None:
+            return True
+        return self.current_task_has_handler_origin_context(resource_id)
+
+    def current_task_has_handler_origin_context(self, resource_id: str | None = None) -> bool:
+        """Return whether this task was created from this dispatcher's handler context."""
+        current_task = asyncio.current_task()
+        if current_task is None:
+            return False
+        current_task_id = id(current_task)
+        dispatcher_id = id(self)
+        return any(
+            origin_dispatcher_id == dispatcher_id
+            and origin_token in self._active_handler_origin_tokens
+            and (
+                self._active_handler_origin_owner_tasks.get(origin_token) is None
+                or self._active_handler_origin_owner_tasks.get(origin_token) == current_task_id
+            )
+            and (
+                resource_id is None
+                or self._active_handler_origin_resources.get(origin_token) == resource_id
+            )
+            for origin_dispatcher_id, origin_token in _handler_origin_context.get()
+        )
+
+    def current_task_inherits_handler_origin_context(self, resource_id: str | None = None) -> bool:
+        """
+        Return whether the caller carries handler-origin provenance.
+
+        Unlike ``current_task_has_handler_origin_context()``, this method does
+        not grant handler-origin authority. It exists only for deadlock
+        avoidance when a user handler spawns and awaits a child task before
+        returning.
+        """
+        current_task = asyncio.current_task()
+        if current_task is None:
+            return False
+        current_task_id = id(current_task)
+        dispatcher_id = id(self)
+        return any(
+            origin_dispatcher_id == dispatcher_id
+            and origin_token in self._active_handler_origin_tokens
+            and (
+                origin_token in self._active_handler_origin_child_provenance_tokens
+                or self._active_handler_origin_owner_tasks.get(origin_token) == current_task_id
+            )
+            and (
+                resource_id is None
+                or self._active_handler_origin_resources.get(origin_token) == resource_id
+            )
+            for origin_dispatcher_id, origin_token in _handler_origin_context.get()
+        )
+
+    def has_active_handler_context(self, resource_id: str | None = None) -> bool:
+        """Return whether this dispatcher currently has an active handler barrier."""
+        if resource_id is None:
+            return bool(self._active_handler_origin_tokens)
+        return any(
+            active_resource_id == resource_id
+            for active_resource_id in self._active_handler_origin_resources.values()
+        )
+
+    def has_active_handler_origin(self) -> bool:
+        """Return whether this dispatcher currently has an active handler-origin barrier."""
+        return self.has_active_handler_context()
+
+    def current_task_would_deliver_inline(self) -> bool:
+        """Return whether emit() from this task would invoke the handler inline."""
+        return (
+            self._delivery.dispatch_mode == EventDispatchMode.INLINE
+            or self._is_in_inline_dispatch_context()
+            or self.current_task_is_worker()
+            or not self._has_background_worker()
+        )
+
+    @contextmanager
+    def _handler_dispatch_context(self, resource_id: str | None) -> Iterator[None]:
+        """Mark the current task as directly executing this dispatcher's handler."""
+        current_task = asyncio.current_task()
+        if current_task is None:
+            yield
+            return
+        self._next_handler_origin_token += 1
+        origin_token = self._next_handler_origin_token
+        self._active_handler_origin_tokens.add(origin_token)
+        self._active_handler_origin_resources[origin_token] = resource_id
+        self._active_handler_origin_owner_tasks[origin_token] = id(current_task)
+        self._active_handler_origin_child_provenance_tokens.add(origin_token)
+        active_handlers = _handler_dispatch_context.get()
+        active_handler_origins = _handler_origin_context.get()
+        reset_token = _handler_dispatch_context.set(
+            active_handlers | {(id(self), id(current_task))}
+        )
+        origin_reset_token = _handler_origin_context.set(
+            active_handler_origins | {(id(self), origin_token)}
+        )
+        try:
+            yield
+        finally:
+            self._active_handler_origin_tokens.discard(origin_token)
+            self._active_handler_origin_resources.pop(origin_token, None)
+            self._active_handler_origin_owner_tasks.pop(origin_token, None)
+            self._active_handler_origin_child_provenance_tokens.discard(origin_token)
+            _handler_dispatch_context.reset(reset_token)
+            _handler_origin_context.reset(origin_reset_token)
+
+    @contextmanager
+    def _handler_origin_context_only(self, resource_id: str | None) -> Iterator[None]:
+        """Mark work as originating from a handler after handler dispatch unwound."""
+        current_task = asyncio.current_task()
+        self._next_handler_origin_token += 1
+        origin_token = self._next_handler_origin_token
+        self._active_handler_origin_tokens.add(origin_token)
+        self._active_handler_origin_resources[origin_token] = resource_id
+        self._active_handler_origin_owner_tasks[origin_token] = (
+            id(current_task) if current_task is not None else None
+        )
+        active_handler_origins = _handler_origin_context.get()
+        origin_reset_token = _handler_origin_context.set(
+            active_handler_origins | {(id(self), origin_token)}
+        )
+        try:
+            yield
+        finally:
+            self._active_handler_origin_tokens.discard(origin_token)
+            self._active_handler_origin_resources.pop(origin_token, None)
+            self._active_handler_origin_owner_tasks.pop(origin_token, None)
+            self._active_handler_origin_child_provenance_tokens.discard(origin_token)
+            _handler_origin_context.reset(origin_reset_token)
+
+    def _is_in_stop_await_bypass_context(self) -> bool:
+        """Return whether the current task has this dispatcher's active stop-bypass token."""
+        current_task = asyncio.current_task()
+        if current_task is None:
+            return False
+        current_task_id = id(current_task)
+        dispatcher_id = id(self)
+        return any(
+            origin_dispatcher_id == dispatcher_id
+            and origin_token in self._active_stop_await_bypass_tokens
+            and self._active_stop_await_bypass_owner_tasks.get(origin_token) == current_task_id
+            for origin_dispatcher_id, origin_token in _stop_await_bypass_context.get()
+        )
+
+    @contextmanager
+    def _stop_await_bypass_context(self) -> Iterator[None]:
+        """Temporarily let a component-owned stop path avoid awaiting the worker."""
+        self._next_stop_await_bypass_token += 1
+        origin_token = self._next_stop_await_bypass_token
+        self._active_stop_await_bypass_tokens.add(origin_token)
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            self._active_stop_await_bypass_owner_tasks[origin_token] = id(current_task)
+        active_bypass_contexts = _stop_await_bypass_context.get()
+        reset_token = _stop_await_bypass_context.set(
+            active_bypass_contexts | {(id(self), origin_token)}
+        )
+        try:
+            yield
+        finally:
+            self._active_stop_await_bypass_tokens.discard(origin_token)
+            self._active_stop_await_bypass_owner_tasks.pop(origin_token, None)
+            _stop_await_bypass_context.reset(reset_token)
 
     @contextmanager
     def inline_delivery_context(self) -> Iterator[None]:
@@ -473,11 +708,17 @@ class AsyncioEventDispatcher:
         leak into user-created tasks through context variable inheritance and
         break normal BACKGROUND queue semantics.
         """
+        self._next_inline_delivery_token += 1
+        origin_token = self._next_inline_delivery_token
+        self._active_inline_delivery_tokens.add(origin_token)
         active_dispatchers = _inline_dispatcher_context.get()
-        reset_token = _inline_dispatcher_context.set(active_dispatchers | {id(self)})
+        reset_token = _inline_dispatcher_context.set(
+            active_dispatchers | {(id(self), origin_token)}
+        )
         try:
             yield
         finally:
+            self._active_inline_delivery_tokens.discard(origin_token)
             _inline_dispatcher_context.reset(reset_token)
 
     def _warn_backpressure_drop(self, *, policy: EventBackpressurePolicy) -> None:
@@ -565,7 +806,8 @@ class AsyncioEventDispatcher:
         """
         self._handler_dispatch_attempts_total += 1
         try:
-            await self._event_handler.on_event(event)
+            with self._handler_dispatch_context(getattr(event, "resource_id", None)):
+                await self._event_handler.on_event(event)
         except asyncio.CancelledError as error:
             if is_task_being_cancelled():
                 raise
@@ -638,8 +880,11 @@ class AsyncioEventDispatcher:
                     dispatch_mode=self._delivery.dispatch_mode,
                 )
             )
-            with self.inline_delivery_context():
-                await stop_callback()
+            with self._stop_await_bypass_context():
+                with self._handler_origin_context_only(
+                    getattr(triggering_event, "resource_id", None)
+                ):
+                    await stop_callback()
             return
         raise RuntimeError(f"Unhandled EventHandlerFailurePolicy: {policy!r}")
 

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -35,8 +35,8 @@ from aionetx.implementations.asyncio_impl.runtime_utils import (
 
 _stop_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
 _backpressure_drop_warning_limiter = WarningRateLimiter(interval_seconds=5.0)
-_inline_dispatcher_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
-    contextvars.ContextVar("aionetx_inline_dispatcher_context", default=frozenset())
+_inline_dispatcher_context: contextvars.ContextVar[frozenset[int]] = contextvars.ContextVar(
+    "aionetx_inline_dispatcher_context", default=frozenset()
 )
 _stop_await_bypass_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
     contextvars.ContextVar("aionetx_stop_await_bypass_context", default=frozenset())
@@ -197,8 +197,6 @@ class AsyncioEventDispatcher:
         self._dropped_backpressure_newest_total = 0
         self._dropped_stop_phase_total = 0
         self._queue_peak = 0
-        self._active_inline_delivery_tokens: set[int] = set()
-        self._next_inline_delivery_token = 0
         self._active_handler_origin_tokens: set[int] = set()
         self._active_handler_origin_resources: dict[int, str | None] = {}
         self._active_handler_origin_owner_tasks: dict[int, int | None] = {}
@@ -509,12 +507,7 @@ class AsyncioEventDispatcher:
         those tasks, so this lets terminal internal events avoid re-entering the
         same background queue that the initiating handler is currently blocking.
         """
-        dispatcher_id = id(self)
-        return any(
-            origin_dispatcher_id == dispatcher_id
-            and origin_token in self._active_inline_delivery_tokens
-            for origin_dispatcher_id, origin_token in _inline_dispatcher_context.get()
-        )
+        return id(self) in _inline_dispatcher_context.get()
 
     def current_task_has_inline_delivery_context(self) -> bool:
         """
@@ -708,17 +701,11 @@ class AsyncioEventDispatcher:
         leak into user-created tasks through context variable inheritance and
         break normal BACKGROUND queue semantics.
         """
-        self._next_inline_delivery_token += 1
-        origin_token = self._next_inline_delivery_token
-        self._active_inline_delivery_tokens.add(origin_token)
         active_dispatchers = _inline_dispatcher_context.get()
-        reset_token = _inline_dispatcher_context.set(
-            active_dispatchers | {(id(self), origin_token)}
-        )
+        reset_token = _inline_dispatcher_context.set(active_dispatchers | {id(self)})
         try:
             yield
         finally:
-            self._active_inline_delivery_tokens.discard(origin_token)
             _inline_dispatcher_context.reset(reset_token)
 
     def _warn_backpressure_drop(self, *, policy: EventBackpressurePolicy) -> None:

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -336,7 +336,7 @@ async def test_handler_origin_context_is_not_inherited_by_child_tasks() -> None:
 
 
 @pytest.mark.asyncio
-async def test_inline_delivery_context_expires_for_tasks_spawned_inside_context() -> None:
+async def test_inline_delivery_context_is_inherited_by_tasks_spawned_inside_context() -> None:
     context_exited = asyncio.Event()
     observed_inline_context: list[bool] = []
 
@@ -364,7 +364,7 @@ async def test_inline_delivery_context_expires_for_tasks_spawned_inside_context(
             with contextlib.suppress(Exception, asyncio.CancelledError):
                 await asyncio.wait_for(child_task, timeout=1.0)
 
-    assert observed_inline_context == [False]
+    assert observed_inline_context == [True]
 
 
 # Backpressure semantics under queue saturation.

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -11,6 +11,7 @@ implementation detail.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 
 import pytest
@@ -33,7 +34,7 @@ from aionetx.implementations.asyncio_impl.event_dispatcher import (
     AsyncioEventDispatcher,
     DispatcherStopPolicy,
 )
-from tests.helpers import assert_awaitable_cancelled
+from tests.helpers import assert_awaitable_cancelled, wait_for_condition
 
 pytestmark = pytest.mark.behavior_critical
 
@@ -118,6 +119,70 @@ async def test_stop_cancels_background_worker_cleanly() -> None:
     await dispatcher.start()
     await dispatcher.emit(_opened(1))
     await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stop_does_not_strand_emit_and_wait_waiters() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+    second_started = asyncio.Event()
+    allow_second_to_finish = asyncio.Event()
+    second_handled = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+            elif event.metadata.connection_id == "c2":
+                second_started.set()
+                await allow_second_to_finish.wait()
+                second_handled.set()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    emit_wait_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        emit_wait_task = asyncio.create_task(dispatcher.emit_and_wait(_opened(2)))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        stop_task = asyncio.create_task(dispatcher.stop())
+        await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+        stop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(stop_task, timeout=1.0)
+
+        allow_first_to_finish.set()
+        await asyncio.wait_for(second_started.wait(), timeout=1.0)
+        assert not emit_wait_task.done()
+        allow_second_to_finish.set()
+        await asyncio.wait_for(emit_wait_task, timeout=1.0)
+        await asyncio.wait_for(second_handled.wait(), timeout=1.0)
+    finally:
+        allow_first_to_finish.set()
+        allow_second_to_finish.set()
+        if emit_wait_task is not None and not emit_wait_task.done():
+            emit_wait_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_wait_task, timeout=1.0)
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
 
 
 @pytest.mark.asyncio
@@ -221,6 +286,362 @@ async def test_drop_oldest_backpressure_policy_keeps_newer_events() -> None:
     await asyncio.wait_for(third_handled.wait(), timeout=1.0)
     await dispatcher.stop()
     assert handler.ids == ["c1", "c3"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "policy",
+    [EventBackpressurePolicy.DROP_NEWEST, EventBackpressurePolicy.DROP_OLDEST],
+)
+async def test_emit_and_wait_raises_when_barrier_event_is_dropped(
+    policy: EventBackpressurePolicy,
+) -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        dispatch_mode=EventDispatchMode.BACKGROUND,
+        max_pending_events=1,
+        backpressure_policy=policy,
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+    emit_wait_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        if policy == EventBackpressurePolicy.DROP_NEWEST:
+            await dispatcher.emit(_opened(2))
+            with pytest.raises(RuntimeError, match="dropped"):
+                await dispatcher.emit_and_wait(_opened(3))
+        else:
+            emit_wait_task = asyncio.create_task(dispatcher.emit_and_wait(_opened(2)))
+            await wait_for_condition(
+                lambda: dispatcher.runtime_stats.queue_depth == 1,
+                timeout_seconds=1.0,
+            )
+            await dispatcher.emit(_opened(3))
+            with pytest.raises(RuntimeError, match="dropped"):
+                await asyncio.wait_for(emit_wait_task, timeout=1.0)
+    finally:
+        allow_first_to_finish.set()
+        if emit_wait_task is not None and not emit_wait_task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_wait_task, timeout=1.0)
+        await dispatcher.stop()
+    if policy == EventBackpressurePolicy.DROP_NEWEST:
+        assert handler.ids == ["c1", "c2"]
+    else:
+        assert handler.ids == ["c1", "c3"]
+
+
+@pytest.mark.asyncio
+async def test_drop_oldest_skips_protected_barrier_events() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=2,
+            backpressure_policy=EventBackpressurePolicy.DROP_OLDEST,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    protected_emit_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        protected_emit_task = asyncio.create_task(
+            dispatcher.emit_and_wait(_opened(2), drop_on_backpressure=False)
+        )
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+        await dispatcher.emit(_opened(3))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 2,
+            timeout_seconds=1.0,
+        )
+
+        await dispatcher.emit(_opened(4))
+        allow_first_to_finish.set()
+        await asyncio.wait_for(protected_emit_task, timeout=1.0)
+        await wait_for_condition(lambda: handler.ids == ["c1", "c2", "c4"])
+    finally:
+        allow_first_to_finish.set()
+        if protected_emit_task is not None and not protected_emit_task.done():
+            protected_emit_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(protected_emit_task, timeout=1.0)
+        await dispatcher.stop()
+
+    assert handler.ids == ["c1", "c2", "c4"]
+
+
+@pytest.mark.asyncio
+async def test_drop_oldest_protected_incoming_event_evicts_oldest_droppable_event() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=2,
+            backpressure_policy=EventBackpressurePolicy.DROP_OLDEST,
+        ),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    protected_emit_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        await dispatcher.emit(_opened(2))
+        await dispatcher.emit(_opened(3))
+        await wait_for_condition(lambda: dispatcher.runtime_stats.queue_depth == 2)
+
+        protected_emit_task = asyncio.create_task(
+            dispatcher.emit_and_wait(_opened(4), drop_on_backpressure=False)
+        )
+        await wait_for_condition(
+            lambda: (
+                dispatcher.runtime_stats.dropped_backpressure_oldest_total == 1
+                and dispatcher.runtime_stats.queue_depth == 2
+            )
+        )
+        assert protected_emit_task.done() is False
+
+        allow_first_to_finish.set()
+        await asyncio.wait_for(protected_emit_task, timeout=1.0)
+        await wait_for_condition(lambda: handler.ids == ["c1", "c3", "c4"])
+    finally:
+        allow_first_to_finish.set()
+        if protected_emit_task is not None and not protected_emit_task.done():
+            protected_emit_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(protected_emit_task, timeout=1.0)
+        await dispatcher.stop()
+
+    assert handler.ids == ["c1", "c3", "c4"]
+
+
+@pytest.mark.asyncio
+async def test_emit_and_wait_raises_when_stop_drops_queued_barrier_event() -> None:
+    first_started = asyncio.Event()
+    allow_stop = asyncio.Event()
+
+    class StopFromHandler:
+        def __init__(self) -> None:
+            self.dispatcher: AsyncioEventDispatcher | None = None
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_stop.wait()
+                if self.dispatcher is not None:
+                    await self.dispatcher.stop()
+
+    handler = StopFromHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    handler.dispatcher = dispatcher
+    await dispatcher.start()
+    emit_wait_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        emit_wait_task = asyncio.create_task(dispatcher.emit_and_wait(_opened(2)))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        allow_stop.set()
+        with pytest.raises(RuntimeError, match="dropped"):
+            await asyncio.wait_for(emit_wait_task, timeout=1.0)
+    finally:
+        allow_stop.set()
+        if emit_wait_task is not None and not emit_wait_task.done():
+            emit_wait_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_wait_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
+    assert handler.ids == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_handler_origin_stop_without_inline_context_drains_queued_events() -> None:
+    first_started = asyncio.Event()
+    allow_stop_to_spawn = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class SpawnStopFromHandler:
+        def __init__(self) -> None:
+            self.dispatcher: AsyncioEventDispatcher | None = None
+            self.stop_task: asyncio.Task[None] | None = None
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_stop_to_spawn.wait()
+                if self.dispatcher is not None:
+                    self.stop_task = asyncio.create_task(self.dispatcher.stop())
+                await allow_first_to_finish.wait()
+
+    handler = SpawnStopFromHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    handler.dispatcher = dispatcher
+    await dispatcher.start()
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        await dispatcher.emit(_opened(2))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        allow_stop_to_spawn.set()
+        await wait_for_condition(lambda: handler.stop_task is not None, timeout_seconds=1.0)
+        await asyncio.sleep(0)
+        assert dispatcher.runtime_stats.queue_depth == 1
+
+        allow_first_to_finish.set()
+        await wait_for_condition(lambda: handler.ids == ["c1", "c2"], timeout_seconds=1.0)
+        assert handler.stop_task is not None
+        await asyncio.wait_for(handler.stop_task, timeout=1.0)
+    finally:
+        allow_stop_to_spawn.set()
+        allow_first_to_finish.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.stop_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_block_backpressure_stop_fails_emit_and_wait_blocked_for_queue_space() -> None:
+    first_started = asyncio.Event()
+    allow_first_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            connection_id = event.metadata.connection_id
+            self.ids.append(connection_id)
+            if connection_id == "c1":
+                first_started.set()
+                await allow_first_to_finish.wait()
+
+    handler = BlockingHandler()
+    settings = EventDeliverySettings(
+        dispatch_mode=EventDispatchMode.BACKGROUND,
+        max_pending_events=1,
+        backpressure_policy=EventBackpressurePolicy.BLOCK,
+    )
+    dispatcher = AsyncioEventDispatcher(handler, settings, logging.getLogger("test"))
+    await dispatcher.start()
+    emit_wait_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        await dispatcher.emit(_opened(2))
+        emit_wait_task = asyncio.create_task(dispatcher.emit_and_wait(_opened(3)))
+        await wait_for_condition(
+            lambda: bool(getattr(dispatcher._queue_not_full, "_waiters", None)),
+            timeout_seconds=1.0,
+        )
+
+        stop_task = asyncio.create_task(dispatcher.stop())
+        await asyncio.wait_for(_wait_until_dispatcher_stopping(dispatcher), timeout=1.0)
+        with pytest.raises(RuntimeError, match="dropped"):
+            await asyncio.wait_for(emit_wait_task, timeout=1.0)
+    finally:
+        allow_first_to_finish.set()
+        if emit_wait_task is not None and not emit_wait_task.done():
+            emit_wait_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_wait_task, timeout=1.0)
+        if stop_task is not None and not stop_task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
+    assert handler.ids == ["c1", "c2"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -213,6 +213,160 @@ async def test_stop_called_from_event_callback_is_safe(caplog: pytest.LogCapture
     assert "Task cannot await on itself" not in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_handler_origin_context_expires_when_handler_returns() -> None:
+    handler_finished = asyncio.Event()
+    observed_origin_context: list[bool] = []
+
+    class SpawnChildFromHandler:
+        def __init__(self) -> None:
+            self.dispatcher: AsyncioEventDispatcher | None = None
+            self.child_task: asyncio.Task[None] | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            del event
+            if self.dispatcher is None:
+                raise AssertionError("dispatcher reference was not attached")
+
+            async def observe_after_handler_returns() -> None:
+                await handler_finished.wait()
+                observed_origin_context.append(
+                    self.dispatcher.current_task_has_handler_origin_context()
+                )
+
+            self.child_task = asyncio.create_task(observe_after_handler_returns())
+
+    handler = SpawnChildFromHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    handler.dispatcher = dispatcher
+    await dispatcher.start()
+    try:
+        await dispatcher.emit_and_wait(_opened("origin"))
+        handler_finished.set()
+        assert handler.child_task is not None
+        await asyncio.wait_for(handler.child_task, timeout=1.0)
+    finally:
+        handler_finished.set()
+        if handler.child_task is not None and not handler.child_task.done():
+            handler.child_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.child_task, timeout=1.0)
+        await dispatcher.stop()
+
+    assert observed_origin_context == [False]
+
+
+@pytest.mark.asyncio
+async def test_handler_origin_context_is_not_inherited_by_child_tasks() -> None:
+    child_ready = asyncio.Event()
+    allow_child_to_check = asyncio.Event()
+    child_checked = asyncio.Event()
+    allow_handler_to_finish = asyncio.Event()
+    observed_handler_origin_context: list[bool] = []
+    observed_child_origin_context: list[bool] = []
+    observed_child_inherited_context: list[bool] = []
+
+    class SpawnChildFromActiveHandler:
+        def __init__(self) -> None:
+            self.dispatcher: AsyncioEventDispatcher | None = None
+            self.child_task: asyncio.Task[None] | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            del event
+            if self.dispatcher is None:
+                raise AssertionError("dispatcher reference was not attached")
+            observed_handler_origin_context.append(
+                self.dispatcher.current_task_has_handler_origin_context()
+            )
+
+            async def observe_while_handler_is_suspended() -> None:
+                child_ready.set()
+                await allow_child_to_check.wait()
+                observed_child_origin_context.append(
+                    self.dispatcher.current_task_has_handler_origin_context()
+                )
+                observed_child_inherited_context.append(
+                    self.dispatcher.current_task_inherits_handler_origin_context()
+                )
+                child_checked.set()
+
+            self.child_task = asyncio.create_task(observe_while_handler_is_suspended())
+            await child_ready.wait()
+            await child_checked.wait()
+            await allow_handler_to_finish.wait()
+
+    handler = SpawnChildFromActiveHandler()
+    dispatcher = AsyncioEventDispatcher(
+        handler,
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    handler.dispatcher = dispatcher
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    try:
+        emit_task = asyncio.create_task(dispatcher.emit_and_wait(_opened("origin")))
+        await asyncio.wait_for(child_ready.wait(), timeout=1.0)
+        allow_child_to_check.set()
+        await asyncio.wait_for(child_checked.wait(), timeout=1.0)
+        assert observed_handler_origin_context == [True]
+        assert observed_child_origin_context == [False]
+        assert observed_child_inherited_context == [True]
+
+        allow_handler_to_finish.set()
+        await asyncio.wait_for(emit_task, timeout=1.0)
+        assert handler.child_task is not None
+        await asyncio.wait_for(handler.child_task, timeout=1.0)
+    finally:
+        allow_child_to_check.set()
+        allow_handler_to_finish.set()
+        if emit_task is not None and not emit_task.done():
+            emit_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_task, timeout=1.0)
+        if handler.child_task is not None and not handler.child_task.done():
+            handler.child_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.child_task, timeout=1.0)
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_inline_delivery_context_expires_for_tasks_spawned_inside_context() -> None:
+    context_exited = asyncio.Event()
+    observed_inline_context: list[bool] = []
+
+    dispatcher = AsyncioEventDispatcher(
+        Recorder(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+
+    async def observe_after_context_exits() -> None:
+        await context_exited.wait()
+        observed_inline_context.append(dispatcher.current_task_has_inline_delivery_context())
+
+    with dispatcher.inline_delivery_context():
+        assert dispatcher.current_task_has_inline_delivery_context() is True
+        child_task = asyncio.create_task(observe_after_context_exits())
+
+    try:
+        context_exited.set()
+        await asyncio.wait_for(child_task, timeout=1.0)
+    finally:
+        context_exited.set()
+        if not child_task.done():
+            child_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(child_task, timeout=1.0)
+
+    assert observed_inline_context == [False]
+
+
 # Backpressure semantics under queue saturation.
 @pytest.mark.asyncio
 async def test_drop_newest_backpressure_policy() -> None:
@@ -1874,6 +2028,202 @@ async def test_handler_failure_policy_stop_component_is_safe_in_background_worke
     await asyncio.wait_for(stopped.wait(), timeout=1.0)
     await dispatcher.stop()
     assert stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_component_callback_does_not_expose_inline_context_to_user_tasks() -> None:
+    class FailThenStop:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                raise RuntimeError("boom")
+
+    child_task_started = asyncio.Event()
+    allow_child_to_emit = asyncio.Event()
+    child_emit_finished = asyncio.Event()
+    observed_inline_context: list[bool] = []
+    observed_origin_context: list[bool] = []
+
+    async def stop_component() -> None:
+        observed_origin_context.append(dispatcher.current_task_has_handler_origin_context())
+
+        async def child_emit() -> None:
+            child_task_started.set()
+            await allow_child_to_emit.wait()
+            observed_inline_context.append(dispatcher.current_task_has_inline_delivery_context())
+            await dispatcher.emit(_opened("child"))
+            child_emit_finished.set()
+
+        child_task = asyncio.create_task(child_emit())
+        await asyncio.wait_for(child_task_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        assert child_emit_finished.is_set() is False
+        await dispatcher.stop()
+        allow_child_to_emit.set()
+        await asyncio.wait_for(child_task, timeout=1.0)
+
+    dispatcher = AsyncioEventDispatcher(
+        FailThenStop(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            max_pending_events=1,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+
+    await dispatcher.start()
+    await dispatcher.emit(_opened("failure"))
+    await wait_for_condition(lambda: dispatcher.is_running is False, timeout_seconds=1.0)
+
+    assert observed_inline_context == [False]
+    assert observed_origin_context == [True]
+    assert child_emit_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_component_callback_awaited_child_does_not_inherit_stop_authority() -> None:
+    first_started = asyncio.Event()
+    release_failure = asyncio.Event()
+    child_ready = asyncio.Event()
+    allow_child_to_stop = asyncio.Event()
+    child_stop_blocked = asyncio.Event()
+    child_stop_finished = asyncio.Event()
+    second_seen = asyncio.Event()
+    observed_child_origin_context: list[bool] = []
+    observed_child_inherited_context: list[bool] = []
+
+    class FailFirstThenRecordSecond:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_failure.wait()
+                raise RuntimeError("boom")
+            if event.metadata.connection_id == "c2":
+                second_seen.set()
+
+    async def stop_component() -> None:
+        async def child_stop() -> None:
+            child_ready.set()
+            await allow_child_to_stop.wait()
+            observed_child_origin_context.append(
+                dispatcher.current_task_has_handler_origin_context()
+            )
+            observed_child_inherited_context.append(
+                dispatcher.current_task_inherits_handler_origin_context()
+            )
+            stop_task = asyncio.create_task(dispatcher.stop())
+            await asyncio.sleep(0)
+            if stop_task.done():
+                await stop_task
+                child_stop_finished.set()
+                return
+            child_stop_blocked.set()
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await stop_task
+            child_stop_finished.set()
+
+        await asyncio.create_task(child_stop())
+
+    dispatcher = AsyncioEventDispatcher(
+        FailFirstThenRecordSecond(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+    await dispatcher.start()
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        await dispatcher.emit(_opened(2))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        release_failure.set()
+        await asyncio.wait_for(child_ready.wait(), timeout=1.0)
+        allow_child_to_stop.set()
+        await asyncio.wait_for(child_stop_blocked.wait(), timeout=1.0)
+        await asyncio.wait_for(second_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(child_stop_finished.wait(), timeout=1.0)
+        assert observed_child_origin_context == [False]
+        assert observed_child_inherited_context == [False]
+    finally:
+        release_failure.set()
+        allow_child_to_stop.set()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_stop_component_callback_child_stop_waits_for_queued_events() -> None:
+    first_started = asyncio.Event()
+    release_failure = asyncio.Event()
+    child_ready = asyncio.Event()
+    allow_child_to_stop = asyncio.Event()
+    child_stop_finished = asyncio.Event()
+    second_seen = asyncio.Event()
+    ordering_errors: list[str] = []
+
+    class FailFirstThenRecordSecond:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if event.metadata.connection_id == "c1":
+                first_started.set()
+                await release_failure.wait()
+                raise RuntimeError("boom")
+            if event.metadata.connection_id == "c2":
+                if child_stop_finished.is_set():
+                    ordering_errors.append("child stop returned before queued c2 event")
+                second_seen.set()
+
+    async def stop_component() -> None:
+        async def child_stop() -> None:
+            child_ready.set()
+            await allow_child_to_stop.wait()
+            await dispatcher.stop()
+            child_stop_finished.set()
+
+        _ = asyncio.create_task(child_stop())
+
+    dispatcher = AsyncioEventDispatcher(
+        FailFirstThenRecordSecond(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+    await dispatcher.start()
+    try:
+        await dispatcher.emit(_opened(1))
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        await dispatcher.emit(_opened(2))
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        release_failure.set()
+        await asyncio.wait_for(child_ready.wait(), timeout=1.0)
+        allow_child_to_stop.set()
+        await asyncio.wait_for(second_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(child_stop_finished.wait(), timeout=1.0)
+        assert ordering_errors == []
+    finally:
+        release_failure.set()
+        allow_child_to_stop.set()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -2117,13 +2117,13 @@ async def test_stop_component_callback_awaited_child_does_not_inherit_stop_autho
             stop_task = asyncio.create_task(dispatcher.stop())
             await asyncio.sleep(0)
             if stop_task.done():
-                await stop_task
+                await asyncio.wait_for(stop_task, timeout=1.0)
                 child_stop_finished.set()
                 return
             child_stop_blocked.set()
             stop_task.cancel()
             with contextlib.suppress(Exception, asyncio.CancelledError):
-                await stop_task
+                await asyncio.wait_for(stop_task, timeout=1.0)
             child_stop_finished.set()
 
         await asyncio.create_task(child_stop())


### PR DESCRIPTION
## Summary

While expanding dispatcher regression coverage for lifecycle-sensitive event ordering, several gaps showed that BACKGROUND delivery did not have a precise internal completion-barrier path and that handler-origin stop provenance was scoped too broadly for the transport lifecycle guarantees built on top of it.

This PR hardens the dispatcher foundation used by TCP and UDP lifecycle paths: lifecycle-sensitive publications can now wait for handler completion without changing normal BACKGROUND `emit()` behavior, barrier events are not silently lost under backpressure, and direct handler-origin stop authority is limited to active dispatcher-owned work while existing inline-delivery helper-task inheritance remains unchanged.

## Problems and approach

### 1. Lifecycle-sensitive BACKGROUND publication needed an explicit completion barrier

Problem:
BACKGROUND dispatch intentionally queues events and lets `emit()` return before user-handler work finishes. That is the right steady-state behavior, but startup and shutdown paths sometimes need a stronger internal guarantee: a lifecycle-sensitive event must be fully published before the transport proceeds to the next lifecycle step.

Without a dedicated barrier, transport code would either have to rely on implementation timing or weaken documented ordering guarantees when BACKGROUND delivery is involved.

Approach:
The dispatcher now has an internal `emit_and_wait()` path backed by queued-event completion waiters. Normal `emit()` semantics remain unchanged: BACKGROUND `emit()` still returns after queueing. The stronger completion guarantee is available only to internal lifecycle paths that explicitly need it.

Regression coverage now proves that:

- `emit_and_wait()` waits for BACKGROUND handler completion
- plain BACKGROUND `emit()` does not wait for handler completion
- cancelled stop paths do not strand completion waiters
- stop-phase queue draining fails pending barrier waiters instead of leaving callers ambiguous

### 2. Barrier events could be lost under backpressure or stop-phase draining

Problem:
Lifecycle barrier events are different from ordinary payload events. Dropping an ordinary queued event can be an explicit backpressure outcome, but silently dropping an event that a caller is waiting on would leave lifecycle coordination in an unsafe state.

The existing queue accounting and backpressure behavior did not distinguish ordinary queued events from completion-sensitive barrier events.

Approach:
Queued dispatcher entries now carry optional completion waiters and an explicit backpressure-drop policy for the entry. Barrier events can opt out of backpressure dropping, and any barrier that is dropped during stop-phase cleanup is failed explicitly so the waiting lifecycle path receives a deterministic result.

Regression coverage now checks DROP_NEWEST, DROP_OLDEST, BLOCK, and stop-boundary behavior around protected barrier events.

### 3. Handler-origin stop context needed task-bound ownership

Problem:
Transport shutdown initiated from inside a handler needs different re-entry handling from shutdown initiated externally. The old handler-origin provenance checks were too coarse for that distinction: child tasks spawned while a handler was active could observe inherited context and accidentally receive stop authority that should belong only to active dispatcher handler work.

That matters for later transport fixes because same-connection terminal events must be deferred until the active handler unwinds, while external callers must not be mistaken for handler-origin shutdown.

Approach:
Handler-origin context is now scoped to the active task that is currently delivering dispatcher work. The dispatcher still exposes inherited-context detection for code that needs to detect ancestry, but direct handler-origin authority is task-bound.

The existing `inline_delivery_context()` helper-task inheritance is intentionally preserved in this PR because current transport close paths create helper tasks inside that context. Transport-specific terminal-event ordering changes are handled in the stacked transport PRs that add the corresponding coverage.

Regression coverage now proves that:

- handler-origin context expires when the handler returns
- child tasks do not inherit direct handler-origin authority
- stop callbacks run with the intended provenance
- awaited child tasks inside stop callbacks cannot use inherited context as direct stop authority
- `inline_delivery_context()` continues to be inherited by helper tasks created inside that context

### 4. Handler-origin stop needed a separate dispatcher stop path

Problem:
A stop requested from handler-origin code must avoid self-deadlock and terminal-event re-entry, but it also must not turn every external stop into a handler-origin stop. The dispatcher needed a narrow primitive that later TCP and UDP lifecycle code can use without weakening the normal `stop()` contract.

Approach:
The dispatcher now exposes `stop_from_handler_origin()` for internally coordinated handler-origin shutdown and `drop_queued_events_for_resource()` for removing queued payload work tied to a resource that is already closing. These hooks keep the lifecycle distinction explicit instead of hiding it inside generic stop behavior.

Regression coverage exercises handler-origin stop paths and same-resource queue dropping without changing public dispatch settings or transport-facing APIs.

## Changes

- Add queued-event completion waiters for lifecycle-sensitive dispatcher work.
- Add internal `emit_and_wait()` completion-barrier publication.
- Preserve normal BACKGROUND `emit()` queue-only completion semantics.
- Protect completion-sensitive barrier events from silent backpressure drops.
- Fail pending barrier waiters deterministically during stop-phase cleanup.
- Scope handler-origin authority to active dispatcher tasks.
- Preserve existing inline-delivery helper-task inheritance.
- Add `stop_from_handler_origin()` for handler-origin shutdown coordination.
- Add `drop_queued_events_for_resource()` for targeted queued payload cleanup.
- Add dispatcher contract coverage for lifecycle barriers, backpressure boundaries, stop provenance, and handler-origin context scoping.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed in PR1: this PR introduces internal dispatcher primitives and regression coverage. User-visible TCP/UDP behavior changes are documented in the stacked transport PRs that use these primitives.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not needed in PR1: public transport semantics are unchanged here; the dispatcher contract is covered in code-level tests and comments.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface changes introduced.

Local verification:

- `python -m pytest -q tests/unit/test_event_dispatcher_contract.py -p no:cacheprovider --timeout=60`
- `python -m pytest -q tests/unit/test_asyncio_tcp_connection.py tests/unit/test_asyncio_tcp_client_internals.py tests/unit/test_asyncio_tcp_server.py -p no:cacheprovider --timeout=60`
- `ruff check . --no-cache`
- `ruff format --check . --no-cache`
- `python -m mypy src`