### PR TITLE
fix(tcp): defer handler-origin terminal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@ Planned contents for the initial public alpha release (`0.1.0`).
   preserving per-connection event ordering across dispatch modes.
 - TCP close and stop paths now defer handler-origin terminal events until the
   active same-connection handler has returned.
+- UDP receivers now preserve deferred stop publication when stop originates
+  from a handler or when an external stop caller is cancelled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,5 @@ Planned contents for the initial public alpha release (`0.1.0`).
 
 - TCP connections now wait for opened-event handlers before starting reads,
   preserving per-connection event ordering across dispatch modes.
+- TCP close and stop paths now defer handler-origin terminal events until the
+  active same-connection handler has returned.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,11 @@ the semantic test suite:
 
 - Once `stop()` returns with state `STOPPED`, no further user callback is
   invoked from the component's internal tasks.
+  Exception: when `stop()` is awaited from the currently running connection
+  event handler for the same connection event stream, the corresponding
+  deferred `ConnectionClosedEvent` is published immediately after that handler
+  unwinds. This avoids self-deadlock while preserving non-overlapping
+  per-connection event execution.
 - Startup cancellation must roll back partial resources and leave the component
   in the same terminal `STOPPED` state as other startup failures.
 - `STOPPING` is a terminal-in-progress state, not a re-entrant steady state:
@@ -96,6 +101,9 @@ async def on_event(self, event: NetworkEvent) -> None:
   `ConnectionClosedEvent` is emitted.
 - Re-entrant shutdown requests from callbacks/handlers must converge safely on
   the same close or stop operation.
+- Shutdown requested from inside a connection event handler defers
+  `ConnectionClosedEvent` until that handler has returned, so close publication
+  never re-enters the same connection event stream.
 - Handler failures remain observable: depending on the configured failure
   policy they either surface as `NetworkErrorEvent`, as
   `HandlerFailurePolicyStopEvent`, or as an inline exception in the caller.

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -125,6 +125,14 @@ class _DatagramStopProvenance:
         return self.has_handler_provenance or self.active_inline_handler
 
 
+@dataclass(slots=True)
+class _DatagramStopExecutionState:
+    """Mutable cross-step state for a single stop execution."""
+
+    deferred_close_waiter: asyncio.Future[None] | None = None
+    stop_waiter_completion_deferred: bool = False
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -309,69 +317,32 @@ class _AsyncioDatagramReceiverBase:
             await asyncio.shield(cast("asyncio.Future[None]", snapshot.stop_waiter))
             return
 
-        first_error: BaseException | None = None
         stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
-        deferred_close_waiter: asyncio.Future[None] | None = None
-        stop_waiter_completion_deferred = False
+        stop_state = _DatagramStopExecutionState()
         try:
             if provenance.defers_terminal_events:
-                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
-                    snapshot=snapshot,
-                    provenance=provenance,
-                    stop_waiter=stop_waiter,
-                    socket_cleanup=socket_cleanup,
+                stop_state.stop_waiter_completion_deferred = (
+                    await self._prepare_deferred_stop_events(
+                        snapshot=snapshot,
+                        provenance=provenance,
+                        stop_waiter=stop_waiter,
+                        socket_cleanup=socket_cleanup,
+                    )
                 )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
-                try:
-                    await self._publish_stopping_transition(snapshot)
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                try:
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    if first_error is None:
-                        first_error = error
-                if first_error is None:
-                    try:
-                        _, deferred_close_waiter = await self._publish_closed_event_if_needed(
-                            snapshot
-                        )
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                    else:
-                        if deferred_close_waiter is not None:
-                            try:
-                                await asyncio.shield(deferred_close_waiter)
-                            except asyncio.CancelledError:
-                                self._complete_stop_waiter_after_deferred_close_and_stop(
-                                    stop_waiter=stop_waiter,
-                                    snapshot=snapshot,
-                                    deferred_close_waiter=deferred_close_waiter,
-                                )
-                                stop_waiter_completion_deferred = True
-                                raise
-                            except Exception as error:
-                                first_error = error
-                await self._publish_stopped_transition_if_needed(
-                    snapshot, emit_event=first_error is None
+                await self._run_ordinary_stop_path(
+                    snapshot=snapshot,
+                    stop_state=stop_state,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
                 )
-                if snapshot.stop_dispatcher:
-                    try:
-                        await self._event_dispatcher.stop()
-                    except (Exception, asyncio.CancelledError) as error:
-                        if first_error is None:
-                            first_error = error
-                if first_error is not None:
-                    raise first_error
         except (Exception, asyncio.CancelledError) as error:
             if (
                 stop_waiter is not None
                 and not stop_waiter.done()
-                and not stop_waiter_completion_deferred
+                and not stop_state.stop_waiter_completion_deferred
             ):
                 stop_waiter.set_exception(error)
                 # Mark the exception as retrieved so failed owner stops do not
@@ -381,17 +352,17 @@ class _AsyncioDatagramReceiverBase:
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                if stop_waiter_completion_deferred:
+                if stop_state.stop_waiter_completion_deferred:
                     pass
-                elif provenance.handler_originated and deferred_close_waiter is not None:
+                elif provenance.handler_originated and stop_state.deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
-                        stop_waiter, deferred_close_waiter
+                        stop_waiter, stop_state.deferred_close_waiter
                     )
-                    stop_waiter_completion_deferred = True
+                    stop_state.stop_waiter_completion_deferred = True
                 else:
                     stop_waiter.set_result(None)
         finally:
-            if stop_waiter is not None and not stop_waiter_completion_deferred:
+            if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
                 async with self._state_lock:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
@@ -443,6 +414,56 @@ class _AsyncioDatagramReceiverBase:
             self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
             return True
         raise first_error
+
+    async def _run_ordinary_stop_path(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        stop_state: _DatagramStopExecutionState,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> None:
+        """Run the ordinary stop path that publishes terminal events inline."""
+        first_error: BaseException | None = None
+        try:
+            await self._publish_stopping_transition(snapshot)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        try:
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        if first_error is None:
+            try:
+                _, stop_state.deferred_close_waiter = await self._publish_closed_event_if_needed(
+                    snapshot
+                )
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+            else:
+                if stop_state.deferred_close_waiter is not None:
+                    try:
+                        await asyncio.shield(stop_state.deferred_close_waiter)
+                    except asyncio.CancelledError:
+                        self._complete_stop_waiter_after_deferred_close_and_stop(
+                            stop_waiter=stop_waiter,
+                            snapshot=snapshot,
+                            deferred_close_waiter=stop_state.deferred_close_waiter,
+                        )
+                        stop_state.stop_waiter_completion_deferred = True
+                        raise
+                    except Exception as error:
+                        first_error = error
+        await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
+        if snapshot.stop_dispatcher:
+            try:
+                await self._event_dispatcher.stop()
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -106,6 +106,25 @@ class _DatagramStopSnapshot:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _DatagramStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    inherited_handler_origin: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def has_handler_provenance(self) -> bool:
+        """Whether the caller is the active handler or inherited handler-origin context."""
+        return self.handler_originated or self.inherited_handler_origin
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.has_handler_provenance or self.active_inline_handler
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -280,22 +299,9 @@ class _AsyncioDatagramReceiverBase:
                         then publish terminal events after active handlers unwind
         """
         snapshot = await self._plan_stop_snapshot()
-        handler_originated_stop = (
-            self._event_dispatcher.current_task_is_dispatching_handler()
-            or self._event_dispatcher.current_task_has_handler_origin_context()
-        )
-        inherited_handler_origin = (
-            self._event_dispatcher.current_task_inherits_handler_origin_context()
-        )
-        handler_provenance_stop = handler_originated_stop or inherited_handler_origin
-        active_inline_handler_stop = (
-            not handler_provenance_stop
-            and self._event_dispatcher.has_active_handler_context()
-            and self._event_dispatcher.current_task_would_deliver_inline()
-        )
-        defer_stop_events = handler_provenance_stop or active_inline_handler_stop
+        provenance = self._capture_stop_provenance()
         if snapshot.waits_for_owner:
-            if handler_provenance_stop:
+            if provenance.has_handler_provenance:
                 return
             # Non-owner stop callers observe the active owner stop path instead
             # of planning another teardown. shield() prevents caller
@@ -308,9 +314,9 @@ class _AsyncioDatagramReceiverBase:
         deferred_close_waiter: asyncio.Future[None] | None = None
         stop_waiter_completion_deferred = False
         try:
-            if defer_stop_events:
+            if provenance.defers_terminal_events:
                 try:
-                    if active_inline_handler_stop:
+                    if provenance.active_inline_handler:
                         snapshot.cancel_task = False
                     await self._teardown_stop_resources(
                         snapshot=snapshot, socket_cleanup=socket_cleanup
@@ -327,7 +333,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter_completion_deferred = True
                 if first_error is not None:
                     raise first_error
-                if not handler_provenance_stop and stop_waiter is not None:
+                if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
                 try:
@@ -389,7 +395,7 @@ class _AsyncioDatagramReceiverBase:
             if stop_waiter is not None and not stop_waiter.done():
                 if stop_waiter_completion_deferred:
                     pass
-                elif handler_originated_stop and deferred_close_waiter is not None:
+                elif provenance.handler_originated and deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
                         stop_waiter, deferred_close_waiter
                     )
@@ -402,6 +408,27 @@ class _AsyncioDatagramReceiverBase:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
                         self._runtime.stop_owner_task = None
+
+    def _capture_stop_provenance(self) -> _DatagramStopProvenance:
+        """Capture handler-origin facts for the current stop caller."""
+        handler_originated = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+        )
+        inherited_handler_origin = (
+            self._event_dispatcher.current_task_inherits_handler_origin_context()
+        )
+        active_inline_handler = (
+            not handler_originated
+            and not inherited_handler_origin
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        return _DatagramStopProvenance(
+            handler_originated=handler_originated,
+            inherited_handler_origin=inherited_handler_origin,
+            active_inline_handler=active_inline_handler,
+        )
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -55,6 +55,10 @@ class _DatagramRuntimeState:
     recv_fallback_warning_emitted: bool = False
     stop_waiter: asyncio.Future[None] | None = None
     stop_owner_task: asyncio.Task[object] | None = None
+    opening_event_task: asyncio.Task[object] | None = None
+    deferred_close_event: ConnectionClosedEvent | None = None
+    deferred_close_event_waiter: asyncio.Future[None] | None = None
+    deferred_close_publish_task: asyncio.Task[None] | None = None
 
 
 @dataclass(slots=True)
@@ -80,6 +84,7 @@ class _DatagramStopSnapshot:
     previous_connection_state: ConnectionState = ConnectionState.CREATED
     task: asyncio.Task[None] | None = None
     sock: socket.socket | None = None
+    cancel_task: bool = True
     stopping_event: ComponentLifecycleChangedEvent | None = None
     stop_waiter: asyncio.Future[None] | None = None
     owns_stop: bool = False
@@ -276,8 +281,22 @@ class _AsyncioDatagramReceiverBase:
             unlock    : emit STOPPED and stop dispatcher
         """
         snapshot = await self._plan_stop_snapshot()
+        handler_originated_stop = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+        )
+        inherited_handler_origin = (
+            self._event_dispatcher.current_task_inherits_handler_origin_context()
+        )
+        handler_provenance_stop = handler_originated_stop or inherited_handler_origin
+        active_inline_handler_stop = (
+            not handler_provenance_stop
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        defer_stop_events = handler_provenance_stop or active_inline_handler_stop
         if snapshot.waits_for_owner:
-            if self._event_dispatcher.current_task_is_worker():
+            if handler_provenance_stop:
                 return
             # Non-owner stop callers observe the active owner stop path instead
             # of planning another teardown. shield() prevents caller
@@ -287,36 +306,80 @@ class _AsyncioDatagramReceiverBase:
 
         first_error: BaseException | None = None
         stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
+        deferred_close_waiter: asyncio.Future[None] | None = None
+        stop_waiter_completion_deferred = False
         try:
-            try:
-                await self._publish_stopping_transition(snapshot)
-            except (Exception, asyncio.CancelledError) as error:
-                first_error = error
-            try:
-                await self._teardown_stop_resources(
-                    snapshot=snapshot, socket_cleanup=socket_cleanup
-                )
-            except (Exception, asyncio.CancelledError) as error:
-                if first_error is None:
-                    first_error = error
-            if first_error is None:
+            if defer_stop_events:
                 try:
-                    await self._publish_closed_event_if_needed(snapshot)
+                    if active_inline_handler_stop:
+                        snapshot.cancel_task = False
+                    await self._teardown_stop_resources(
+                        snapshot=snapshot, socket_cleanup=socket_cleanup
+                    )
                 except (Exception, asyncio.CancelledError) as error:
                     first_error = error
-            await self._publish_stopped_transition_if_needed(
-                snapshot, emit_event=first_error is None
-            )
-            if snapshot.stop_dispatcher:
+                if first_error is None:
+                    try:
+                        await self._event_dispatcher.stop_from_handler_origin()
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                if first_error is None:
+                    self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
+                    stop_waiter_completion_deferred = True
+                if first_error is not None:
+                    raise first_error
+                if not handler_provenance_stop and stop_waiter is not None:
+                    await asyncio.shield(stop_waiter)
+            else:
                 try:
-                    await self._event_dispatcher.stop()
+                    await self._publish_stopping_transition(snapshot)
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+                try:
+                    await self._teardown_stop_resources(
+                        snapshot=snapshot, socket_cleanup=socket_cleanup
+                    )
                 except (Exception, asyncio.CancelledError) as error:
                     if first_error is None:
                         first_error = error
-            if first_error is not None:
-                raise first_error
+                if first_error is None:
+                    try:
+                        _, deferred_close_waiter = await self._publish_closed_event_if_needed(
+                            snapshot
+                        )
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                    else:
+                        if deferred_close_waiter is not None:
+                            try:
+                                await asyncio.shield(deferred_close_waiter)
+                            except asyncio.CancelledError:
+                                self._complete_stop_waiter_after_deferred_close_and_stop(
+                                    stop_waiter=stop_waiter,
+                                    snapshot=snapshot,
+                                    deferred_close_waiter=deferred_close_waiter,
+                                )
+                                stop_waiter_completion_deferred = True
+                                raise
+                            except Exception as error:
+                                first_error = error
+                await self._publish_stopped_transition_if_needed(
+                    snapshot, emit_event=first_error is None
+                )
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
         except (Exception, asyncio.CancelledError) as error:
-            if stop_waiter is not None and not stop_waiter.done():
+            if (
+                stop_waiter is not None
+                and not stop_waiter.done()
+                and not stop_waiter_completion_deferred
+            ):
                 stop_waiter.set_exception(error)
                 # Mark the exception as retrieved so failed owner stops do not
                 # leave an unhandled-Future warning behind.
@@ -325,13 +388,151 @@ class _AsyncioDatagramReceiverBase:
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                stop_waiter.set_result(None)
+                if stop_waiter_completion_deferred:
+                    pass
+                elif handler_originated_stop and deferred_close_waiter is not None:
+                    self._complete_stop_waiter_after_deferred_close(
+                        stop_waiter, deferred_close_waiter
+                    )
+                    stop_waiter_completion_deferred = True
+                else:
+                    stop_waiter.set_result(None)
         finally:
-            if stop_waiter is not None:
+            if stop_waiter is not None and not stop_waiter_completion_deferred:
                 async with self._state_lock:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
                         self._runtime.stop_owner_task = None
+
+    def _complete_stop_waiter_after_deferred_close(
+        self,
+        stop_waiter: asyncio.Future[None],
+        deferred_close_waiter: asyncio.Future[None],
+    ) -> None:
+        """Release external stop waiters after handler-originated deferred close publication."""
+
+        async def _complete() -> None:
+            try:
+                await asyncio.shield(deferred_close_waiter)
+            except BaseException as error:
+                if not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_close_and_stop(
+        self,
+        *,
+        stop_waiter: asyncio.Future[None] | None,
+        snapshot: _DatagramStopSnapshot,
+        deferred_close_waiter: asyncio.Future[None],
+    ) -> None:
+        """Complete terminal stop publication after close was deferred elsewhere."""
+
+        async def _complete() -> None:
+            first_error: BaseException | None = None
+            try:
+                try:
+                    await asyncio.shield(deferred_close_waiter)
+                except BaseException as error:
+                    first_error = error
+                try:
+                    await self._publish_stopped_transition_if_needed(
+                        snapshot, emit_event=first_error is None
+                    )
+                except (Exception, asyncio.CancelledError) as error:
+                    if first_error is None:
+                        first_error = error
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_stop_events(
+        self,
+        stop_waiter: asyncio.Future[None] | None,
+        snapshot: _DatagramStopSnapshot,
+    ) -> None:
+        """Publish terminal stop events after a handler-originated stop unwinds."""
+
+        async def _complete() -> None:
+            first_error: BaseException | None = None
+            try:
+                while self._event_dispatcher.has_active_handler_context():
+                    await asyncio.sleep(0)
+                with self._event_dispatcher.inline_delivery_context():
+                    try:
+                        await self._publish_stopping_transition(snapshot)
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                    if first_error is None:
+                        try:
+                            _, deferred_close_waiter = await self._publish_closed_event_if_needed(
+                                snapshot
+                            )
+                            if deferred_close_waiter is not None:
+                                await asyncio.shield(deferred_close_waiter)
+                        except (Exception, asyncio.CancelledError) as error:
+                            first_error = error
+                    try:
+                        await self._publish_stopped_transition_if_needed(
+                            snapshot, emit_event=first_error is None
+                        )
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
 
     async def _plan_stop_snapshot(self) -> _DatagramStopSnapshot:
         """Detach stop-time resources under lock and return the resulting stop snapshot."""
@@ -381,17 +582,146 @@ class _AsyncioDatagramReceiverBase:
             return
         await self._emit_lifecycle_event(snapshot.stopping_event)
 
-    async def _publish_closed_event_if_needed(self, snapshot: _DatagramStopSnapshot) -> None:
+    async def _publish_closed_event_if_needed(
+        self, snapshot: _DatagramStopSnapshot
+    ) -> tuple[bool, asyncio.Future[None] | None]:
         """Emit the connection-closed event unless stop is rolling back startup."""
         if not snapshot.should_emit_closed_event:
-            return
-        await self._event_dispatcher.emit(
-            ConnectionClosedEvent(
-                resource_id=self._connection_id,
-                previous_state=snapshot.previous_connection_state,
-                metadata=self._connection_metadata,
-            )
+            return False, None
+        closed_event = ConnectionClosedEvent(
+            resource_id=self._connection_id,
+            previous_state=snapshot.previous_connection_state,
+            metadata=self._connection_metadata,
         )
+        deferred, deferred_waiter = await self._defer_close_event_until_current_handler_unwinds(
+            closed_event
+        )
+        if deferred:
+            return True, deferred_waiter
+        await self._event_dispatcher.emit(closed_event)
+        return False, None
+
+    async def _defer_close_event_until_current_handler_unwinds(
+        self, closed_event: ConnectionClosedEvent
+    ) -> tuple[bool, asyncio.Future[None] | None]:
+        """Defer close publication while the current connection handler is in flight."""
+        async with self._state_lock:
+            opening_event_in_flight = self._runtime.opening_event_task is not None
+            inherited_handler_origin = (
+                self._event_dispatcher.current_task_inherits_handler_origin_context()
+            )
+            handler_origin_in_flight = (
+                self._event_dispatcher.current_task_is_dispatching_handler()
+                or self._event_dispatcher.current_task_has_handler_origin_context()
+            )
+            active_inline_handler_in_flight = (
+                self._event_dispatcher.has_active_handler_context()
+                and self._event_dispatcher.current_task_would_deliver_inline()
+            )
+            if (
+                not opening_event_in_flight
+                and not handler_origin_in_flight
+                and not inherited_handler_origin
+                and not active_inline_handler_in_flight
+            ):
+                return False, None
+            self._runtime.deferred_close_event = closed_event
+            if (
+                self._runtime.deferred_close_event_waiter is None
+                or self._runtime.deferred_close_event_waiter.done()
+            ):
+                current_task = asyncio.current_task()
+                loop = (
+                    current_task.get_loop()
+                    if current_task is not None
+                    else asyncio.get_running_loop()
+                )
+                self._runtime.deferred_close_event_waiter = loop.create_future()
+            if not opening_event_in_flight and (
+                handler_origin_in_flight
+                or inherited_handler_origin
+                or active_inline_handler_in_flight
+            ):
+                publish_task = self._runtime.deferred_close_publish_task
+                if publish_task is None or publish_task.done():
+                    self._runtime.deferred_close_publish_task = asyncio.create_task(
+                        self._publish_deferred_close_after_handler_origin_expires(),
+                        name=f"{self._connection_id}-deferred-close-publisher",
+                    )
+            if handler_origin_in_flight or inherited_handler_origin:
+                return True, None
+            return True, self._runtime.deferred_close_event_waiter
+
+    async def _publish_deferred_close_after_handler_origin_expires(self) -> None:
+        """Publish a deferred close once the handler-origin context has unwound."""
+        current_task = asyncio.current_task()
+        try:
+            while self._event_dispatcher.has_active_handler_context():
+                await asyncio.sleep(0)
+            await self._publish_deferred_close_after_opened_event()
+        except (Exception, asyncio.CancelledError) as error:
+            async with self._state_lock:
+                deferred_waiter = self._runtime.deferred_close_event_waiter
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    deferred_waiter.exception()
+            if not isinstance(error, asyncio.CancelledError):
+                self._logger.warning(
+                    "%s deferred close publication failed: %s",
+                    self._receiver_name,
+                    error,
+                )
+        finally:
+            async with self._state_lock:
+                if self._runtime.deferred_close_publish_task is current_task:
+                    self._runtime.deferred_close_publish_task = None
+
+    async def _publish_deferred_close_after_opened_event_preserving_cancellation(self) -> bool:
+        """Publish deferred close even if receiver startup is cancelled at the barrier."""
+        publish_task = asyncio.create_task(self._publish_deferred_close_after_opened_event())
+        caller_cancelled = False
+        try:
+            while True:
+                try:
+                    result = await asyncio.shield(publish_task)
+                    break
+                except asyncio.CancelledError:
+                    caller_cancelled = True
+                    if publish_task.done():
+                        result = publish_task.result()
+                        break
+                    continue
+        finally:
+            if caller_cancelled and not publish_task.done():
+                _ = await asyncio.shield(publish_task)
+        if caller_cancelled:
+            raise asyncio.CancelledError
+        return result
+
+    async def _publish_deferred_close_after_opened_event(self) -> bool:
+        """Publish a close event deferred until ConnectionOpenedEvent handling completed."""
+        async with self._state_lock:
+            closed_event = self._runtime.deferred_close_event
+            if closed_event is None:
+                return False
+            self._runtime.deferred_close_event = None
+            deferred_waiter = self._runtime.deferred_close_event_waiter
+        try:
+            with self._event_dispatcher.inline_delivery_context():
+                await self._event_dispatcher.emit(closed_event)
+        except (Exception, asyncio.CancelledError) as error:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+            raise
+        else:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_result(None)
+        finally:
+            async with self._state_lock:
+                if self._runtime.deferred_close_event_waiter is deferred_waiter:
+                    self._runtime.deferred_close_event_waiter = None
+        return True
 
     def _is_fully_stopped_locked(self) -> bool:
         """Return whether runtime state already represents a fully stopped receiver."""
@@ -410,7 +740,7 @@ class _AsyncioDatagramReceiverBase:
         """Cancel the detached receive task and close the detached socket, if present."""
         task_error: BaseException | None = None
         if snapshot.task is not None:
-            if snapshot.task is not asyncio.current_task():
+            if snapshot.cancel_task and snapshot.task is not asyncio.current_task():
                 snapshot.task.cancel()
                 try:
                     await await_task_completion_preserving_cancellation(
@@ -423,7 +753,11 @@ class _AsyncioDatagramReceiverBase:
             if socket_cleanup is not None:
                 socket_cleanup(snapshot.sock)
             snapshot.sock.close()
-        if snapshot.task is not None and snapshot.task is not asyncio.current_task():
+        if (
+            snapshot.cancel_task
+            and snapshot.task is not None
+            and snapshot.task is not asyncio.current_task()
+        ):
             if task_error is not None:
                 raise task_error
 
@@ -521,9 +855,32 @@ class _AsyncioDatagramReceiverBase:
             running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
         try:
             await self._emit_lifecycle_event(running_event)
-            await self._event_dispatcher.emit(
-                ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
-            )
+            async with self._state_lock:
+                if (
+                    self._socket is not sock
+                    or not self._running
+                    or self._lifecycle_state != ComponentLifecycleState.RUNNING
+                ):
+                    return
+            opening_task = asyncio.current_task()
+            self._runtime.opening_event_task = cast(asyncio.Task[object] | None, opening_task)
+            try:
+                await self._event_dispatcher.emit_and_wait(
+                    ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata),
+                    drop_on_backpressure=False,
+                )
+            except (Exception, asyncio.CancelledError):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await self._publish_deferred_close_after_opened_event_preserving_cancellation()
+                if self._runtime.opening_event_task is opening_task:
+                    self._runtime.opening_event_task = None
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
+                raise
+            if self._runtime.opening_event_task is opening_task:
+                self._runtime.opening_event_task = None
+            if await self._publish_deferred_close_after_opened_event_preserving_cancellation():
+                return
             async with self._state_lock:
                 if (
                     self._socket is not sock

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -315,24 +315,12 @@ class _AsyncioDatagramReceiverBase:
         stop_waiter_completion_deferred = False
         try:
             if provenance.defers_terminal_events:
-                try:
-                    if provenance.active_inline_handler:
-                        snapshot.cancel_task = False
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                if first_error is None:
-                    try:
-                        await self._event_dispatcher.stop_from_handler_origin()
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                if first_error is None:
-                    self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
-                    stop_waiter_completion_deferred = True
-                if first_error is not None:
-                    raise first_error
+                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
+                    snapshot=snapshot,
+                    provenance=provenance,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
+                )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
@@ -429,6 +417,32 @@ class _AsyncioDatagramReceiverBase:
             inherited_handler_origin=inherited_handler_origin,
             active_inline_handler=active_inline_handler,
         )
+
+    async def _prepare_deferred_stop_events(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        provenance: _DatagramStopProvenance,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> bool:
+        """Tear down resources and schedule terminal publication after handlers unwind."""
+        first_error: BaseException | None = None
+        try:
+            if provenance.active_inline_handler:
+                snapshot.cancel_task = False
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        if first_error is None:
+            try:
+                await self._event_dispatcher.stop_from_handler_origin()
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+        if first_error is None:
+            self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
+            return True
+        raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -363,10 +363,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter.set_result(None)
         finally:
             if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
     def _capture_stop_provenance(self) -> _DatagramStopProvenance:
         """Capture handler-origin facts for the current stop caller."""
@@ -465,6 +462,13 @@ class _AsyncioDatagramReceiverBase:
         if first_error is not None:
             raise first_error
 
+    async def _clear_stop_waiter_if_current(self, stop_waiter: asyncio.Future[None] | None) -> None:
+        """Clear the shared stop waiter when the caller still owns it."""
+        async with self._state_lock:
+            if self._runtime.stop_waiter is stop_waiter:
+                self._runtime.stop_waiter = None
+                self._runtime.stop_owner_task = None
+
     def _complete_stop_waiter_after_deferred_close(
         self,
         stop_waiter: asyncio.Future[None],
@@ -484,10 +488,7 @@ class _AsyncioDatagramReceiverBase:
                 if not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -531,10 +532,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -588,10 +586,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -274,11 +274,10 @@ class _AsyncioDatagramReceiverBase:
 
         Flow overview:
             lock      : plan snapshot, detach task/socket, compute STOPPING
-            unlock    : emit STOPPING
-            unlock    : cancel task and close socket
-            unlock    : emit ConnectionClosedEvent when this is not startup rollback
-            lock      : compute STOPPED
-            unlock    : emit STOPPED and stop dispatcher
+            ordinary  : emit STOPPING, tear down resources, then publish
+                        ConnectionClosedEvent/STOPPED and stop dispatcher
+            deferred  : tear down resources first, stop handler-origin dispatch,
+                        then publish terminal events after active handlers unwind
         """
         snapshot = await self._plan_stop_snapshot()
         handler_originated_stop = (

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -198,7 +198,13 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         should_stop_dispatcher = False
         await_supervisor_completion_only = False
         skip_await_supervisor = False
+        stop_called_from_supervisor = False
+        cancel_supervisor_after_local_cleanup = False
         stop_waiter: asyncio.Future[None] | None = None
+        deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
+        stop_waiter_completion_deferred = False
+        active_inline_handler_stop = False
+        defer_stop_events = False
         owns_stop = False
         current_task = asyncio.current_task()
         async with self._state_lock:
@@ -234,7 +240,9 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     self._supervisor_task = None
                     supervisor_task = None
                 else:
-                    await_supervisor_completion_only = supervisor_task is not None
+                    await_supervisor_completion_only = (
+                        supervisor_task is not None and supervisor_task is not current_task
+                    )
                 should_stop_dispatcher = self._event_dispatcher.is_running
             elif owns_stop and self._lifecycle_state == ComponentLifecycleState.STOPPED:
                 supervisor_task = self._supervisor_task
@@ -242,80 +250,156 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     self._supervisor_task = None
                     supervisor_task = None
                 else:
-                    await_supervisor_completion_only = supervisor_task is not None
+                    await_supervisor_completion_only = (
+                        supervisor_task is not None and supervisor_task is not current_task
+                    )
                 should_stop_dispatcher = self._event_dispatcher.is_running
             elif owns_stop:
                 stopping_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPING)
                 supervisor_task = self._supervisor_task
                 self._supervisor_task = None
+                connection = self._connection
+                connection_startup_in_progress = self._starting_connection is not None or (
+                    connection is not None and connection._opening_event_task is not None
+                )
+                stop_called_from_supervisor = (
+                    supervisor_task is not None and current_task is supervisor_task
+                )
+                handler_originated_stop = (
+                    self._event_dispatcher.current_task_is_dispatching_handler()
+                    or self._event_dispatcher.current_task_has_handler_origin_context()
+                    or self._event_dispatcher.current_task_inherits_handler_origin_context()
+                )
+                active_inline_handler_stop = (
+                    not handler_originated_stop
+                    and self._event_dispatcher.has_active_handler_context()
+                    and self._event_dispatcher.current_task_would_deliver_inline()
+                )
+                defer_stop_events = handler_originated_stop or active_inline_handler_stop
                 should_stop_dispatcher = True
-                skip_await_supervisor = (
-                    current_task is not None
-                    and self._event_dispatcher.current_task_is_worker()
-                    and supervisor_task is not None
+                skip_await_supervisor = supervisor_task is not None and (
+                    stop_called_from_supervisor
+                    or (
+                        current_task is not None and self._event_dispatcher.current_task_is_worker()
+                    )
+                    or (current_task is not None and handler_originated_stop)
+                )
+                cancel_supervisor_after_local_cleanup = (
+                    supervisor_task is not None
+                    and skip_await_supervisor
+                    and not stop_called_from_supervisor
+                    and not connection_startup_in_progress
                 )
         if not owns_stop:
-            if stop_waiter is not None and not self._event_dispatcher.current_task_is_worker():
+            if stop_waiter is not None and not (
+                self._event_dispatcher.current_task_is_dispatching_handler()
+                or self._event_dispatcher.current_task_has_handler_origin_context()
+                or self._event_dispatcher.current_task_inherits_handler_origin_context()
+            ):
                 await asyncio.shield(stop_waiter)
             return
-        inline_delivery_context = (
-            self._event_dispatcher.inline_delivery_context()
-            if self._event_dispatcher.current_task_is_worker()
-            else contextlib.nullcontext()
+        handler_originated_stop = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+            or self._event_dispatcher.current_task_inherits_handler_origin_context()
         )
+        active_inline_handler_stop = (
+            not handler_originated_stop
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        defer_stop_events = handler_originated_stop or active_inline_handler_stop
         try:
-            with inline_delivery_context:
-                first_error: BaseException | None = None
+            first_error: BaseException | None = None
+            if not defer_stop_events:
                 try:
                     await self._emit_lifecycle_event(stopping_event)
                 except (Exception, asyncio.CancelledError) as error:
                     first_error = error
-                try:
-                    if supervisor_task is not None and not skip_await_supervisor:
+            try:
+                if supervisor_task is not None and not skip_await_supervisor:
+                    try:
+                        if not await_supervisor_completion_only:
+                            supervisor_task.cancel()
+                        await await_task_completion_preserving_cancellation(
+                            cast(asyncio.Task[object], supervisor_task)
+                        )
+                    finally:
+                        if self._supervisor_task is supervisor_task:
+                            self._supervisor_task = None
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+            try:
+                # A cancelled supervisor wait must not skip local resource cleanup.
+                # Preserve the first error, finish teardown, then re-raise below.
+                await self._stop_heartbeat_sender()
+                deferred_close_waiters = await self._close_current_connection()
+                if cancel_supervisor_after_local_cleanup and supervisor_task is not None:
+                    supervisor_task.cancel()
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+            if should_stop_dispatcher:
+                async with self._state_lock:
+                    if self._lifecycle_state == ComponentLifecycleState.STOPPING:
+                        stopped_event = self._apply_lifecycle_state(ComponentLifecycleState.STOPPED)
+                if defer_stop_events:
+                    if first_error is None:
                         try:
-                            if not await_supervisor_completion_only:
-                                supervisor_task.cancel()
-                            await await_task_completion_preserving_cancellation(
+                            await self._event_dispatcher.stop_from_handler_origin()
+                        except (Exception, asyncio.CancelledError) as error:
+                            first_error = error
+                    if first_error is None:
+                        self._complete_stop_waiter_after_deferred_stop_events(
+                            stop_waiter=stop_waiter,
+                            stopping_event=stopping_event,
+                            stopped_event=stopped_event,
+                            deferred_close_waiters=deferred_close_waiters,
+                            supervisor_task=(
                                 cast(asyncio.Task[object], supervisor_task)
-                            )
-                        finally:
-                            if self._supervisor_task is supervisor_task:
-                                self._supervisor_task = None
-                except (Exception, asyncio.CancelledError) as error:
-                    if first_error is None:
-                        first_error = error
-                try:
-                    # A cancelled supervisor wait must not skip local resource cleanup.
-                    # Preserve the first error, finish teardown, then re-raise below.
-                    await self._stop_heartbeat_sender()
-                    await self._close_current_connection()
-                    if (
-                        supervisor_task is not None
-                        and skip_await_supervisor
-                        and not await_supervisor_completion_only
-                    ):
-                        supervisor_task.cancel()
-                except (Exception, asyncio.CancelledError) as error:
-                    if first_error is None:
-                        first_error = error
-                if should_stop_dispatcher:
-                    async with self._state_lock:
-                        if self._lifecycle_state == ComponentLifecycleState.STOPPING:
-                            stopped_event = self._apply_lifecycle_state(
-                                ComponentLifecycleState.STOPPED
-                            )
+                                if supervisor_task is not None
+                                and supervisor_task is not current_task
+                                else None
+                            ),
+                            stop_dispatcher=True,
+                        )
+                        stop_waiter_completion_deferred = True
+                else:
                     if first_error is None:
                         try:
                             await self._emit_lifecycle_event(stopped_event)
                         except (Exception, asyncio.CancelledError) as error:
                             first_error = error
+                if not defer_stop_events:
                     try:
                         await self._event_dispatcher.stop()
                     except (Exception, asyncio.CancelledError) as error:
                         if first_error is None:
                             first_error = error
-                if first_error is not None:
-                    raise first_error
+            elif defer_stop_events and first_error is None:
+                self._complete_stop_waiter_after_deferred_stop_events(
+                    stop_waiter=stop_waiter,
+                    stopping_event=stopping_event,
+                    stopped_event=None,
+                    deferred_close_waiters=deferred_close_waiters,
+                    supervisor_task=(
+                        cast(asyncio.Task[object], supervisor_task)
+                        if supervisor_task is not None and supervisor_task is not current_task
+                        else None
+                    ),
+                    stop_dispatcher=False,
+                )
+                stop_waiter_completion_deferred = True
+            if (
+                active_inline_handler_stop
+                and first_error is None
+                and stop_waiter is not None
+                and not stop_waiter.done()
+            ):
+                await asyncio.shield(stop_waiter)
+            if first_error is not None:
+                raise first_error
         except (Exception, asyncio.CancelledError) as error:
             if stop_waiter is not None and not stop_waiter.done():
                 stop_waiter.set_exception(error)
@@ -324,12 +408,21 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                stop_waiter.set_result(None)
+                if stop_waiter_completion_deferred:
+                    pass
+                elif defer_stop_events and deferred_close_waiters:
+                    self._complete_stop_waiter_after_deferred_closes(
+                        stop_waiter, deferred_close_waiters
+                    )
+                    stop_waiter_completion_deferred = True
+                else:
+                    stop_waiter.set_result(None)
         finally:
-            async with self._state_lock:
-                if self._stop_waiter is stop_waiter:
-                    self._stop_waiter = None
-                    self._stop_owner_task = None
+            if not stop_waiter_completion_deferred:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+                        self._stop_owner_task = None
         self._logger.debug("TCP client stopped.")
 
     async def __aenter__(self) -> AsyncioTcpClient:
@@ -474,12 +567,13 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         self._heartbeat_sender = None
         await stop_heartbeat_sender(sender=sender, logger=self._logger)
 
-    async def _close_current_connection(self) -> None:
+    async def _close_current_connection(self) -> tuple[asyncio.Future[None], ...]:
         """Detach and close the current or startup-pending connection, if one is tracked."""
         connection = self._connection
         starting_connection = self._starting_connection
         self._starting_connection = None
         close_targets: list[AsyncioTcpConnection] = []
+        deferred_close_waiters: list[asyncio.Future[None]] = []
         for candidate in (starting_connection, connection):
             if (
                 candidate is not None
@@ -490,11 +584,94 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         try:
             for target in close_targets:
                 await target.close()
+                if waiter := target._pending_deferred_close_waiter():
+                    deferred_close_waiters.append(waiter)
+                elif (
+                    not target._closed_event_published
+                    and (
+                        self._event_dispatcher.has_active_handler_context(target.connection_id)
+                        or self._event_dispatcher.current_task_inherits_handler_origin_context(
+                            target.connection_id
+                        )
+                    )
+                    and (waiter := await target._ensure_deferred_close_publication_waiter())
+                ):
+                    deferred_close_waiters.append(waiter)
         finally:
             if self._connection is connection or self._connection is starting_connection:
                 self._connection = None
             self._connection_closed_event.set()
             self._notify_status_changed()
+        return tuple(deferred_close_waiters)
+
+    def _complete_stop_waiter_after_deferred_stop_events(
+        self,
+        *,
+        stop_waiter: asyncio.Future[None] | None,
+        stopping_event: ComponentLifecycleChangedEvent | None,
+        stopped_event: ComponentLifecycleChangedEvent | None,
+        deferred_close_waiters: tuple[asyncio.Future[None], ...],
+        supervisor_task: asyncio.Task[object] | None,
+        stop_dispatcher: bool,
+    ) -> None:
+        """Publish terminal stop events after a handler-originated stop unwinds."""
+
+        async def _complete() -> None:
+            try:
+                while self._event_dispatcher.has_active_handler_context():
+                    await asyncio.sleep(0)
+                with self._event_dispatcher.inline_delivery_context():
+                    await self._emit_lifecycle_event(stopping_event)
+                    if deferred_close_waiters:
+                        await asyncio.gather(
+                            *(asyncio.shield(waiter) for waiter in deferred_close_waiters)
+                        )
+                    if supervisor_task is not None:
+                        await await_task_completion_preserving_cancellation(supervisor_task)
+                    await self._emit_lifecycle_event(stopped_event)
+                if stop_dispatcher:
+                    await self._event_dispatcher.stop()
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+                        self._stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_closes(
+        self,
+        stop_waiter: asyncio.Future[None],
+        deferred_close_waiters: tuple[asyncio.Future[None], ...],
+    ) -> None:
+        """Release external stop waiters after handler-originated deferred close publication."""
+
+        async def _complete() -> None:
+            try:
+                await asyncio.gather(*(asyncio.shield(waiter) for waiter in deferred_close_waiters))
+            except BaseException as error:
+                if not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+                        self._stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
 
     async def _on_connection_closed(self, connection: AsyncioTcpConnection) -> None:
         """Detach the closed connection, notify waiters, and stop heartbeats."""

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -87,6 +87,10 @@ class AsyncioTcpConnection(ConnectionProtocol):
         self._close_event_previous_state: ConnectionState | None = None
         self._close_task: asyncio.Task[None] | None = None
         self._close_event_task: asyncio.Task[None] | None = None
+        self._opening_event_task: asyncio.Task[object] | None = None
+        self._close_event_deferred_until_opened_event_completes = False
+        self._deferred_close_event_waiter: asyncio.Future[None] | None = None
+        self._deferred_close_publish_task: asyncio.Task[None] | None = None
 
     @property
     def connection_id(self) -> str:
@@ -136,6 +140,8 @@ class AsyncioTcpConnection(ConnectionProtocol):
             raise
         if self._state != ConnectionState.CONNECTED:
             return
+        opening_task = asyncio.current_task()
+        self._opening_event_task = cast(asyncio.Task[object] | None, opening_task)
         try:
             await self._event_dispatcher.emit_and_wait(
                 ConnectionOpenedEvent(
@@ -143,6 +149,19 @@ class AsyncioTcpConnection(ConnectionProtocol):
                 ),
                 drop_on_backpressure=False,
             )
+        except (Exception, asyncio.CancelledError):
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await self._publish_deferred_close_after_opened_event_preserving_cancellation()
+            if self._opening_event_task is opening_task:
+                self._opening_event_task = None
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await self.close()
+            raise
+        if self._opening_event_task is opening_task:
+            self._opening_event_task = None
+        try:
+            if await self._publish_deferred_close_after_opened_event_preserving_cancellation():
+                return
         except (Exception, asyncio.CancelledError):
             with contextlib.suppress(Exception, asyncio.CancelledError):
                 await self.close()
@@ -206,6 +225,13 @@ class AsyncioTcpConnection(ConnectionProtocol):
         """
         close_task: asyncio.Task[None]
         async with self._close_lock:
+            current_task = asyncio.current_task()
+            if (
+                self._state == ConnectionState.CLOSED
+                and self._close_event_deferred_until_opened_event_completes
+                and self._opening_event_task is current_task
+            ):
+                return
             if self._state == ConnectionState.CLOSED and self._closed_event_published:
                 return
             if self._close_task is None or self._close_task.done():
@@ -222,10 +248,16 @@ class AsyncioTcpConnection(ConnectionProtocol):
                     )
                     self._state = ConnectionState.CLOSING
                 callback = self._on_closed_callback
-                close_caller_task = asyncio.current_task()
+                close_caller_task = current_task
+                close_caller_uses_inline_delivery = (
+                    self._event_dispatcher.current_task_is_worker()
+                    or self._event_dispatcher.current_task_is_dispatching_handler()
+                    or self._event_dispatcher.current_task_has_handler_origin_context()
+                    or self._event_dispatcher.current_task_has_inline_delivery_context()
+                )
                 inline_delivery_context = (
                     self._event_dispatcher.inline_delivery_context()
-                    if self._event_dispatcher.current_task_is_worker()
+                    if close_caller_uses_inline_delivery
                     else contextlib.nullcontext()
                 )
                 with inline_delivery_context:
@@ -235,6 +267,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
                             read_task=read_task,
                             callback=callback,
                             close_caller_task=close_caller_task,
+                            close_caller_uses_inline_delivery=close_caller_uses_inline_delivery,
                         )
                     )
             close_task = self._close_task
@@ -243,10 +276,29 @@ class AsyncioTcpConnection(ConnectionProtocol):
             return
         if self._close_event_task is asyncio.current_task():
             return
+        if self._close_event_deferred_until_opened_event_completes and (
+            self._event_dispatcher.current_task_is_dispatching_handler(self._connection_id)
+            or self._event_dispatcher.current_task_inherits_handler_origin_context(
+                self._connection_id
+            )
+        ):
+            return
 
+        handler_origin_caller = self._event_dispatcher.current_task_is_dispatching_handler(
+            self._connection_id
+        ) or self._event_dispatcher.current_task_inherits_handler_origin_context(
+            self._connection_id
+        )
         cancellation_requested = False
         try:
             await asyncio.shield(close_task)
+            deferred_waiter = self._pending_deferred_close_waiter()
+            if (
+                deferred_waiter is not None
+                and not handler_origin_caller
+                and self._event_dispatcher.has_active_handler_context(self._connection_id)
+            ):
+                await asyncio.shield(deferred_waiter)
         except asyncio.CancelledError:
             if close_task.done() and close_task.cancelled():
                 raise
@@ -262,6 +314,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
         read_task: asyncio.Task[None] | None,
         callback: ConnectionClosedCallback | None,
         close_caller_task: asyncio.Task[None] | None,
+        close_caller_uses_inline_delivery: bool,
     ) -> None:
         """
         Execute the shared teardown portion of ``close()`` exactly once.
@@ -271,16 +324,27 @@ class AsyncioTcpConnection(ConnectionProtocol):
             read_task: Detached read-loop task to cancel and await.
             callback: Optional close callback invoked before terminal publication.
             close_caller_task: Task that created the shared close lifecycle task.
+            close_caller_uses_inline_delivery: Whether close() was initiated by a handler
+                path that must not queue terminal events behind the current handler.
         """
         cancellation_requested = False
         try:
             if needs_teardown:
                 try:
                     current_task = asyncio.current_task()
+                    preserve_active_inline_read_task = (
+                        self._event_dispatcher.has_active_handler_context(self._connection_id)
+                        and self._event_dispatcher.current_task_would_deliver_inline()
+                    )
+                    if self._event_dispatcher.has_active_handler_context(self._connection_id):
+                        await self._event_dispatcher.drop_queued_events_for_resource(
+                            self._connection_id
+                        )
                     if (
                         read_task is not None
                         and read_task is not current_task
                         and read_task is not close_caller_task
+                        and not preserve_active_inline_read_task
                     ):
                         read_task.cancel()
                         await self._await_read_task_shutdown(read_task)
@@ -301,7 +365,17 @@ class AsyncioTcpConnection(ConnectionProtocol):
                             await self._safe_emit_error(error)
                 except asyncio.CancelledError:
                     cancellation_requested = True
-            await self._finalize_close()
+            deferred, deferred_waiter = await self._defer_close_event_until_opened_event_completes(
+                close_caller_task,
+                close_caller_uses_inline_delivery=close_caller_uses_inline_delivery,
+            )
+            if deferred:
+                await self._event_dispatcher.drop_queued_events_for_resource(self._connection_id)
+            if deferred_waiter is not None:
+                await asyncio.shield(deferred_waiter)
+            if not deferred:
+                await self._event_dispatcher.drop_queued_events_for_resource(self._connection_id)
+                await self._finalize_close()
         finally:
             async with self._close_lock:
                 current_task = asyncio.current_task()
@@ -337,6 +411,13 @@ class AsyncioTcpConnection(ConnectionProtocol):
         result = self._on_ready_callback(self)
         if asyncio.iscoroutine(result):
             _ = await result
+
+    def _pending_deferred_close_waiter(self) -> asyncio.Future[None] | None:
+        """Return the in-flight deferred close publication waiter, if any."""
+        waiter = self._deferred_close_event_waiter
+        if waiter is None or waiter.done():
+            return None
+        return waiter
 
     async def _finalize_close(self) -> None:
         """
@@ -386,6 +467,171 @@ class AsyncioTcpConnection(ConnectionProtocol):
             _ = await cast(Awaitable[object], publication_task)
         if cancelled_during_emit:
             raise asyncio.CancelledError
+
+    async def _defer_close_event_until_opened_event_completes(
+        self,
+        close_caller_task: asyncio.Task[None] | None,
+        *,
+        close_caller_uses_inline_delivery: bool,
+    ) -> tuple[bool, asyncio.Future[None] | None]:
+        """Defer close publication while a connection handler is in flight."""
+        async with self._close_lock:
+            opening_event_task = self._opening_event_task
+            inherited_handler_origin = (
+                self._event_dispatcher.current_task_inherits_handler_origin_context(
+                    self._connection_id
+                )
+            )
+            handler_origin_in_flight = (
+                close_caller_task is opening_event_task
+                or self._event_dispatcher.current_task_is_dispatching_handler(self._connection_id)
+                or self._event_dispatcher.current_task_has_handler_origin_context(
+                    self._connection_id
+                )
+            )
+            active_inline_handler_in_flight = (
+                self._event_dispatcher.has_active_handler_context(self._connection_id)
+                and self._event_dispatcher.current_task_would_deliver_inline()
+            )
+            if (
+                opening_event_task is None
+                and not handler_origin_in_flight
+                and not close_caller_uses_inline_delivery
+                and not inherited_handler_origin
+                and not active_inline_handler_in_flight
+                and not self._close_event_deferred_until_opened_event_completes
+            ):
+                return False, None
+            self._state = ConnectionState.CLOSED
+            self._close_event_deferred_until_opened_event_completes = True
+            if (
+                self._deferred_close_event_waiter is None
+                or self._deferred_close_event_waiter.done()
+            ):
+                current_task = asyncio.current_task()
+                loop = (
+                    current_task.get_loop()
+                    if current_task is not None
+                    else asyncio.get_running_loop()
+                )
+                self._deferred_close_event_waiter = loop.create_future()
+            if opening_event_task is None and (
+                handler_origin_in_flight
+                or close_caller_uses_inline_delivery
+                or inherited_handler_origin
+                or active_inline_handler_in_flight
+            ):
+                publish_task = self._deferred_close_publish_task
+                if publish_task is None or publish_task.done():
+                    self._deferred_close_publish_task = asyncio.create_task(
+                        self._publish_deferred_close_after_handler_context_expires(),
+                        name=f"{self._connection_id}-deferred-close-publisher",
+                    )
+            # Handler-originated close paths cannot await this waiter: the
+            # active handler must return before the deferred close event may run.
+            # External close callers do get the waiter so their close() call
+            # still observes terminal publication.
+            if (
+                handler_origin_in_flight
+                or close_caller_uses_inline_delivery
+                or inherited_handler_origin
+                or self._event_dispatcher.current_task_has_handler_origin_context(
+                    self._connection_id
+                )
+            ):
+                return True, None
+            return True, self._deferred_close_event_waiter
+
+    async def _ensure_deferred_close_publication_waiter(self) -> asyncio.Future[None] | None:
+        """Ensure unpublished terminal close has a deferred publication waiter."""
+        async with self._close_lock:
+            if self._closed_event_published:
+                return None
+            self._close_event_deferred_until_opened_event_completes = True
+            if (
+                self._deferred_close_event_waiter is None
+                or self._deferred_close_event_waiter.done()
+            ):
+                current_task = asyncio.current_task()
+                loop = (
+                    current_task.get_loop()
+                    if current_task is not None
+                    else asyncio.get_running_loop()
+                )
+                self._deferred_close_event_waiter = loop.create_future()
+            publish_task = self._deferred_close_publish_task
+            if publish_task is None or publish_task.done():
+                self._deferred_close_publish_task = asyncio.create_task(
+                    self._publish_deferred_close_after_handler_context_expires(),
+                    name=f"{self._connection_id}-deferred-close-publisher",
+                )
+            return self._deferred_close_event_waiter
+
+    async def _publish_deferred_close_after_handler_context_expires(self) -> None:
+        """Publish a deferred close once active connection handlers have unwound."""
+        current_task = asyncio.current_task()
+        try:
+            while self._event_dispatcher.has_active_handler_context(self._connection_id):
+                await asyncio.sleep(0)
+            await self._publish_deferred_close_after_opened_event()
+        except (Exception, asyncio.CancelledError) as error:
+            async with self._close_lock:
+                deferred_waiter = self._deferred_close_event_waiter
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    deferred_waiter.exception()
+            if not isinstance(error, asyncio.CancelledError):
+                self._logger.warning("Deferred close publication failed: %s", error)
+        finally:
+            async with self._close_lock:
+                if self._deferred_close_publish_task is current_task:
+                    self._deferred_close_publish_task = None
+
+    async def _publish_deferred_close_after_opened_event_preserving_cancellation(self) -> bool:
+        """Publish deferred close even if the opening task is cancelled at the barrier."""
+        publish_task = asyncio.create_task(self._publish_deferred_close_after_opened_event())
+        caller_cancelled = False
+        try:
+            while True:
+                try:
+                    result = await asyncio.shield(publish_task)
+                    break
+                except asyncio.CancelledError:
+                    caller_cancelled = True
+                    if publish_task.done():
+                        result = publish_task.result()
+                        break
+                    continue
+        finally:
+            if caller_cancelled and not publish_task.done():
+                _ = await asyncio.shield(publish_task)
+        if caller_cancelled:
+            raise asyncio.CancelledError
+        return result
+
+    async def _publish_deferred_close_after_opened_event(self) -> bool:
+        """Publish a close event deferred until ConnectionOpenedEvent handling completed."""
+        async with self._close_lock:
+            if not self._close_event_deferred_until_opened_event_completes:
+                return False
+            self._close_event_deferred_until_opened_event_completes = False
+            deferred_waiter = self._deferred_close_event_waiter
+        try:
+            with self._event_dispatcher.inline_delivery_context():
+                await self._finalize_close()
+        except (Exception, asyncio.CancelledError) as error:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+            raise
+        else:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_result(None)
+        finally:
+            async with self._close_lock:
+                if self._deferred_close_event_waiter is deferred_waiter:
+                    self._deferred_close_event_waiter = None
+        return True
 
     async def _run_close_event_publication(self, previous_state: ConnectionState) -> None:
         """Emit the terminal close event and mark publication success atomically."""

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -205,6 +205,11 @@ class AsyncioTcpServer(TcpServerProtocol):
         stopped_event: ComponentLifecycleChangedEvent | None = None
         should_transition_to_stopped = False
         stop_waiter: asyncio.Future[None] | None = None
+        deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
+        stop_waiter_completion_deferred = False
+        dispatcher_stopped_from_handler_origin = False
+        active_inline_handler_stop = False
+        defer_stop_events = False
         owns_stop = False
         heartbeat_senders: tuple[AsyncioHeartbeatSender, ...] = ()
         connections: tuple[AsyncioTcpConnection, ...] = ()
@@ -234,69 +239,127 @@ class AsyncioTcpServer(TcpServerProtocol):
                 self._connections.clear()
         if not owns_stop:
             if stop_waiter is not None:
-                if self._event_dispatcher.current_task_is_worker():
+                if (
+                    self._event_dispatcher.current_task_is_dispatching_handler()
+                    or self._event_dispatcher.current_task_has_handler_origin_context()
+                    or self._event_dispatcher.current_task_inherits_handler_origin_context()
+                ):
                     return
                 await asyncio.shield(stop_waiter)
             return
-        inline_delivery_context = (
-            self._event_dispatcher.inline_delivery_context()
-            if self._event_dispatcher.current_task_is_worker()
-            else contextlib.nullcontext()
+        handler_originated_stop = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+            or self._event_dispatcher.current_task_inherits_handler_origin_context()
         )
+        active_inline_handler_stop = (
+            not handler_originated_stop
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        defer_stop_events = handler_originated_stop or active_inline_handler_stop
         try:
-            with inline_delivery_context:
-                first_error: BaseException | None = None
+            first_error: BaseException | None = None
+            if not defer_stop_events:
                 try:
                     await self._emit_lifecycle_event(stopping_event)
                 except (Exception, asyncio.CancelledError) as error:
                     first_error = error
+            else:
                 try:
-                    if server is not None:
-                        server.close()
-                    await stop_server_heartbeat_senders(
-                        senders=heartbeat_senders,
-                        event_dispatcher=self._event_dispatcher,
-                        logger=self._logger,
-                        component_id=self._component_id,
+                    await self._event_dispatcher.stop_from_handler_origin()
+                    dispatcher_stopped_from_handler_origin = True
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+            try:
+                if server is not None:
+                    server.close()
+                await stop_server_heartbeat_senders(
+                    senders=heartbeat_senders,
+                    event_dispatcher=self._event_dispatcher,
+                    logger=self._logger,
+                    component_id=self._component_id,
+                )
+                if connections:
+                    close_context = (
+                        self._event_dispatcher.inline_delivery_context()
+                        if defer_stop_events
+                        else contextlib.nullcontext()
                     )
-                    if connections:
+                    with close_context:
                         close_results = await asyncio.gather(
                             *(connection.close() for connection in connections),
                             return_exceptions=True,
                         )
-                        await report_teardown_errors(
-                            event_dispatcher=self._event_dispatcher,
-                            logger=self._logger,
-                            component_id=self._component_id,
-                            operation="TCP connection close",
-                            targets=(connection.connection_id for connection in connections),
-                            results=close_results,
-                        )
-                    if server is not None:
-                        await server.wait_closed()
-                except (Exception, asyncio.CancelledError) as error:
+                    deferred_close_waiters = await self._pending_deferred_close_waiters(connections)
+                    await report_teardown_errors(
+                        event_dispatcher=self._event_dispatcher,
+                        logger=self._logger,
+                        component_id=self._component_id,
+                        operation="TCP connection close",
+                        targets=(connection.connection_id for connection in connections),
+                        results=close_results,
+                    )
+                if server is not None:
+                    await server.wait_closed()
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+            if should_transition_to_stopped:
+                async with self._state_lock:
+                    stopped_event = apply_stopped_transition_if_stopping(
+                        get_state=lambda: self._lifecycle_state,
+                        apply_transition=self._apply_lifecycle_state,
+                    )
+                if defer_stop_events:
                     if first_error is None:
-                        first_error = error
-                if should_transition_to_stopped:
-                    async with self._state_lock:
-                        stopped_event = apply_stopped_transition_if_stopping(
-                            get_state=lambda: self._lifecycle_state,
-                            apply_transition=self._apply_lifecycle_state,
+                        self._complete_stop_waiter_after_deferred_stop_events(
+                            stop_waiter=stop_waiter,
+                            stopping_event=stopping_event,
+                            stopped_event=stopped_event,
+                            deferred_close_waiters=deferred_close_waiters,
                         )
+                        stop_waiter_completion_deferred = True
+                else:
                     if first_error is None:
                         try:
                             await self._emit_lifecycle_event(stopped_event)
                         except (Exception, asyncio.CancelledError) as error:
                             first_error = error
+                if not defer_stop_events:
                     try:
                         await self._event_dispatcher.stop()
                     except (Exception, asyncio.CancelledError) as error:
                         if first_error is None:
                             first_error = error
-                self._notify_status_changed()
-                self._logger.debug("TCP server stopped.")
-                if first_error is not None:
-                    raise first_error
+            elif (
+                defer_stop_events
+                and first_error is None
+                and not dispatcher_stopped_from_handler_origin
+            ):
+                try:
+                    await self._event_dispatcher.stop_from_handler_origin()
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+            if not should_transition_to_stopped and defer_stop_events and first_error is None:
+                self._complete_stop_waiter_after_deferred_stop_events(
+                    stop_waiter=stop_waiter,
+                    stopping_event=stopping_event,
+                    stopped_event=None,
+                    deferred_close_waiters=deferred_close_waiters,
+                )
+                stop_waiter_completion_deferred = True
+            if (
+                active_inline_handler_stop
+                and first_error is None
+                and stop_waiter is not None
+                and not stop_waiter.done()
+            ):
+                await asyncio.shield(stop_waiter)
+            self._notify_status_changed()
+            self._logger.debug("TCP server stopped.")
+            if first_error is not None:
+                raise first_error
         except (Exception, asyncio.CancelledError) as error:
             if stop_waiter is not None and not stop_waiter.done():
                 stop_waiter.set_exception(error)
@@ -305,11 +368,107 @@ class AsyncioTcpServer(TcpServerProtocol):
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                stop_waiter.set_result(None)
+                if stop_waiter_completion_deferred:
+                    pass
+                elif defer_stop_events and deferred_close_waiters:
+                    self._complete_stop_waiter_after_deferred_closes(
+                        stop_waiter, deferred_close_waiters
+                    )
+                    stop_waiter_completion_deferred = True
+                else:
+                    stop_waiter.set_result(None)
         finally:
-            async with self._state_lock:
-                if self._stop_waiter is stop_waiter:
-                    self._stop_waiter = None
+            if not stop_waiter_completion_deferred:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+
+    def _complete_stop_waiter_after_deferred_closes(
+        self,
+        stop_waiter: asyncio.Future[None],
+        deferred_close_waiters: tuple[asyncio.Future[None], ...],
+    ) -> None:
+        """Release external stop waiters after handler-originated deferred close publication."""
+
+        async def _complete() -> None:
+            try:
+                await asyncio.gather(*(asyncio.shield(waiter) for waiter in deferred_close_waiters))
+            except BaseException as error:
+                if not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_stop_events(
+        self,
+        *,
+        stop_waiter: asyncio.Future[None] | None,
+        stopping_event: ComponentLifecycleChangedEvent | None,
+        stopped_event: ComponentLifecycleChangedEvent | None,
+        deferred_close_waiters: tuple[asyncio.Future[None], ...],
+    ) -> None:
+        """Publish terminal stop events after a handler-originated stop unwinds."""
+
+        async def _complete() -> None:
+            try:
+                while self._event_dispatcher.has_active_handler_context():
+                    await asyncio.sleep(0)
+                with self._event_dispatcher.inline_delivery_context():
+                    await self._emit_lifecycle_event(stopping_event)
+                    if deferred_close_waiters:
+                        await asyncio.gather(
+                            *(asyncio.shield(waiter) for waiter in deferred_close_waiters)
+                        )
+                    await self._emit_lifecycle_event(stopped_event)
+                await self._event_dispatcher.stop()
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._stop_waiter is stop_waiter:
+                        self._stop_waiter = None
+
+        _ = asyncio.create_task(_complete())
+
+    async def _pending_deferred_close_waiters(
+        self, connections: tuple[AsyncioTcpConnection, ...]
+    ) -> tuple[asyncio.Future[None], ...]:
+        """Collect or create deferred close waiters from managed TCP connections."""
+        waiters: list[asyncio.Future[None]] = []
+        for connection in connections:
+            get_waiter = getattr(connection, "_pending_deferred_close_waiter", None)
+            if get_waiter is None:
+                continue
+            if waiter := get_waiter():
+                waiters.append(waiter)
+                continue
+            if (
+                not connection._closed_event_published
+                and (
+                    self._event_dispatcher.has_active_handler_context(connection.connection_id)
+                    or self._event_dispatcher.current_task_inherits_handler_origin_context(
+                        connection.connection_id
+                    )
+                )
+                and (waiter := await connection._ensure_deferred_close_publication_waiter())
+            ):
+                waiters.append(waiter)
+        return tuple(waiters)
 
     async def __aenter__(self) -> AsyncioTcpServer:
         """Start the server and return ``self``."""

--- a/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
+++ b/src/aionetx/implementations/asyncio_impl/tcp_client_supervision.py
@@ -47,6 +47,7 @@ class _TcpClientForSupervision(Protocol):
     _running: bool
     _settings: TcpClientSettings
     _state_lock: asyncio.Lock
+    _stop_waiter: asyncio.Future[None] | None
     _status_changed: asyncio.Event
     _status_version: int
 
@@ -59,7 +60,7 @@ class _TcpClientForSupervision(Protocol):
     ) -> ComponentLifecycleChangedEvent | None:
         raise NotImplementedError
 
-    async def _close_current_connection(self) -> None:
+    async def _close_current_connection(self) -> tuple[asyncio.Future[None], ...]:
         raise NotImplementedError
 
     async def _connect_once(self) -> None:
@@ -165,7 +166,8 @@ class TcpClientConnectionSupervisor:
 
     async def _run_connect_cycle(self) -> bool:
         """Run one connect-to-disconnect cycle and decide whether supervision continues."""
-        await self._start_connect_attempt()
+        if not await self._start_connect_attempt():
+            return False
         await self._await_connection_termination()
         return await self._schedule_reconnect_after_disconnect()
 
@@ -195,7 +197,7 @@ class TcpClientConnectionSupervisor:
         policy = self._capture_failure_state(error)
         return _FailureOutcome(policy=policy, reconnect=self._plan_reconnect())
 
-    async def _start_connect_attempt(self) -> None:
+    async def _start_connect_attempt(self) -> bool:
         """Advance attempt counters, publish start notification, and open one connection."""
         client = self._client
         client._last_connect_error = None
@@ -207,9 +209,14 @@ class TcpClientConnectionSupervisor:
                 attempt=client._attempt_counter,
             )
         )
+        if not client._running or client._lifecycle_state != ComponentLifecycleState.RUNNING:
+            return False
         await client._connect_once()
+        if not client._running:
+            return False
         client._backoff.reset()
         client._logger.debug("TCP client connected.")
+        return True
 
     async def _await_connection_termination(self) -> None:
         """Wait until the current connection disappears or reaches ``CLOSED``."""
@@ -340,7 +347,10 @@ class TcpClientConnectionSupervisor:
         """Leave the client in a fully stopped state after supervision exits."""
         try:
             await self._shutdown_active_resources()
-            await self._publish_terminal_lifecycle_transitions()
+            async with self._client._state_lock:
+                explicit_stop_in_progress = self._client._stop_waiter is not None
+            if not explicit_stop_in_progress:
+                await self._publish_terminal_lifecycle_transitions()
         finally:
             await self._stop_dispatcher()
 
@@ -360,6 +370,9 @@ class TcpClientConnectionSupervisor:
         # Supervision can reach a terminal state on its own, for example after a
         # non-retrying connect failure. The dispatcher is still stopped here so
         # background delivery never outlives the final STOPPED transition.
+        async with self._client._state_lock:
+            if self._client._stop_waiter is not None:
+                return
         await self._client._event_dispatcher.stop()
 
     async def _collect_terminal_lifecycle_events(self) -> list[ComponentLifecycleChangedEvent]:

--- a/tests/integration/test_concurrency_scenarios.py
+++ b/tests/integration/test_concurrency_scenarios.py
@@ -945,12 +945,8 @@ async def test_inline_attempt_started_handler_can_stop_client_before_socket_open
 
     try:
         await asyncio.wait_for(client.start(), timeout=3.0)
-        supervisor_task = client._supervisor_task
         await asyncio.wait_for(handler.attempt_seen.wait(), timeout=3.0)
         await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
-        assert supervisor_task is not None
-        with contextlib.suppress(asyncio.CancelledError):
-            await asyncio.wait_for(supervisor_task, timeout=3.0)
     finally:
         with contextlib.suppress(Exception, asyncio.CancelledError):
             await asyncio.wait_for(client.stop(), timeout=1.0)
@@ -959,6 +955,7 @@ async def test_inline_attempt_started_handler_can_stop_client_before_socket_open
     assert not opener_called.is_set()
     assert client.lifecycle_state == ComponentLifecycleState.STOPPED
     assert client.connection is None
+    assert client._supervisor_task is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_concurrency_scenarios.py
+++ b/tests/integration/test_concurrency_scenarios.py
@@ -15,6 +15,7 @@ import socket
 
 import pytest
 
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.connection_events import ConnectionClosedEvent
@@ -25,6 +26,7 @@ from aionetx.api.event_delivery_settings import (
     EventHandlerFailurePolicy,
 )
 from aionetx.api.network_event import NetworkEvent
+from aionetx.api.reconnect_events import ReconnectAttemptStartedEvent
 from aionetx.api.tcp_client import TcpClientSettings
 from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings
 from aionetx.api.tcp_server import TcpServerSettings
@@ -258,8 +260,705 @@ async def test_stop_component_policy_background_mode_stops_client_on_handler_fai
         )
         assert handler.called, "Handler must have been called at least once."
     finally:
-        await client.stop()
-        await server.stop()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_opened_handler_can_stop_client_without_overlapping_connection_events(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    port = _unused_port()
+
+    class _StopClientOnOpen:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.stop_error: BaseException | None = None
+            self.active_connection_handlers = 0
+            self.max_active_connection_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            is_connection_event = isinstance(event, (ConnectionOpenedEvent, ConnectionClosedEvent))
+            if is_connection_event:
+                self.active_connection_handlers += 1
+                self.max_active_connection_handlers = max(
+                    self.max_active_connection_handlers,
+                    self.active_connection_handlers,
+                )
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.client is None:
+                    raise AssertionError("client reference was not attached")
+                await self.client.stop()
+                assert not self.closed_seen.is_set()
+                assert self.max_active_connection_handlers == 1
+                assert self.client.lifecycle_state == ComponentLifecycleState.STOPPED
+                assert self.client.connection is None
+                assert self.client._starting_connection is None
+            except BaseException as error:
+                self.stop_error = error
+            finally:
+                if is_connection_event:
+                    self.active_connection_handlers -= 1
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+                    self.stop_returned.set()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    handler = _StopClientOnOpen()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    handler.client = client
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+        await wait_for_condition(
+            lambda: (
+                client.lifecycle_state == ComponentLifecycleState.STOPPED
+                and client.connection is None
+            ),
+            timeout_seconds=3.0,
+        )
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.stop_error is None
+    assert handler.opened_finished.is_set()
+    assert handler.closed_seen.is_set()
+    assert handler.max_active_connection_handlers == 1
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_client_opened_handler_can_observe_active_connection(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    port = _unused_port()
+
+    class _ObserveConnectionOnOpen:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.opened_checked = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ConnectionOpenedEvent):
+                return
+            if self.client is None:
+                raise AssertionError("client reference was not attached")
+            try:
+                connection = self.client.connection
+                assert connection is not None
+                observed = await self.client.wait_until_connected(timeout_seconds=1.0)
+                assert observed is connection
+            except BaseException as error:
+                self.error = error
+            finally:
+                self.opened_checked.set()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    handler = _ObserveConnectionOnOpen()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    handler.client = client
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_checked.wait(), timeout=3.0)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_external_client_stop_waits_for_handler_owned_deferred_close() -> None:
+    port = _unused_port()
+
+    class _StopClientOnOpenWithBlockedStopping:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stopping_seen = asyncio.Event()
+            self.allow_stopping_to_finish = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
+            self.handler_stop_returned = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                    return
+                if (
+                    isinstance(event, ComponentLifecycleChangedEvent)
+                    and event.current == ComponentLifecycleState.STOPPING
+                ):
+                    assert self.opened_finished.is_set()
+                    self.stopping_seen.set()
+                    await self.allow_stopping_to_finish.wait()
+                    return
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.client is None:
+                    raise AssertionError("client reference was not attached")
+                await self.client.stop()
+                self.handler_stop_returned.set()
+                await self.allow_opened_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+            finally:
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    handler = _StopClientOnOpenWithBlockedStopping()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.client = client
+    external_stop_task: asyncio.Task[None] | None = None
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+
+        external_stop_task = asyncio.create_task(client.stop())
+        await asyncio.wait_for(handler.handler_stop_returned.wait(), timeout=3.0)
+        await asyncio.sleep(0)
+        assert not external_stop_task.done()
+        assert not handler.stopping_seen.is_set()
+
+        handler.allow_opened_to_finish.set()
+        await asyncio.wait_for(handler.stopping_seen.wait(), timeout=3.0)
+        await asyncio.sleep(0)
+        assert not external_stop_task.done()
+
+        handler.allow_stopping_to_finish.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(external_stop_task, timeout=3.0)
+    finally:
+        handler.allow_stopping_to_finish.set()
+        handler.allow_opened_to_finish.set()
+        if external_stop_task is not None and not external_stop_task.done():
+            external_stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(external_stop_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+    assert handler.closed_seen.is_set()
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_opened_handler_spawned_client_stop_task_does_not_overlap_connection_events(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    port = _unused_port()
+
+    class _SpawnStopTaskOnOpen:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.stop_error: BaseException | None = None
+            self.active_connection_handlers = 0
+            self.max_active_connection_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            is_connection_event = isinstance(event, (ConnectionOpenedEvent, ConnectionClosedEvent))
+            if is_connection_event:
+                self.active_connection_handlers += 1
+                self.max_active_connection_handlers = max(
+                    self.max_active_connection_handlers,
+                    self.active_connection_handlers,
+                )
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.client is None:
+                    raise AssertionError("client reference was not attached")
+                stop_task = asyncio.create_task(self.client.stop())
+                await stop_task
+                assert not self.closed_seen.is_set()
+                assert self.max_active_connection_handlers == 1
+                assert self.client.lifecycle_state == ComponentLifecycleState.STOPPED
+                assert self.client.connection is None
+            except BaseException as error:
+                self.stop_error = error
+            finally:
+                if is_connection_event:
+                    self.active_connection_handlers -= 1
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+                    self.stop_returned.set()
+
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    handler = _SpawnStopTaskOnOpen()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    handler.client = client
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.stop_error is None
+    assert handler.max_active_connection_handlers == 1
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_opened_handler_can_stop_server_without_overlapping_connection_events(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    port = _unused_port()
+
+    class _StopServerOnOpen:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.stop_error: BaseException | None = None
+            self.active_connection_handlers = 0
+            self.max_active_connection_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            is_connection_event = isinstance(event, (ConnectionOpenedEvent, ConnectionClosedEvent))
+            if is_connection_event:
+                self.active_connection_handlers += 1
+                self.max_active_connection_handlers = max(
+                    self.max_active_connection_handlers,
+                    self.active_connection_handlers,
+                )
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+                assert not self.closed_seen.is_set()
+                assert self.max_active_connection_handlers == 1
+                assert self.server.lifecycle_state == ComponentLifecycleState.STOPPED
+                assert self.server.connections == ()
+            except BaseException as error:
+                self.stop_error = error
+            finally:
+                if is_connection_event:
+                    self.active_connection_handlers -= 1
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+                    self.stop_returned.set()
+
+    handler = _StopServerOnOpen()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    handler.server = server
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.stop_error is None
+    assert handler.opened_finished.is_set()
+    assert handler.closed_seen.is_set()
+    assert handler.max_active_connection_handlers == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server.connections == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_opened_handler_spawned_server_stop_task_does_not_overlap_connection_events(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    port = _unused_port()
+
+    class _SpawnServerStopTaskOnOpen:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.stop_error: BaseException | None = None
+            self.active_connection_handlers = 0
+            self.max_active_connection_handlers = 0
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            is_connection_event = isinstance(event, (ConnectionOpenedEvent, ConnectionClosedEvent))
+            if is_connection_event:
+                self.active_connection_handlers += 1
+                self.max_active_connection_handlers = max(
+                    self.max_active_connection_handlers,
+                    self.active_connection_handlers,
+                )
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                stop_task = asyncio.create_task(self.server.stop())
+                await stop_task
+                assert not self.closed_seen.is_set()
+                assert self.max_active_connection_handlers == 1
+                assert self.server.lifecycle_state == ComponentLifecycleState.STOPPED
+                assert self.server.connections == ()
+            except BaseException as error:
+                self.stop_error = error
+            finally:
+                if is_connection_event:
+                    self.active_connection_handlers -= 1
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+                    self.stop_returned.set()
+
+    handler = _SpawnServerStopTaskOnOpen()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    handler.server = server
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.stop_error is None
+    assert handler.opened_finished.is_set()
+    assert handler.closed_seen.is_set()
+    assert handler.max_active_connection_handlers == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server.connections == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_external_server_stop_waits_for_handler_owned_deferred_close() -> None:
+    port = _unused_port()
+
+    class _StopServerOnOpenWithBlockedStopping:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.opened_seen = asyncio.Event()
+            self.opened_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stopping_seen = asyncio.Event()
+            self.allow_stopping_to_finish = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
+            self.handler_stop_returned = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            try:
+                if isinstance(event, ConnectionClosedEvent):
+                    assert self.opened_finished.is_set()
+                    self.closed_seen.set()
+                    return
+                if (
+                    isinstance(event, ComponentLifecycleChangedEvent)
+                    and event.current == ComponentLifecycleState.STOPPING
+                ):
+                    assert self.opened_finished.is_set()
+                    self.stopping_seen.set()
+                    await self.allow_stopping_to_finish.wait()
+                    return
+                if not isinstance(event, ConnectionOpenedEvent):
+                    return
+                self.opened_seen.set()
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+                self.handler_stop_returned.set()
+                await self.allow_opened_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+            finally:
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_finished.set()
+
+    handler = _StopServerOnOpenWithBlockedStopping()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    handler.server = server
+    external_stop_task: asyncio.Task[None] | None = None
+
+    try:
+        await server.start()
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=3.0)
+
+        external_stop_task = asyncio.create_task(server.stop())
+        await asyncio.wait_for(handler.handler_stop_returned.wait(), timeout=3.0)
+        await asyncio.sleep(0)
+        assert not external_stop_task.done()
+        assert not handler.stopping_seen.is_set()
+
+        handler.allow_opened_to_finish.set()
+        await asyncio.wait_for(handler.stopping_seen.wait(), timeout=3.0)
+        await asyncio.sleep(0)
+        assert not external_stop_task.done()
+
+        handler.allow_stopping_to_finish.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(external_stop_task, timeout=3.0)
+    finally:
+        handler.allow_stopping_to_finish.set()
+        handler.allow_opened_to_finish.set()
+        if external_stop_task is not None and not external_stop_task.done():
+            external_stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(external_stop_task, timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+    assert handler.closed_seen.is_set()
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server.connections == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_inline_attempt_started_handler_can_stop_client_before_socket_open() -> None:
+    opener_called = asyncio.Event()
+
+    async def _open_connection(**_kwargs: object):
+        opener_called.set()
+        raise AssertionError("connection opener should not run after attempt-start stop")
+
+    class _StopClientOnAttemptStarted:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.attempt_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.stop_error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if not isinstance(event, ReconnectAttemptStartedEvent):
+                return
+            self.attempt_seen.set()
+            if self.client is None:
+                raise AssertionError("client reference was not attached")
+            try:
+                await self.client.stop()
+            except BaseException as error:
+                self.stop_error = error
+            finally:
+                self.stop_returned.set()
+
+    handler = _StopClientOnAttemptStarted()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=1,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+        connection_opener=_open_connection,
+    )
+    handler.client = client
+
+    try:
+        await asyncio.wait_for(client.start(), timeout=3.0)
+        supervisor_task = client._supervisor_task
+        await asyncio.wait_for(handler.attempt_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        assert supervisor_task is not None
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.wait_for(supervisor_task, timeout=3.0)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+
+    assert handler.stop_error is None
+    assert not opener_called.is_set()
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
 
 
 @pytest.mark.asyncio
@@ -305,8 +1004,443 @@ async def test_handler_initiated_client_stop_publishes_connection_closed_event()
         await server.broadcast(b"stop-from-handler")
         await asyncio.wait_for(stop_returned.wait(), timeout=3.0)
 
-        assert client.lifecycle_state == ComponentLifecycleState.STOPPED
-        assert any(isinstance(event, ConnectionClosedEvent) for event in client_handler.events)
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await wait_for_condition(
+            lambda: any(
+                isinstance(event, ConnectionClosedEvent) for event in client_handler.events
+            ),
+            timeout_seconds=3.0,
+        )
     finally:
         await client.stop()
         await server.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_inline_client_stop_from_bytes_handler_defers_terminal_events() -> None:
+    port = _unused_port()
+    stop_returned = asyncio.Event()
+
+    class _StopOnBytesAndBlock:
+        def __init__(self) -> None:
+            self.client: AsyncioTcpClient | None = None
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.error: BaseException | None = None
+            self._stopped = False
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent) and not self._stopped:
+                self._stopped = True
+                assert self.client is not None
+                await self.client.stop()
+                stop_returned.set()
+                if self.terminal_event_seen.is_set():
+                    self.error = AssertionError("terminal event was published before stop returned")
+                    self.release_bytes.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    handler = _StopOnBytesAndBlock()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    handler.client = client
+
+    await server.start()
+    try:
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await server.broadcast(b"inline-stop-from-handler")
+        await asyncio.wait_for(stop_returned.wait(), timeout=3.0)
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+
+        handler.release_bytes.set()
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=3.0)
+    finally:
+        handler.release_bytes.set()
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_inline_server_stop_from_bytes_handler_defers_terminal_events() -> None:
+    port = _unused_port()
+    stop_returned = asyncio.Event()
+
+    class _StopOnBytesAndBlock:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.error: BaseException | None = None
+            self.bytes_payloads: list[bytes] = []
+            self._stopped = False
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_payloads.append(event.data)
+                if self._stopped:
+                    self.error = AssertionError("bytes event delivered after server stop")
+                    self.release_bytes.set()
+                    return
+                self._stopped = True
+                assert self.server is not None
+                await self.server.stop()
+                stop_returned.set()
+                if self.terminal_event_seen.is_set():
+                    self.error = AssertionError("terminal event was published before stop returned")
+                    self.release_bytes.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    handler = _StopOnBytesAndBlock()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    handler.server = server
+
+    await server.start()
+    try:
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"first")
+        await asyncio.wait_for(stop_returned.wait(), timeout=3.0)
+        with contextlib.suppress(Exception):
+            await connection.send(b"second")
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+
+        handler.release_bytes.set()
+        await wait_for_condition(
+            lambda: server.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=3.0)
+    finally:
+        handler.release_bytes.set()
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None
+    assert handler.bytes_payloads == [b"first"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_spawned_server_stop_preserves_close_events_for_two_real_clients() -> None:
+    port = _unused_port()
+
+    class _SpawnStopFromBytesAndBlock:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.opened_ids: list[str] = []
+            self.closed_ids: list[str] = []
+            self.origin_connection_id: str | None = None
+            self.bytes_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_ids.append(event.resource_id)
+                return
+            if isinstance(event, ConnectionClosedEvent):
+                if (
+                    event.resource_id == self.origin_connection_id
+                    and not self.bytes_finished.is_set()
+                ):
+                    self.error = AssertionError("origin close event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_ids.append(event.resource_id)
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+
+            async def child_stop() -> None:
+                assert self.server is not None
+                await self.server.stop()
+                self.stop_returned.set()
+
+            self.origin_connection_id = event.resource_id
+            self.bytes_seen.set()
+            try:
+                self.stop_task = asyncio.create_task(child_stop())
+                await self.stop_task
+                if event.resource_id in self.closed_ids:
+                    raise AssertionError("origin close event was published before handler returned")
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    handler = _SpawnStopFromBytesAndBlock()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.server = server
+    client_streams: list[tuple[asyncio.StreamReader, asyncio.StreamWriter]] = []
+
+    await server.start()
+    try:
+        client_streams.append(await asyncio.open_connection("127.0.0.1", port))
+        client_streams.append(await asyncio.open_connection("127.0.0.1", port))
+        await wait_for_condition(lambda: len(handler.opened_ids) == 2, timeout_seconds=3.0)
+
+        _, first_writer = client_streams[0]
+        first_writer.write(b"spawned-server-stop")
+        await first_writer.drain()
+
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=3.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=3.0)
+        assert handler.origin_connection_id not in handler.closed_ids
+
+        handler.release_bytes.set()
+        await wait_for_condition(
+            lambda: set(handler.closed_ids) == set(handler.opened_ids),
+            timeout_seconds=3.0,
+        )
+    finally:
+        handler.release_bytes.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.stop_task, timeout=1.0)
+        for _, writer in client_streams:
+            writer.close()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await writer.wait_closed()
+        await server.stop()
+
+    assert handler.error is None
+    assert handler.origin_connection_id is not None
+    assert len(handler.opened_ids) == 2
+    assert set(handler.closed_ids) == set(handler.opened_ids)
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_external_inline_client_stop_waits_for_active_bytes_handler() -> None:
+    port = _unused_port()
+
+    class _BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    handler = _BlockingBytesHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    stop_task: asyncio.Task[None] | None = None
+    await server.start()
+    try:
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await server.broadcast(b"external-client-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=3.0)
+
+        stop_task = asyncio.create_task(client.stop())
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=3.0,
+        )
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+        assert stop_task.done() is False
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(stop_task, timeout=3.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=3.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_external_inline_server_stop_waits_for_active_bytes_handler() -> None:
+    port = _unused_port()
+
+    class _BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    handler = _BlockingBytesHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    stop_task: asyncio.Task[None] | None = None
+    await server.start()
+    try:
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"external-server-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=3.0)
+
+        stop_task = asyncio.create_task(server.stop())
+        await wait_for_condition(
+            lambda: server.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=3.0,
+        )
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+        assert stop_task.done() is False
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(stop_task, timeout=3.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=3.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -40,6 +40,7 @@ from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioT
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
+from tests.helpers import wait_for_condition
 from tests.internal_asyncio_impl_refs import WarningRateLimiter
 
 
@@ -595,6 +596,8 @@ async def test_client_connect_attempt_clears_cached_last_connect_error_before_ne
     )
     observed_cached_error: list[object] = []
     client._last_connect_error = RuntimeError("stale-connect-error")  # type: ignore[attr-defined]
+    client._apply_lifecycle_state(ComponentLifecycleState.STARTING)  # type: ignore[attr-defined]
+    client._apply_lifecycle_state(ComponentLifecycleState.RUNNING)  # type: ignore[attr-defined]
 
     async def fake_connect_once() -> None:
         observed_cached_error.append(client._last_connect_error)  # type: ignore[attr-defined]
@@ -1173,6 +1176,14 @@ async def test_stop_component_policy_from_worker_with_full_queue_stops_client() 
 
     await asyncio.wait_for(_wait_until_stopped(), timeout=1.0)
     await asyncio.wait_for(client._event_dispatcher.stop(), timeout=1.0)  # type: ignore[attr-defined]
+    await wait_for_condition(
+        lambda: any(
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == tcp_client_module.ComponentLifecycleState.STOPPING
+            for event in observed_events
+        ),
+        timeout_seconds=1.0,
+    )
 
     lifecycle_states = [
         event.current

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -158,7 +158,7 @@ async def test_tcp_connection_dispatch_waits_for_opened_before_reading(
     dispatch_mode: EventDispatchMode,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class BlockingOpenedHandler:
+    class BlockingInlineHandler:
         def __init__(self) -> None:
             self.opened_started = asyncio.Event()
             self.opened_finished = asyncio.Event()
@@ -182,7 +182,7 @@ async def test_tcp_connection_dispatch_waits_for_opened_before_reading(
                 if is_opened_event:
                     self.opened_finished.set()
 
-    handler = BlockingOpenedHandler()
+    handler = BlockingInlineHandler()
     read_task_created = asyncio.Event()
     original_create_task = asyncio.create_task
 
@@ -282,6 +282,62 @@ async def test_tcp_connection_starts_read_loop_after_opened_event_publication(
 
 
 @pytest.mark.asyncio
+async def test_tcp_connection_close_during_ready_callback_does_not_emit_late_opened() -> None:
+    ready_started = asyncio.Event()
+    allow_ready_to_finish = asyncio.Event()
+
+    class RecordingHandler:
+        def __init__(self) -> None:
+            self.events: list[str] = []
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                self.events.append("opened")
+            elif isinstance(event, ConnectionClosedEvent):
+                self.events.append("closed")
+
+    async def on_ready(_connection: AsyncioTcpConnection) -> None:
+        ready_started.set()
+        await allow_ready_to_finish.wait()
+
+    handler = RecordingHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:close-during-ready",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+        on_ready_callback=on_ready,
+    )
+
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    try:
+        await asyncio.wait_for(ready_started.wait(), timeout=1.0)
+        await connection.close()
+        allow_ready_to_finish.set()
+        await asyncio.wait_for(start_task, timeout=1.0)
+    finally:
+        allow_ready_to_finish.set()
+        if not start_task.done():
+            start_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(start_task, timeout=1.0)
+        await dispatcher.stop()
+
+    assert handler.events == ["closed"]
+    assert connection.state == ConnectionState.CLOSED
+    assert writer.closed
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "policy",
     [EventBackpressurePolicy.DROP_NEWEST, EventBackpressurePolicy.DROP_OLDEST],
@@ -363,25 +419,360 @@ async def test_tcp_connection_opened_barrier_is_not_dropped_by_background_backpr
 
 
 @pytest.mark.asyncio
-async def test_tcp_connection_close_during_ready_callback_does_not_emit_late_opened() -> None:
-    ready_started = asyncio.Event()
-    allow_ready_to_finish = asyncio.Event()
+async def test_tcp_connection_start_closes_when_opened_handler_raises() -> None:
+    class FailingOpenedHandler:
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                raise RuntimeError("opened failed")
 
-    class RecordingHandler:
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=FailingOpenedHandler(),
+        delivery=EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.INLINE,
+            handler_failure_policy=EventHandlerFailurePolicy.RAISE_IN_INLINE_MODE,
+        ),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:opened-failure",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    try:
+        with pytest.raises(RuntimeError, match="opened failed"):
+            await connection.start()
+    finally:
+        await dispatcher.stop()
+
+    assert connection.state == ConnectionState.CLOSED
+    assert connection._read_task is None
+    assert writer.closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_tcp_connection_start_closes_when_opened_publication_is_cancelled(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    class BlockingOpenedHandler:
         def __init__(self) -> None:
+            self.opened_started = asyncio.Event()
+            self.keep_opened_blocked = asyncio.Event()
+            self.closed_started = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_started.set()
+                await self.keep_opened_blocked.wait()
+            elif isinstance(event, ConnectionClosedEvent):
+                self.closed_started.set()
+
+    handler = BlockingOpenedHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:opened-cancelled",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    try:
+        await asyncio.wait_for(handler.opened_started.wait(), timeout=1.0)
+        start_task.cancel()
+        if dispatch_mode == EventDispatchMode.BACKGROUND:
+            await asyncio.sleep(0)
+            assert not start_task.done()
+            handler.keep_opened_blocked.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+
+        assert connection.state == ConnectionState.CLOSED
+        assert connection._read_task is None
+        assert writer.closed
+
+        handler.keep_opened_blocked.set()
+        await asyncio.wait_for(handler.closed_started.wait(), timeout=1.0)
+    finally:
+        handler.keep_opened_blocked.set()
+        if not start_task.done():
+            start_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(start_task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_cancelled_opened_publication_releases_external_close_waiter() -> None:
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.opened_started = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
             self.events: list[str] = []
 
         async def on_event(self, event) -> None:
             if isinstance(event, ConnectionOpenedEvent):
                 self.events.append("opened")
+                self.opened_started.set()
+                await self.allow_opened_to_finish.wait()
             elif isinstance(event, ConnectionClosedEvent):
                 self.events.append("closed")
 
-    async def on_ready(_connection: AsyncioTcpConnection) -> None:
-        ready_started.set()
-        await allow_ready_to_finish.wait()
+    handler = BlockingOpenedHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:cancelled-opened-external-close",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
 
-    handler = RecordingHandler()
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    close_task: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(handler.opened_started.wait(), timeout=1.0)
+        close_task = asyncio.create_task(connection.close())
+        await wait_for_condition(lambda: writer.closed, timeout_seconds=1.0)
+        await asyncio.sleep(0)
+        assert not close_task.done()
+
+        start_task.cancel()
+        handler.allow_opened_to_finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(close_task, timeout=1.0)
+    finally:
+        handler.allow_opened_to_finish.set()
+        for task in (start_task, close_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.events == ["opened", "closed"]
+    assert connection.state == ConnectionState.CLOSED
+    assert connection._read_task is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_background_start_cancellation_waits_for_queued_opened_event() -> None:
+    class BlockingBackgroundHandler:
+        def __init__(self) -> None:
+            self.blocker_started = asyncio.Event()
+            self.allow_blocker_to_finish = asyncio.Event()
+            self.opened_seen = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.events: list[str] = []
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, BytesReceivedEvent) and event.resource_id == "blocker":
+                self.blocker_started.set()
+                await self.allow_blocker_to_finish.wait()
+            elif isinstance(event, ConnectionOpenedEvent):
+                self.events.append("opened")
+                self.opened_seen.set()
+            elif isinstance(event, ConnectionClosedEvent):
+                self.events.append("closed")
+                self.closed_seen.set()
+
+    handler = BlockingBackgroundHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:background-cancelled-queued-opened",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    try:
+        await dispatcher.emit(BytesReceivedEvent(resource_id="blocker", data=b"hold"))
+        await asyncio.wait_for(handler.blocker_started.wait(), timeout=1.0)
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        start_task.cancel()
+        await asyncio.sleep(0)
+        assert not start_task.done()
+
+        handler.allow_blocker_to_finish.set()
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=1.0)
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+
+        assert handler.events == ["opened", "closed"]
+        assert connection.state == ConnectionState.CLOSED
+        assert connection._read_task is None
+        assert writer.closed
+    finally:
+        handler.allow_blocker_to_finish.set()
+        if not start_task.done():
+            start_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(start_task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_tcp_connection_external_close_waits_for_opened_handler_before_closed_event(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.opened_started = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
+            self.closed_started = asyncio.Event()
+            self.active_connection_handlers = 0
+            self.max_active_connection_handlers = 0
+
+        async def on_event(self, event) -> None:
+            is_connection_event = isinstance(event, (ConnectionOpenedEvent, ConnectionClosedEvent))
+            if is_connection_event:
+                self.active_connection_handlers += 1
+                self.max_active_connection_handlers = max(
+                    self.max_active_connection_handlers,
+                    self.active_connection_handlers,
+                )
+            try:
+                if isinstance(event, ConnectionOpenedEvent):
+                    self.opened_started.set()
+                    await self.allow_opened_to_finish.wait()
+                elif isinstance(event, ConnectionClosedEvent):
+                    self.closed_started.set()
+            finally:
+                if is_connection_event:
+                    self.active_connection_handlers -= 1
+
+    handler = BlockingOpenedHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:external-close-during-opened",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    close_task: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(handler.opened_started.wait(), timeout=1.0)
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(writer.closed_event.wait(), timeout=1.0)
+
+        assert not handler.closed_started.is_set()
+        assert not close_task.done()
+        assert handler.max_active_connection_handlers == 1
+
+        handler.allow_opened_to_finish.set()
+        await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(close_task, timeout=1.0)
+        await asyncio.wait_for(handler.closed_started.wait(), timeout=1.0)
+        assert handler.max_active_connection_handlers == 1
+    finally:
+        handler.allow_opened_to_finish.set()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+        if close_task is not None:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(close_task, timeout=1.0)
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_inline_close_from_bytes_handler_defers_closed_event() -> None:
+    class CloseFromBytesHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.close_returned = asyncio.Event()
+            self.closed_started = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.close_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_started.set()
+                return
+            if self.connection is None or not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            try:
+                self.close_task = asyncio.create_task(self.connection.close())
+                await self.close_task
+                self.close_returned.set()
+                if self.closed_started.is_set():
+                    raise AssertionError("closed event was published before bytes handler returned")
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    handler = CloseFromBytesHandler()
     dispatcher = AsyncioEventDispatcher(
         event_handler=handler,
         delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
@@ -389,33 +780,682 @@ async def test_tcp_connection_close_during_ready_callback_does_not_emit_late_ope
     )
     writer = _DummyWriter()
     connection = AsyncioTcpConnection(
-        "client:close-during-ready",
+        "client:close-from-bytes-handler",
         ConnectionRole.CLIENT,
         asyncio.StreamReader(),
         writer,  # type: ignore[arg-type]
         dispatcher,
         4096,
-        on_ready_callback=on_ready,
+    )
+    handler.connection = connection
+
+    emit_task: asyncio.Task[None] | None = None
+    await dispatcher.start()
+    try:
+        await connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"close"))
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.close_returned.wait(), timeout=1.0)
+
+        assert not handler.closed_started.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_started.wait(), timeout=1.0)
+        await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if emit_task is not None and not emit_task.done():
+            emit_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_task, timeout=1.0)
+        if handler.close_task is not None and not handler.close_task.done():
+            handler.close_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.close_task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+    assert connection.state == ConnectionState.CLOSED
+    assert writer.closed
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_background_direct_close_from_bytes_handler_defers_closed_event() -> (
+    None
+):
+    class DirectCloseFromBytesHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.connection is None or not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            try:
+                await self.connection.close()
+                if self.closed_seen.is_set():
+                    raise AssertionError("closed event was published before bytes handler returned")
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    handler = DirectCloseFromBytesHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:background-direct-close",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    handler.connection = connection
+
+    await dispatcher.start()
+    try:
+        await connection.start()
+        await dispatcher.emit(
+            BytesReceivedEvent(resource_id=connection.connection_id, data=b"close")
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+    assert connection.state == ConnectionState.CLOSED
+    assert writer.closed
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_inline_close_deferral_is_scoped_to_connection() -> None:
+    class BlockingFirstConnectionHandler:
+        def __init__(self) -> None:
+            self.first_bytes_started = asyncio.Event()
+            self.first_bytes_finished = asyncio.Event()
+            self.allow_first_bytes_to_finish = asyncio.Event()
+            self.second_closed_seen = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, BytesReceivedEvent) and event.resource_id == "client:first":
+                self.first_bytes_started.set()
+                await self.allow_first_bytes_to_finish.wait()
+                self.first_bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) and event.resource_id == "client:second":
+                self.second_closed_seen.set()
+
+    handler = BlockingFirstConnectionHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    first_connection = AsyncioTcpConnection(
+        "client:first",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    second_writer = _DummyWriter()
+    second_connection = AsyncioTcpConnection(
+        "client:second",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        second_writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    emit_task: asyncio.Task[None] | None = None
+    await dispatcher.start()
+    try:
+        await first_connection.start()
+        await second_connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id="client:first", data=b"hold"))
+        )
+        await asyncio.wait_for(handler.first_bytes_started.wait(), timeout=1.0)
+
+        await asyncio.wait_for(second_connection.close(), timeout=1.0)
+
+        assert handler.second_closed_seen.is_set()
+        assert not handler.first_bytes_finished.is_set()
+    finally:
+        handler.allow_first_bytes_to_finish.set()
+        if emit_task is not None and not emit_task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(emit_task, timeout=1.0)
+        for connection in (first_connection, second_connection):
+            if connection.state != ConnectionState.CLOSED:
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await connection.close()
+        await dispatcher.stop()
+
+    assert second_writer.closed
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_background_deferred_close_drops_queued_same_connection_bytes() -> (
+    None
+):
+    class CloseOnFirstBytesHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.first_bytes_seen = asyncio.Event()
+            self.close_returned = asyncio.Event()
+            self.release_first_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.events: list[object] = []
+            self.close_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionClosedEvent):
+                self.closed_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            if event.data == b"second":
+                self.error = AssertionError("queued bytes event was delivered after close")
+                self.release_first_bytes.set()
+                return
+            self.first_bytes_seen.set()
+            try:
+                if self.connection is None:
+                    raise AssertionError("connection reference was not attached")
+                self.close_task = asyncio.create_task(self.connection.close())
+                await self.close_task
+                self.close_returned.set()
+                await self.release_first_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_first_bytes.set()
+
+    handler = CloseOnFirstBytesHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:background-close-drops-queued",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    handler.connection = connection
+
+    await dispatcher.start()
+    first_emit_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        first_emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"first"))
+        )
+        await asyncio.wait_for(handler.first_bytes_seen.wait(), timeout=1.0)
+        await dispatcher.emit(
+            BytesReceivedEvent(resource_id=connection.connection_id, data=b"second")
+        )
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        await asyncio.wait_for(handler.close_returned.wait(), timeout=1.0)
+        handler.release_first_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        if first_emit_task is not None:
+            await asyncio.wait_for(first_emit_task, timeout=1.0)
+    finally:
+        handler.release_first_bytes.set()
+        if first_emit_task is not None and not first_emit_task.done():
+            first_emit_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(first_emit_task, timeout=1.0)
+        if handler.close_task is not None and not handler.close_task.done():
+            handler.close_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(handler.close_task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+    assert [event.data for event in handler.events if isinstance(event, BytesReceivedEvent)] == [
+        b"first"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_background_external_close_drops_queued_bytes_before_closed() -> None:
+    class ScriptedReader:
+        def __init__(self) -> None:
+            self._reads = [b"first", b"second"]
+            self.release_read = asyncio.Event()
+
+        async def read(self, _size: int) -> bytes:
+            if self._reads:
+                return self._reads.pop(0)
+            await self.release_read.wait()
+            return b""
+
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.events: list[object] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionClosedEvent):
+                self.closed_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            if event.data == b"second":
+                self.error = AssertionError("queued bytes event was delivered after close")
+                self.release_bytes.set()
+                return
+            self.bytes_started.set()
+            await self.release_bytes.wait()
+
+    handler = BlockingBytesHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logger=logging.getLogger("test"),
+    )
+    reader = ScriptedReader()
+    connection = AsyncioTcpConnection(
+        "client:background-external-close-drops-queued",
+        ConnectionRole.CLIENT,
+        reader,  # type: ignore[arg-type]
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    await dispatcher.start()
+    close_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+        await wait_for_condition(
+            lambda: dispatcher.runtime_stats.queue_depth == 1,
+            timeout_seconds=1.0,
+        )
+
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(close_task, timeout=1.0)
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        reader.release_read.set()
+        for task in (close_task,):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+    assert [event.data for event in handler.events if isinstance(event, BytesReceivedEvent)] == [
+        b"first"
+    ]
+    assert isinstance(handler.events[-1], ConnectionClosedEvent)
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_inline_reentrant_close_returns_while_external_close_waits() -> None:
+    class ReentrantCloseHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.bytes_started = asyncio.Event()
+            self.reentrant_close_returned = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.reentrant_close_returned.is_set():
+                    self.error = AssertionError("closed event re-entered before close returned")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.connection is None or not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            try:
+                await self.connection.close()
+                self.reentrant_close_returned.set()
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+
+    handler = ReentrantCloseHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:inline-reentrant-close",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    handler.connection = connection
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    external_close_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"first"))
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        external_close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(handler.reentrant_close_returned.wait(), timeout=1.0)
+        assert external_close_task.done() is False
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(external_close_task, timeout=1.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        for task in (emit_task, external_close_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_external_close_joiner_waits_for_deferred_close_event() -> None:
+    class ReentrantCloseWithJoinerHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.bytes_started = asyncio.Event()
+            self.handler_close_returned = asyncio.Event()
+            self.callback_started = asyncio.Event()
+            self.release_callback = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.handler_close_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.release_bytes.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.connection is None or not isinstance(event, BytesReceivedEvent):
+                return
+
+            self.bytes_started.set()
+            try:
+                self.handler_close_task = asyncio.create_task(self.connection.close())
+                await self.handler_close_task
+                self.handler_close_returned.set()
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_callback.set()
+                self.release_bytes.set()
+
+    handler = ReentrantCloseWithJoinerHandler()
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        handler.callback_started.set()
+        await handler.release_callback.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:inline-close-joiner",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+        on_closed_callback=on_closed,
+    )
+    handler.connection = connection
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    external_close_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"first"))
+        )
+        await asyncio.wait_for(handler.callback_started.wait(), timeout=1.0)
+
+        external_close_task = asyncio.create_task(connection.close())
+        await asyncio.sleep(0)
+        assert external_close_task.done() is False
+
+        handler.release_callback.set()
+        await asyncio.wait_for(handler.handler_close_returned.wait(), timeout=1.0)
+        assert external_close_task.done() is False
+        assert handler.closed_seen.is_set() is False
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(external_close_task, timeout=1.0)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_callback.set()
+        handler.release_bytes.set()
+        for task in (emit_task, handler.handler_close_task, external_close_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_start_cancellation_completes_deferred_close_publication() -> None:
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.opened_started = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
+            self.closed_started = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_started.set()
+                await self.allow_opened_to_finish.wait()
+            elif isinstance(event, ConnectionClosedEvent):
+                self.closed_started.set()
+
+    handler = BlockingOpenedHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:cancelled-deferred-close",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
     )
 
     await dispatcher.start()
     start_task = asyncio.create_task(connection.start())
+    close_task: asyncio.Task[None] | None = None
     try:
-        await asyncio.wait_for(ready_started.wait(), timeout=1.0)
-        await connection.close()
-        allow_ready_to_finish.set()
-        await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(handler.opened_started.wait(), timeout=1.0)
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(writer.closed_event.wait(), timeout=1.0)
+        assert not close_task.done()
+
+        start_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(asyncio.shield(close_task), timeout=1.0)
+        await asyncio.wait_for(handler.closed_started.wait(), timeout=1.0)
     finally:
-        allow_ready_to_finish.set()
+        handler.allow_opened_to_finish.set()
         if not start_task.done():
             start_task.cancel()
             with contextlib.suppress(Exception, asyncio.CancelledError):
                 await asyncio.wait_for(start_task, timeout=1.0)
+        if close_task is not None and not close_task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(asyncio.shield(close_task), timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
         await dispatcher.stop()
 
-    assert handler.events == ["closed"]
-    assert connection.state == ConnectionState.CLOSED
-    assert writer.closed
+
+@pytest.mark.asyncio
+async def test_tcp_connection_repeated_start_cancellation_preserves_deferred_close_publication() -> (
+    None
+):
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.opened_started = asyncio.Event()
+            self.allow_opened_to_finish = asyncio.Event()
+            self.closed_started = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_started.set()
+                await self.allow_opened_to_finish.wait()
+            elif isinstance(event, ConnectionClosedEvent):
+                self.closed_started.set()
+
+    handler = BlockingOpenedHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:repeat-cancelled-deferred-close",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    start_task = asyncio.create_task(connection.start())
+    close_task: asyncio.Task[None] | None = None
+    cancel_driver_task: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(handler.opened_started.wait(), timeout=1.0)
+        close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(writer.closed_event.wait(), timeout=1.0)
+        assert not close_task.done()
+
+        async def cancel_start_repeatedly() -> None:
+            start_task.cancel()
+            await asyncio.sleep(0)
+            start_task.cancel()
+            await asyncio.sleep(0)
+            start_task.cancel()
+
+        cancel_driver_task = asyncio.create_task(cancel_start_repeatedly())
+        await asyncio.wait_for(cancel_driver_task, timeout=1.0)
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(start_task, timeout=1.0)
+        await asyncio.wait_for(asyncio.shield(close_task), timeout=1.0)
+        await asyncio.wait_for(handler.closed_started.wait(), timeout=1.0)
+    finally:
+        handler.allow_opened_to_finish.set()
+        if cancel_driver_task is not None and not cancel_driver_task.done():
+            cancel_driver_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(cancel_driver_task, timeout=1.0)
+        if not start_task.done():
+            start_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(start_task, timeout=1.0)
+        if close_task is not None and not close_task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(asyncio.shield(close_task), timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -18,7 +18,8 @@ import pytest
 
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
-from aionetx.api.connection_events import ConnectionRejectedEvent
+from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionRejectedEvent
 from aionetx.api.heartbeat import TcpHeartbeatSettings
 from aionetx.api.errors import HeartbeatConfigurationError
 from aionetx.api.heartbeat import HeartbeatRequest
@@ -480,6 +481,195 @@ async def test_server_concurrent_stop_waits_for_active_teardown(
     await asyncio.gather(first_stop, second_stop)
 
     assert blocking.close_attempts == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_handler_origin_stop_drops_queued_background_bytes() -> None:
+    class StopServerFromFirstBytes:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.first_seen = asyncio.Event()
+            self.allow_stop_to_start = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.allow_first_to_finish = asyncio.Event()
+            self.events: list[object] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            if event.data == b"second":
+                self.error = AssertionError("queued bytes event was delivered after server stop")
+                self.allow_first_to_finish.set()
+                return
+            self.first_seen.set()
+            try:
+                await self.allow_stop_to_start.wait()
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+                self.stop_returned.set()
+                await self.allow_first_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+                self.allow_first_to_finish.set()
+
+    handler = StopServerFromFirstBytes()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12348,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.server = server
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    await server._event_dispatcher.start()  # type: ignore[attr-defined]
+    try:
+        await server._event_dispatcher.emit(  # type: ignore[attr-defined]
+            BytesReceivedEvent(resource_id="server:queued-stop:1", data=b"first")
+        )
+        await asyncio.wait_for(handler.first_seen.wait(), timeout=1.0)
+        await server._event_dispatcher.emit(  # type: ignore[attr-defined]
+            BytesReceivedEvent(resource_id="server:queued-stop:1", data=b"second")
+        )
+        await wait_for_condition(
+            lambda: server._event_dispatcher.runtime_stats.queue_depth == 1,  # type: ignore[attr-defined]
+            timeout_seconds=1.0,
+        )
+
+        handler.allow_stop_to_start.set()
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert server._event_dispatcher.runtime_stats.queue_depth == 0  # type: ignore[attr-defined]
+    finally:
+        handler.allow_stop_to_start.set()
+        handler.allow_first_to_finish.set()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+    assert [event.data for event in handler.events if isinstance(event, BytesReceivedEvent)] == [
+        b"first"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_server_spawned_handler_stop_preserves_close_events_for_all_connections() -> None:
+    class SpawnStopFromFirstBytes:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.first_seen = asyncio.Event()
+            self.allow_stop_to_start = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.allow_first_to_finish = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_ids: list[str] = []
+            self.origin_connection_id: str | None = None
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if (
+                    event.resource_id == self.origin_connection_id
+                    and not self.bytes_finished.is_set()
+                ):
+                    self.error = AssertionError("origin close event re-entered bytes handler")
+                    self.allow_first_to_finish.set()
+                self.closed_ids.append(event.resource_id)
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+
+            async def child_stop() -> None:
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+                self.stop_returned.set()
+
+            self.first_seen.set()
+            try:
+                await self.allow_stop_to_start.wait()
+                self.stop_task = asyncio.create_task(child_stop())
+                await self.stop_task
+                await self.allow_first_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+                self.allow_first_to_finish.set()
+            finally:
+                self.bytes_finished.set()
+
+    handler = SpawnStopFromFirstBytes()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12348,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.server = server
+    origin_connection = AsyncioTcpConnection(
+        "server:spawned-stop:origin",
+        ConnectionRole.SERVER,
+        asyncio.StreamReader(),
+        _FakeWriter(),  # type: ignore[arg-type]
+        server._event_dispatcher,  # type: ignore[attr-defined]
+        receive_buffer_size=4096,
+    )
+    sibling_connection = AsyncioTcpConnection(
+        "server:spawned-stop:sibling",
+        ConnectionRole.SERVER,
+        asyncio.StreamReader(),
+        _FakeWriter(),  # type: ignore[arg-type]
+        server._event_dispatcher,  # type: ignore[attr-defined]
+        receive_buffer_size=4096,
+    )
+    handler.origin_connection_id = origin_connection.connection_id
+    origin_connection._state = ConnectionState.CONNECTED  # type: ignore[attr-defined]
+    sibling_connection._state = ConnectionState.CONNECTED  # type: ignore[attr-defined]
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    server._connections = {  # type: ignore[attr-defined]
+        origin_connection.connection_id: origin_connection,
+        sibling_connection.connection_id: sibling_connection,
+    }
+    await server._event_dispatcher.start()  # type: ignore[attr-defined]
+    try:
+        await server._event_dispatcher.emit(  # type: ignore[attr-defined]
+            BytesReceivedEvent(resource_id=origin_connection.connection_id, data=b"first")
+        )
+        await asyncio.wait_for(handler.first_seen.wait(), timeout=1.0)
+
+        handler.allow_stop_to_start.set()
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert origin_connection.connection_id not in handler.closed_ids
+        handler.allow_first_to_finish.set()
+        await wait_for_condition(
+            lambda: (
+                set(handler.closed_ids)
+                == {origin_connection.connection_id, sibling_connection.connection_id}
+            ),
+            timeout_seconds=1.0,
+        )
+    finally:
+        handler.allow_stop_to_start.set()
+        handler.allow_first_to_finish.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+    assert set(handler.closed_ids) == {
+        origin_connection.connection_id,
+        sibling_connection.connection_id,
+    }
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
 
 

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -16,6 +16,7 @@ import socket
 
 import pytest
 
+from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.connection_events import ConnectionClosedEvent
@@ -39,6 +40,7 @@ from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdp
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
+from tests.helpers import wait_for_condition
 
 
 class NoopHandler:
@@ -92,6 +94,52 @@ class StopAgainOnStoppingHandler:
         ):
             await self.receiver.stop()
             self.reentered_stop.set()
+
+
+class SpawnStopOnOpenedHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.receiver: AsyncioUdpReceiver | None = None
+        self.opened_seen = asyncio.Event()
+        self.opened_finished = asyncio.Event()
+        self.closed_seen = asyncio.Event()
+        self.stop_returned = asyncio.Event()
+        self.release_opened = asyncio.Event()
+        self.stop_task: asyncio.Task[None] | None = None
+        self.error: BaseException | None = None
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if isinstance(event, ConnectionClosedEvent):
+            if not self.opened_finished.is_set():
+                self.error = AssertionError("closed event re-entered opened handler")
+                self.release_opened.set()
+                return
+            self.closed_seen.set()
+            return
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            and not self.opened_finished.is_set()
+        ):
+            self.error = AssertionError("lifecycle event re-entered opened handler")
+            self.release_opened.set()
+            return
+        if self.receiver is None or not isinstance(event, ConnectionOpenedEvent):
+            return
+        self.opened_seen.set()
+        try:
+            self.stop_task = asyncio.create_task(self.receiver.stop())
+            await self.stop_task
+            self.stop_returned.set()
+            if self.closed_seen.is_set():
+                raise AssertionError("closed event was published before opened handler returned")
+            await self.release_opened.wait()
+        except BaseException as error:
+            self.error = error
+            self.release_opened.set()
+        finally:
+            self.opened_finished.set()
 
 
 class HoldingOpenEventLockHandler:
@@ -235,15 +283,17 @@ async def test_udp_receiver_background_startup_cancellation_after_opened_event_r
         event_handler=NoopHandler(),
     )
 
-    original_emit = receiver._event_dispatcher.emit  # type: ignore[attr-defined]
+    original_emit_and_wait = receiver._event_dispatcher.emit_and_wait  # type: ignore[attr-defined]
 
-    async def _emit_blocking_opened_event(event) -> None:
+    async def _emit_and_wait_blocking_opened_event(
+        event, *, drop_on_backpressure: bool = True
+    ) -> None:
         if isinstance(event, ConnectionOpenedEvent):
             opened_emit_seen.set()
             await allow_opened_emit_to_return.wait()
-        await original_emit(event)
+        await original_emit_and_wait(event, drop_on_backpressure=drop_on_backpressure)
 
-    receiver._event_dispatcher.emit = _emit_blocking_opened_event  # type: ignore[method-assign]
+    receiver._event_dispatcher.emit_and_wait = _emit_and_wait_blocking_opened_event  # type: ignore[method-assign]
 
     start_task = asyncio.create_task(receiver.start())
     await asyncio.wait_for(opened_emit_seen.wait(), timeout=1.0)
@@ -254,6 +304,73 @@ async def test_udp_receiver_background_startup_cancellation_after_opened_event_r
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_cancelled_external_stop_during_opened_barrier_publishes_terminal_events() -> (
+    None
+):
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.events: list[object] = []
+            self.opened_seen = asyncio.Event()
+            self.release_opened = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_seen.set()
+                await self.release_opened.wait()
+
+    handler = BlockingOpenedHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    start_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    joiner_stop_task: asyncio.Task[None] | None = None
+    try:
+        start_task = asyncio.create_task(receiver.start())
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await wait_for_condition(
+            lambda: receiver.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=1.0,
+        )
+        stop_task.cancel()
+        await assert_awaitable_cancelled(stop_task)
+
+        joiner_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not joiner_stop_task.done()
+
+        handler.release_opened.set()
+        await asyncio.wait_for(joiner_stop_task, timeout=1.0)
+        await asyncio.wait_for(start_task, timeout=1.0)
+    finally:
+        handler.release_opened.set()
+        for task in (stop_task, joiner_stop_task, start_task):
+            if task is not None and not task.done():
+                task.cancel()
+                await drain_awaitable_ignoring_cancelled(task)
+        await receiver.stop()
+
+    lifecycle_states = [
+        event.current
+        for event in handler.events
+        if isinstance(event, ComponentLifecycleChangedEvent)
+    ]
+    assert ComponentLifecycleState.STOPPING in lifecycle_states
+    assert ComponentLifecycleState.STOPPED in lifecycle_states
+    assert any(isinstance(event, ConnectionClosedEvent) for event in handler.events)
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
@@ -955,6 +1072,482 @@ async def test_udp_receiver_inline_stop_reentry_does_not_self_await() -> None:
         ComponentLifecycleState.STOPPED,
     ]
     assert len(closed_events) == 1
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_spawned_stop_from_opened_handler_delivers_terminal_events() -> None:
+    handler = SpawnStopOnOpenedHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    start_task: asyncio.Task[None] | None = None
+
+    try:
+        start_task = asyncio.create_task(receiver.start())
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+        assert not start_task.done()
+        assert not any(
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            for event in handler.events
+        )
+
+        handler.release_opened.set()
+        assert handler.stop_task is not None
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(start_task, timeout=1.0)
+    finally:
+        handler.release_opened.set()
+        if start_task is not None and not start_task.done():
+            start_task.cancel()
+            await drain_awaitable_ignoring_cancelled(start_task)
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await receiver.stop()
+
+    assert handler.error is None
+    stop_relevant_events = [
+        event
+        for event in handler.events
+        if isinstance(event, ConnectionClosedEvent)
+        or (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
+    ]
+    assert [type(event).__name__ for event in stop_relevant_events] == [
+        "ComponentLifecycleChangedEvent",
+        "ConnectionClosedEvent",
+        "ComponentLifecycleChangedEvent",
+    ]
+    assert isinstance(stop_relevant_events[0], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[0].current == ComponentLifecycleState.STOPPING
+    assert isinstance(stop_relevant_events[1], ConnectionClosedEvent)
+    assert isinstance(stop_relevant_events[2], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[2].current == ComponentLifecycleState.STOPPED
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_spawned_stop_from_bytes_handler_defers_close_until_handler_returns() -> (
+    None
+):
+    class SpawnStopFromBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.bytes_seen = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+                and not self.bytes_finished.is_set()
+            ):
+                self.error = AssertionError("lifecycle event re-entered bytes handler")
+                self.release_bytes.set()
+                return
+            if self.receiver is None or not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_seen.set()
+            try:
+                self.stop_task = asyncio.create_task(self.receiver.stop())
+                await self.stop_task
+                self.stop_returned.set()
+                if self.closed_seen.is_set():
+                    raise AssertionError("closed event was published before bytes handler returned")
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = SpawnStopFromBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"stop-from-bytes-handler")
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_inherited_handler_stop_does_not_wait_for_owner() -> None:
+    class AwaitChildStopFromBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.bytes_seen = asyncio.Event()
+            self.child_stop_returned = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.child_stop_task: asyncio.Task[None] | None = None
+            self.second_child_stop_returned = asyncio.Event()
+            self.second_child_stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.receiver is None or not isinstance(event, BytesReceivedEvent):
+                return
+
+            async def child_stop(returned: asyncio.Event) -> None:
+                await self.receiver.stop()
+                returned.set()
+
+            self.bytes_seen.set()
+            try:
+                self.child_stop_task = asyncio.create_task(child_stop(self.child_stop_returned))
+                await self.child_stop_task
+                self.second_child_stop_task = asyncio.create_task(
+                    child_stop(self.second_child_stop_returned)
+                )
+                await self.second_child_stop_task
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = AwaitChildStopFromBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"child-stop-from-handler")
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.child_stop_returned.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.second_child_stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if handler.child_stop_task is not None and not handler.child_stop_task.done():
+            handler.child_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.child_stop_task)
+        if handler.second_child_stop_task is not None and not handler.second_child_stop_task.done():
+            handler.second_child_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.second_child_stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_handler_origin_stop_drops_queued_background_bytes_before_terminal_events() -> (
+    None
+):
+    class StopFromFirstBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.first_bytes_seen = asyncio.Event()
+            self.first_bytes_finished = asyncio.Event()
+            self.allow_stop_to_start = asyncio.Event()
+            self.allow_first_bytes_to_finish = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.events: list[object] = []
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.first_bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.allow_first_bytes_to_finish.set()
+                self.closed_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            if event.data == b"second":
+                self.error = AssertionError("queued bytes event was delivered after receiver stop")
+                self.allow_first_bytes_to_finish.set()
+                return
+            self.first_bytes_seen.set()
+            try:
+                await self.allow_stop_to_start.wait()
+                if self.receiver is None:
+                    raise AssertionError("receiver reference was not attached")
+                self.stop_task = asyncio.create_task(self.receiver.stop())
+                await self.stop_task
+                self.stop_returned.set()
+                await self.allow_first_bytes_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+                self.allow_first_bytes_to_finish.set()
+            finally:
+                self.first_bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = StopFromFirstBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"first")
+        await asyncio.wait_for(handler.first_bytes_seen.wait(), timeout=1.0)
+        await sender.send(b"second")
+        await wait_for_condition(
+            lambda: receiver._event_dispatcher.runtime_stats.queue_depth == 1,  # type: ignore[attr-defined]
+            timeout_seconds=1.0,
+        )
+
+        handler.allow_stop_to_start.set()
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        handler.allow_first_bytes_to_finish.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+    finally:
+        handler.allow_stop_to_start.set()
+        handler.allow_first_bytes_to_finish.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert [event.data for event in handler.events if isinstance(event, BytesReceivedEvent)] == [
+        b"first"
+    ]
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_external_inline_stop_waits_for_active_bytes_handler() -> None:
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.events: list[object] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                try:
+                    await self.release_bytes.wait()
+                finally:
+                    self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    port = _get_unused_udp_port()
+    handler = BlockingBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        await sender.send(b"external-inline-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+        assert not stop_task.done()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_cancelled_external_inline_stop_keeps_shared_waiter() -> None:
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                try:
+                    await self.release_bytes.wait()
+                finally:
+                    self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    port = _get_unused_udp_port()
+    handler = BlockingBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    stop_task: asyncio.Task[None] | None = None
+    joiner_stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        await sender.send(b"cancel-external-inline-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await wait_for_condition(
+            lambda: receiver.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=1.0,
+        )
+        assert not handler.terminal_event_seen.is_set()
+
+        stop_task.cancel()
+        await assert_awaitable_cancelled(stop_task)
+
+        joiner_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not joiner_stop_task.done()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(joiner_stop_task, timeout=1.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(stop_task)
+        if joiner_stop_task is not None and not joiner_stop_task.done():
+            joiner_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(joiner_stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary

While expanding TCP lifecycle and ordering regression coverage, several handler-origin shutdown interleavings showed that terminal publication was still too eager in places where a connection event handler was active. A handler could request `connection.close()`, `client.stop()`, or `server.stop()` and then observe close/lifecycle events for the same connection or component before the handler itself had returned.

This PR preserves the documented per-connection event stream guarantee by deferring handler-origin terminal events until active handlers unwind, dropping queued same-connection bytes during close, and keeping client/server stop waiters tied to the deferred close publication they depend on.

## Problems and approach

### 1. Handler-origin connection close could re-enter terminal publication

Problem:
Calling `connection.close()` from inside a TCP event handler could publish `ConnectionClosedEvent` before that same handler returned. In INLINE delivery this creates visible terminal re-entry for the same connection; in BACKGROUND delivery, queued same-connection bytes could also remain behind the close request and be delivered after close had already started.

Approach:
`AsyncioTcpConnection.close()` now detects active same-connection handler context and defers close-event publication until that handler context has unwound. Same-connection queued payload events are dropped when close begins, and external close callers wait for the deferred close waiter so `close()` still observes terminal publication before returning.

Regression coverage now exercises:

- direct close from INLINE bytes handlers
- direct close from BACKGROUND bytes handlers
- external close while a handler-owned close is deferred
- queued same-connection bytes being dropped during close
- scoped deferral that does not block unrelated connections

### 2. Close during opened publication needed deferred terminal reconciliation

Problem:
PR #15 made TCP startup wait for `ConnectionOpenedEvent` handlers before reads begin. That creates a legitimate transition window where close/cancellation can happen while opened publication is still in flight. Without explicit deferred reconciliation, close publication can be lost, duplicated, or observed in the wrong order by external waiters.

Approach:
TCP connection startup now tracks opened publication as an in-flight task and reconciles deferred close publication after the opened barrier finishes, including cancellation paths. Deferred close waiters are preserved across repeated startup-cancellation attempts so external close callers and startup cleanup observe a single terminal publication result.

Regression coverage now blocks or cancels opened publication and asserts close publication, external close waiting, and repeated cancellation behavior remain coherent.

### 3. TCP client stop needed handler-origin terminal ordering

Problem:
`client.stop()` can be called from connection opened handlers, bytes handlers, handler-spawned tasks, dispatcher worker paths, or external waiters while a handler-owned close is still pending. Those paths need different await behavior: handler-origin callers must not wait on themselves, while external stop callers must not return before deferred close and terminal lifecycle events have actually published.

Approach:
The client stop path now distinguishes handler-origin, inherited handler-origin, dispatcher-worker, active-inline-handler, and external stop callers. Handler-origin stop defers terminal lifecycle publication until active handlers unwind, closes startup-pending/current connections, collects deferred close waiters, and completes the shared stop waiter only after the deferred terminal work finishes.

Regression coverage now exercises:

- opened handlers stopping the client without overlapping connection events
- opened handlers observing the active connection before publication completes
- handler-spawned client stop tasks
- bytes handlers stopping the client
- external stop waiting for handler-owned deferred close
- attempt-start handlers stopping the client before a socket is opened

### 4. TCP server stop needed sibling close publication guarantees

Problem:
`server.stop()` from a connection handler or handler-spawned task could stop accepting and tear down active clients, but terminal publication for sibling connections could be suppressed or ordered ahead of the active handler. With multiple connected clients, that risks losing `ConnectionClosedEvent` for peers not directly involved in the handler that initiated shutdown.

Approach:
The server stop path now mirrors the client deferral model: handler-origin stop requests defer terminal lifecycle publication, close all active connections under the appropriate inline-delivery context, collect deferred close waiters, and complete stop waiters only after active handlers and deferred close publication finish.

Regression coverage now exercises:

- opened handlers stopping the server without overlapping connection events
- handler-spawned server stop tasks
- bytes handlers stopping the server
- external stop waiting for handler-owned deferred close
- two real clients where handler-spawned server stop preserves close events for both connections

### 5. The documented shutdown ordering contract needed to be explicit

Problem:
The architecture docs already required sequential per-connection dispatch, but handler-origin shutdown was not spelled out as a specific ordering case. Future lifecycle work needs that rule to be visible because the implementation necessarily has separate paths for direct handler calls, inherited handler-origin tasks, and external callers.

Approach:
`docs/architecture.md` now documents that shutdown requested from inside a connection event handler defers terminal events until the active handler returns. `CHANGELOG.md` records the user-visible TCP close/stop ordering fix.

## Changes

- Defer same-connection `ConnectionClosedEvent` publication for handler-origin close paths.
- Drop queued same-connection bytes once close begins.
- Preserve deferred close publication across opened-publication cancellation and startup cleanup.
- Preserve external close/stop waiter behavior while avoiding self-await from handler-origin callers.
- Defer TCP client terminal lifecycle events for handler-origin stop paths.
- Preserve TCP client cleanup for startup-pending/current connections under deferred close publication.
- Defer TCP server terminal lifecycle events for handler-origin stop paths.
- Preserve close-event publication for all active server connections during handler-origin server stop.
- Add unit and integration regression coverage for connection, client, and server shutdown interleavings.
- Document handler-origin shutdown ordering and update `CHANGELOG.md`.


## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - `docs/architecture.md` now documents handler-origin terminal-event ordering.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface was added; this restores documented lifecycle/event ordering behavior.

Local verification:

- `python -m pytest -q tests/unit/test_asyncio_tcp_connection.py tests/unit/test_asyncio_tcp_server.py tests/integration/test_concurrency_scenarios.py -p no:cacheprovider --timeout=60`
- `python -m pytest -q -m "behavior_critical" -p no:cacheprovider --timeout=60`
- `ruff check . --no-cache`
- `ruff format --check . --no-cache`
- `python -m mypy src`