### PR TITLE
fix(udp): preserve deferred stop publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@ Planned contents for the initial public alpha release (`0.1.0`).
   preserving per-connection event ordering across dispatch modes.
 - TCP close and stop paths now defer handler-origin terminal events until the
   active same-connection handler has returned.
+- UDP receivers now preserve deferred stop publication when stop originates
+  from a handler or when an external stop caller is cancelled.

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -125,6 +125,14 @@ class _DatagramStopProvenance:
         return self.has_handler_provenance or self.active_inline_handler
 
 
+@dataclass(slots=True)
+class _DatagramStopExecutionState:
+    """Mutable cross-step state for a single stop execution."""
+
+    deferred_close_waiter: asyncio.Future[None] | None = None
+    stop_waiter_completion_deferred: bool = False
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -309,69 +317,32 @@ class _AsyncioDatagramReceiverBase:
             await asyncio.shield(cast("asyncio.Future[None]", snapshot.stop_waiter))
             return
 
-        first_error: BaseException | None = None
         stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
-        deferred_close_waiter: asyncio.Future[None] | None = None
-        stop_waiter_completion_deferred = False
+        stop_state = _DatagramStopExecutionState()
         try:
             if provenance.defers_terminal_events:
-                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
-                    snapshot=snapshot,
-                    provenance=provenance,
-                    stop_waiter=stop_waiter,
-                    socket_cleanup=socket_cleanup,
+                stop_state.stop_waiter_completion_deferred = (
+                    await self._prepare_deferred_stop_events(
+                        snapshot=snapshot,
+                        provenance=provenance,
+                        stop_waiter=stop_waiter,
+                        socket_cleanup=socket_cleanup,
+                    )
                 )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
-                try:
-                    await self._publish_stopping_transition(snapshot)
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                try:
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    if first_error is None:
-                        first_error = error
-                if first_error is None:
-                    try:
-                        _, deferred_close_waiter = await self._publish_closed_event_if_needed(
-                            snapshot
-                        )
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                    else:
-                        if deferred_close_waiter is not None:
-                            try:
-                                await asyncio.shield(deferred_close_waiter)
-                            except asyncio.CancelledError:
-                                self._complete_stop_waiter_after_deferred_close_and_stop(
-                                    stop_waiter=stop_waiter,
-                                    snapshot=snapshot,
-                                    deferred_close_waiter=deferred_close_waiter,
-                                )
-                                stop_waiter_completion_deferred = True
-                                raise
-                            except Exception as error:
-                                first_error = error
-                await self._publish_stopped_transition_if_needed(
-                    snapshot, emit_event=first_error is None
+                await self._run_ordinary_stop_path(
+                    snapshot=snapshot,
+                    stop_state=stop_state,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
                 )
-                if snapshot.stop_dispatcher:
-                    try:
-                        await self._event_dispatcher.stop()
-                    except (Exception, asyncio.CancelledError) as error:
-                        if first_error is None:
-                            first_error = error
-                if first_error is not None:
-                    raise first_error
         except (Exception, asyncio.CancelledError) as error:
             if (
                 stop_waiter is not None
                 and not stop_waiter.done()
-                and not stop_waiter_completion_deferred
+                and not stop_state.stop_waiter_completion_deferred
             ):
                 stop_waiter.set_exception(error)
                 # Mark the exception as retrieved so failed owner stops do not
@@ -381,17 +352,17 @@ class _AsyncioDatagramReceiverBase:
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                if stop_waiter_completion_deferred:
+                if stop_state.stop_waiter_completion_deferred:
                     pass
-                elif provenance.handler_originated and deferred_close_waiter is not None:
+                elif provenance.handler_originated and stop_state.deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
-                        stop_waiter, deferred_close_waiter
+                        stop_waiter, stop_state.deferred_close_waiter
                     )
-                    stop_waiter_completion_deferred = True
+                    stop_state.stop_waiter_completion_deferred = True
                 else:
                     stop_waiter.set_result(None)
         finally:
-            if stop_waiter is not None and not stop_waiter_completion_deferred:
+            if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
                 async with self._state_lock:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
@@ -443,6 +414,56 @@ class _AsyncioDatagramReceiverBase:
             self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
             return True
         raise first_error
+
+    async def _run_ordinary_stop_path(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        stop_state: _DatagramStopExecutionState,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> None:
+        """Run the ordinary stop path that publishes terminal events inline."""
+        first_error: BaseException | None = None
+        try:
+            await self._publish_stopping_transition(snapshot)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        try:
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        if first_error is None:
+            try:
+                _, stop_state.deferred_close_waiter = await self._publish_closed_event_if_needed(
+                    snapshot
+                )
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+            else:
+                if stop_state.deferred_close_waiter is not None:
+                    try:
+                        await asyncio.shield(stop_state.deferred_close_waiter)
+                    except asyncio.CancelledError:
+                        self._complete_stop_waiter_after_deferred_close_and_stop(
+                            stop_waiter=stop_waiter,
+                            snapshot=snapshot,
+                            deferred_close_waiter=stop_state.deferred_close_waiter,
+                        )
+                        stop_state.stop_waiter_completion_deferred = True
+                        raise
+                    except Exception as error:
+                        first_error = error
+        await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
+        if snapshot.stop_dispatcher:
+            try:
+                await self._event_dispatcher.stop()
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -106,6 +106,25 @@ class _DatagramStopSnapshot:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _DatagramStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    inherited_handler_origin: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def has_handler_provenance(self) -> bool:
+        """Whether the caller is the active handler or inherited handler-origin context."""
+        return self.handler_originated or self.inherited_handler_origin
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.has_handler_provenance or self.active_inline_handler
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -280,22 +299,9 @@ class _AsyncioDatagramReceiverBase:
                         then publish terminal events after active handlers unwind
         """
         snapshot = await self._plan_stop_snapshot()
-        handler_originated_stop = (
-            self._event_dispatcher.current_task_is_dispatching_handler()
-            or self._event_dispatcher.current_task_has_handler_origin_context()
-        )
-        inherited_handler_origin = (
-            self._event_dispatcher.current_task_inherits_handler_origin_context()
-        )
-        handler_provenance_stop = handler_originated_stop or inherited_handler_origin
-        active_inline_handler_stop = (
-            not handler_provenance_stop
-            and self._event_dispatcher.has_active_handler_context()
-            and self._event_dispatcher.current_task_would_deliver_inline()
-        )
-        defer_stop_events = handler_provenance_stop or active_inline_handler_stop
+        provenance = self._capture_stop_provenance()
         if snapshot.waits_for_owner:
-            if handler_provenance_stop:
+            if provenance.has_handler_provenance:
                 return
             # Non-owner stop callers observe the active owner stop path instead
             # of planning another teardown. shield() prevents caller
@@ -308,9 +314,9 @@ class _AsyncioDatagramReceiverBase:
         deferred_close_waiter: asyncio.Future[None] | None = None
         stop_waiter_completion_deferred = False
         try:
-            if defer_stop_events:
+            if provenance.defers_terminal_events:
                 try:
-                    if active_inline_handler_stop:
+                    if provenance.active_inline_handler:
                         snapshot.cancel_task = False
                     await self._teardown_stop_resources(
                         snapshot=snapshot, socket_cleanup=socket_cleanup
@@ -327,7 +333,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter_completion_deferred = True
                 if first_error is not None:
                     raise first_error
-                if not handler_provenance_stop and stop_waiter is not None:
+                if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
                 try:
@@ -389,7 +395,7 @@ class _AsyncioDatagramReceiverBase:
             if stop_waiter is not None and not stop_waiter.done():
                 if stop_waiter_completion_deferred:
                     pass
-                elif handler_originated_stop and deferred_close_waiter is not None:
+                elif provenance.handler_originated and deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
                         stop_waiter, deferred_close_waiter
                     )
@@ -402,6 +408,27 @@ class _AsyncioDatagramReceiverBase:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
                         self._runtime.stop_owner_task = None
+
+    def _capture_stop_provenance(self) -> _DatagramStopProvenance:
+        """Capture handler-origin facts for the current stop caller."""
+        handler_originated = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+        )
+        inherited_handler_origin = (
+            self._event_dispatcher.current_task_inherits_handler_origin_context()
+        )
+        active_inline_handler = (
+            not handler_originated
+            and not inherited_handler_origin
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        return _DatagramStopProvenance(
+            handler_originated=handler_originated,
+            inherited_handler_origin=inherited_handler_origin,
+            active_inline_handler=active_inline_handler,
+        )
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -55,6 +55,10 @@ class _DatagramRuntimeState:
     recv_fallback_warning_emitted: bool = False
     stop_waiter: asyncio.Future[None] | None = None
     stop_owner_task: asyncio.Task[object] | None = None
+    opening_event_task: asyncio.Task[object] | None = None
+    deferred_close_event: ConnectionClosedEvent | None = None
+    deferred_close_event_waiter: asyncio.Future[None] | None = None
+    deferred_close_publish_task: asyncio.Task[None] | None = None
 
 
 @dataclass(slots=True)
@@ -80,6 +84,7 @@ class _DatagramStopSnapshot:
     previous_connection_state: ConnectionState = ConnectionState.CREATED
     task: asyncio.Task[None] | None = None
     sock: socket.socket | None = None
+    cancel_task: bool = True
     stopping_event: ComponentLifecycleChangedEvent | None = None
     stop_waiter: asyncio.Future[None] | None = None
     owns_stop: bool = False
@@ -276,8 +281,22 @@ class _AsyncioDatagramReceiverBase:
             unlock    : emit STOPPED and stop dispatcher
         """
         snapshot = await self._plan_stop_snapshot()
+        handler_originated_stop = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+        )
+        inherited_handler_origin = (
+            self._event_dispatcher.current_task_inherits_handler_origin_context()
+        )
+        handler_provenance_stop = handler_originated_stop or inherited_handler_origin
+        active_inline_handler_stop = (
+            not handler_provenance_stop
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        defer_stop_events = handler_provenance_stop or active_inline_handler_stop
         if snapshot.waits_for_owner:
-            if self._event_dispatcher.current_task_is_worker():
+            if handler_provenance_stop:
                 return
             # Non-owner stop callers observe the active owner stop path instead
             # of planning another teardown. shield() prevents caller
@@ -287,36 +306,80 @@ class _AsyncioDatagramReceiverBase:
 
         first_error: BaseException | None = None
         stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
+        deferred_close_waiter: asyncio.Future[None] | None = None
+        stop_waiter_completion_deferred = False
         try:
-            try:
-                await self._publish_stopping_transition(snapshot)
-            except (Exception, asyncio.CancelledError) as error:
-                first_error = error
-            try:
-                await self._teardown_stop_resources(
-                    snapshot=snapshot, socket_cleanup=socket_cleanup
-                )
-            except (Exception, asyncio.CancelledError) as error:
-                if first_error is None:
-                    first_error = error
-            if first_error is None:
+            if defer_stop_events:
                 try:
-                    await self._publish_closed_event_if_needed(snapshot)
+                    if active_inline_handler_stop:
+                        snapshot.cancel_task = False
+                    await self._teardown_stop_resources(
+                        snapshot=snapshot, socket_cleanup=socket_cleanup
+                    )
                 except (Exception, asyncio.CancelledError) as error:
                     first_error = error
-            await self._publish_stopped_transition_if_needed(
-                snapshot, emit_event=first_error is None
-            )
-            if snapshot.stop_dispatcher:
+                if first_error is None:
+                    try:
+                        await self._event_dispatcher.stop_from_handler_origin()
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                if first_error is None:
+                    self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
+                    stop_waiter_completion_deferred = True
+                if first_error is not None:
+                    raise first_error
+                if not handler_provenance_stop and stop_waiter is not None:
+                    await asyncio.shield(stop_waiter)
+            else:
                 try:
-                    await self._event_dispatcher.stop()
+                    await self._publish_stopping_transition(snapshot)
+                except (Exception, asyncio.CancelledError) as error:
+                    first_error = error
+                try:
+                    await self._teardown_stop_resources(
+                        snapshot=snapshot, socket_cleanup=socket_cleanup
+                    )
                 except (Exception, asyncio.CancelledError) as error:
                     if first_error is None:
                         first_error = error
-            if first_error is not None:
-                raise first_error
+                if first_error is None:
+                    try:
+                        _, deferred_close_waiter = await self._publish_closed_event_if_needed(
+                            snapshot
+                        )
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                    else:
+                        if deferred_close_waiter is not None:
+                            try:
+                                await asyncio.shield(deferred_close_waiter)
+                            except asyncio.CancelledError:
+                                self._complete_stop_waiter_after_deferred_close_and_stop(
+                                    stop_waiter=stop_waiter,
+                                    snapshot=snapshot,
+                                    deferred_close_waiter=deferred_close_waiter,
+                                )
+                                stop_waiter_completion_deferred = True
+                                raise
+                            except Exception as error:
+                                first_error = error
+                await self._publish_stopped_transition_if_needed(
+                    snapshot, emit_event=first_error is None
+                )
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
         except (Exception, asyncio.CancelledError) as error:
-            if stop_waiter is not None and not stop_waiter.done():
+            if (
+                stop_waiter is not None
+                and not stop_waiter.done()
+                and not stop_waiter_completion_deferred
+            ):
                 stop_waiter.set_exception(error)
                 # Mark the exception as retrieved so failed owner stops do not
                 # leave an unhandled-Future warning behind.
@@ -325,13 +388,151 @@ class _AsyncioDatagramReceiverBase:
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                stop_waiter.set_result(None)
+                if stop_waiter_completion_deferred:
+                    pass
+                elif handler_originated_stop and deferred_close_waiter is not None:
+                    self._complete_stop_waiter_after_deferred_close(
+                        stop_waiter, deferred_close_waiter
+                    )
+                    stop_waiter_completion_deferred = True
+                else:
+                    stop_waiter.set_result(None)
         finally:
-            if stop_waiter is not None:
+            if stop_waiter is not None and not stop_waiter_completion_deferred:
                 async with self._state_lock:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
                         self._runtime.stop_owner_task = None
+
+    def _complete_stop_waiter_after_deferred_close(
+        self,
+        stop_waiter: asyncio.Future[None],
+        deferred_close_waiter: asyncio.Future[None],
+    ) -> None:
+        """Release external stop waiters after handler-originated deferred close publication."""
+
+        async def _complete() -> None:
+            try:
+                await asyncio.shield(deferred_close_waiter)
+            except BaseException as error:
+                if not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_close_and_stop(
+        self,
+        *,
+        stop_waiter: asyncio.Future[None] | None,
+        snapshot: _DatagramStopSnapshot,
+        deferred_close_waiter: asyncio.Future[None],
+    ) -> None:
+        """Complete terminal stop publication after close was deferred elsewhere."""
+
+        async def _complete() -> None:
+            first_error: BaseException | None = None
+            try:
+                try:
+                    await asyncio.shield(deferred_close_waiter)
+                except BaseException as error:
+                    first_error = error
+                try:
+                    await self._publish_stopped_transition_if_needed(
+                        snapshot, emit_event=first_error is None
+                    )
+                except (Exception, asyncio.CancelledError) as error:
+                    if first_error is None:
+                        first_error = error
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
+
+    def _complete_stop_waiter_after_deferred_stop_events(
+        self,
+        stop_waiter: asyncio.Future[None] | None,
+        snapshot: _DatagramStopSnapshot,
+    ) -> None:
+        """Publish terminal stop events after a handler-originated stop unwinds."""
+
+        async def _complete() -> None:
+            first_error: BaseException | None = None
+            try:
+                while self._event_dispatcher.has_active_handler_context():
+                    await asyncio.sleep(0)
+                with self._event_dispatcher.inline_delivery_context():
+                    try:
+                        await self._publish_stopping_transition(snapshot)
+                    except (Exception, asyncio.CancelledError) as error:
+                        first_error = error
+                    if first_error is None:
+                        try:
+                            _, deferred_close_waiter = await self._publish_closed_event_if_needed(
+                                snapshot
+                            )
+                            if deferred_close_waiter is not None:
+                                await asyncio.shield(deferred_close_waiter)
+                        except (Exception, asyncio.CancelledError) as error:
+                            first_error = error
+                    try:
+                        await self._publish_stopped_transition_if_needed(
+                            snapshot, emit_event=first_error is None
+                        )
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if snapshot.stop_dispatcher:
+                    try:
+                        await self._event_dispatcher.stop()
+                    except (Exception, asyncio.CancelledError) as error:
+                        if first_error is None:
+                            first_error = error
+                if first_error is not None:
+                    raise first_error
+            except BaseException as error:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_exception(error)
+                    with contextlib.suppress(BaseException):
+                        stop_waiter.exception()
+            else:
+                if stop_waiter is not None and not stop_waiter.done():
+                    stop_waiter.set_result(None)
+            finally:
+                async with self._state_lock:
+                    if self._runtime.stop_waiter is stop_waiter:
+                        self._runtime.stop_waiter = None
+                        self._runtime.stop_owner_task = None
+
+        _ = asyncio.create_task(_complete())
 
     async def _plan_stop_snapshot(self) -> _DatagramStopSnapshot:
         """Detach stop-time resources under lock and return the resulting stop snapshot."""
@@ -381,17 +582,146 @@ class _AsyncioDatagramReceiverBase:
             return
         await self._emit_lifecycle_event(snapshot.stopping_event)
 
-    async def _publish_closed_event_if_needed(self, snapshot: _DatagramStopSnapshot) -> None:
+    async def _publish_closed_event_if_needed(
+        self, snapshot: _DatagramStopSnapshot
+    ) -> tuple[bool, asyncio.Future[None] | None]:
         """Emit the connection-closed event unless stop is rolling back startup."""
         if not snapshot.should_emit_closed_event:
-            return
-        await self._event_dispatcher.emit(
-            ConnectionClosedEvent(
-                resource_id=self._connection_id,
-                previous_state=snapshot.previous_connection_state,
-                metadata=self._connection_metadata,
-            )
+            return False, None
+        closed_event = ConnectionClosedEvent(
+            resource_id=self._connection_id,
+            previous_state=snapshot.previous_connection_state,
+            metadata=self._connection_metadata,
         )
+        deferred, deferred_waiter = await self._defer_close_event_until_current_handler_unwinds(
+            closed_event
+        )
+        if deferred:
+            return True, deferred_waiter
+        await self._event_dispatcher.emit(closed_event)
+        return False, None
+
+    async def _defer_close_event_until_current_handler_unwinds(
+        self, closed_event: ConnectionClosedEvent
+    ) -> tuple[bool, asyncio.Future[None] | None]:
+        """Defer close publication while the current connection handler is in flight."""
+        async with self._state_lock:
+            opening_event_in_flight = self._runtime.opening_event_task is not None
+            inherited_handler_origin = (
+                self._event_dispatcher.current_task_inherits_handler_origin_context()
+            )
+            handler_origin_in_flight = (
+                self._event_dispatcher.current_task_is_dispatching_handler()
+                or self._event_dispatcher.current_task_has_handler_origin_context()
+            )
+            active_inline_handler_in_flight = (
+                self._event_dispatcher.has_active_handler_context()
+                and self._event_dispatcher.current_task_would_deliver_inline()
+            )
+            if (
+                not opening_event_in_flight
+                and not handler_origin_in_flight
+                and not inherited_handler_origin
+                and not active_inline_handler_in_flight
+            ):
+                return False, None
+            self._runtime.deferred_close_event = closed_event
+            if (
+                self._runtime.deferred_close_event_waiter is None
+                or self._runtime.deferred_close_event_waiter.done()
+            ):
+                current_task = asyncio.current_task()
+                loop = (
+                    current_task.get_loop()
+                    if current_task is not None
+                    else asyncio.get_running_loop()
+                )
+                self._runtime.deferred_close_event_waiter = loop.create_future()
+            if not opening_event_in_flight and (
+                handler_origin_in_flight
+                or inherited_handler_origin
+                or active_inline_handler_in_flight
+            ):
+                publish_task = self._runtime.deferred_close_publish_task
+                if publish_task is None or publish_task.done():
+                    self._runtime.deferred_close_publish_task = asyncio.create_task(
+                        self._publish_deferred_close_after_handler_origin_expires(),
+                        name=f"{self._connection_id}-deferred-close-publisher",
+                    )
+            if handler_origin_in_flight or inherited_handler_origin:
+                return True, None
+            return True, self._runtime.deferred_close_event_waiter
+
+    async def _publish_deferred_close_after_handler_origin_expires(self) -> None:
+        """Publish a deferred close once the handler-origin context has unwound."""
+        current_task = asyncio.current_task()
+        try:
+            while self._event_dispatcher.has_active_handler_context():
+                await asyncio.sleep(0)
+            await self._publish_deferred_close_after_opened_event()
+        except (Exception, asyncio.CancelledError) as error:
+            async with self._state_lock:
+                deferred_waiter = self._runtime.deferred_close_event_waiter
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    deferred_waiter.exception()
+            if not isinstance(error, asyncio.CancelledError):
+                self._logger.warning(
+                    "%s deferred close publication failed: %s",
+                    self._receiver_name,
+                    error,
+                )
+        finally:
+            async with self._state_lock:
+                if self._runtime.deferred_close_publish_task is current_task:
+                    self._runtime.deferred_close_publish_task = None
+
+    async def _publish_deferred_close_after_opened_event_preserving_cancellation(self) -> bool:
+        """Publish deferred close even if receiver startup is cancelled at the barrier."""
+        publish_task = asyncio.create_task(self._publish_deferred_close_after_opened_event())
+        caller_cancelled = False
+        try:
+            while True:
+                try:
+                    result = await asyncio.shield(publish_task)
+                    break
+                except asyncio.CancelledError:
+                    caller_cancelled = True
+                    if publish_task.done():
+                        result = publish_task.result()
+                        break
+                    continue
+        finally:
+            if caller_cancelled and not publish_task.done():
+                _ = await asyncio.shield(publish_task)
+        if caller_cancelled:
+            raise asyncio.CancelledError
+        return result
+
+    async def _publish_deferred_close_after_opened_event(self) -> bool:
+        """Publish a close event deferred until ConnectionOpenedEvent handling completed."""
+        async with self._state_lock:
+            closed_event = self._runtime.deferred_close_event
+            if closed_event is None:
+                return False
+            self._runtime.deferred_close_event = None
+            deferred_waiter = self._runtime.deferred_close_event_waiter
+        try:
+            with self._event_dispatcher.inline_delivery_context():
+                await self._event_dispatcher.emit(closed_event)
+        except (Exception, asyncio.CancelledError) as error:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_exception(error)
+            raise
+        else:
+            if deferred_waiter is not None and not deferred_waiter.done():
+                deferred_waiter.set_result(None)
+        finally:
+            async with self._state_lock:
+                if self._runtime.deferred_close_event_waiter is deferred_waiter:
+                    self._runtime.deferred_close_event_waiter = None
+        return True
 
     def _is_fully_stopped_locked(self) -> bool:
         """Return whether runtime state already represents a fully stopped receiver."""
@@ -410,7 +740,7 @@ class _AsyncioDatagramReceiverBase:
         """Cancel the detached receive task and close the detached socket, if present."""
         task_error: BaseException | None = None
         if snapshot.task is not None:
-            if snapshot.task is not asyncio.current_task():
+            if snapshot.cancel_task and snapshot.task is not asyncio.current_task():
                 snapshot.task.cancel()
                 try:
                     await await_task_completion_preserving_cancellation(
@@ -423,7 +753,11 @@ class _AsyncioDatagramReceiverBase:
             if socket_cleanup is not None:
                 socket_cleanup(snapshot.sock)
             snapshot.sock.close()
-        if snapshot.task is not None and snapshot.task is not asyncio.current_task():
+        if (
+            snapshot.cancel_task
+            and snapshot.task is not None
+            and snapshot.task is not asyncio.current_task()
+        ):
             if task_error is not None:
                 raise task_error
 
@@ -521,9 +855,32 @@ class _AsyncioDatagramReceiverBase:
             running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
         try:
             await self._emit_lifecycle_event(running_event)
-            await self._event_dispatcher.emit(
-                ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
-            )
+            async with self._state_lock:
+                if (
+                    self._socket is not sock
+                    or not self._running
+                    or self._lifecycle_state != ComponentLifecycleState.RUNNING
+                ):
+                    return
+            opening_task = asyncio.current_task()
+            self._runtime.opening_event_task = cast(asyncio.Task[object] | None, opening_task)
+            try:
+                await self._event_dispatcher.emit_and_wait(
+                    ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata),
+                    drop_on_backpressure=False,
+                )
+            except (Exception, asyncio.CancelledError):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await self._publish_deferred_close_after_opened_event_preserving_cancellation()
+                if self._runtime.opening_event_task is opening_task:
+                    self._runtime.opening_event_task = None
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await self._stop_datagram_receiver(socket_cleanup=self._cleanup_socket)
+                raise
+            if self._runtime.opening_event_task is opening_task:
+                self._runtime.opening_event_task = None
+            if await self._publish_deferred_close_after_opened_event_preserving_cancellation():
+                return
             async with self._state_lock:
                 if (
                     self._socket is not sock

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -315,24 +315,12 @@ class _AsyncioDatagramReceiverBase:
         stop_waiter_completion_deferred = False
         try:
             if provenance.defers_terminal_events:
-                try:
-                    if provenance.active_inline_handler:
-                        snapshot.cancel_task = False
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                if first_error is None:
-                    try:
-                        await self._event_dispatcher.stop_from_handler_origin()
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                if first_error is None:
-                    self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
-                    stop_waiter_completion_deferred = True
-                if first_error is not None:
-                    raise first_error
+                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
+                    snapshot=snapshot,
+                    provenance=provenance,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
+                )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
@@ -429,6 +417,32 @@ class _AsyncioDatagramReceiverBase:
             inherited_handler_origin=inherited_handler_origin,
             active_inline_handler=active_inline_handler,
         )
+
+    async def _prepare_deferred_stop_events(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        provenance: _DatagramStopProvenance,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> bool:
+        """Tear down resources and schedule terminal publication after handlers unwind."""
+        first_error: BaseException | None = None
+        try:
+            if provenance.active_inline_handler:
+                snapshot.cancel_task = False
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        if first_error is None:
+            try:
+                await self._event_dispatcher.stop_from_handler_origin()
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+        if first_error is None:
+            self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
+            return True
+        raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -363,10 +363,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter.set_result(None)
         finally:
             if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
     def _capture_stop_provenance(self) -> _DatagramStopProvenance:
         """Capture handler-origin facts for the current stop caller."""
@@ -465,6 +462,13 @@ class _AsyncioDatagramReceiverBase:
         if first_error is not None:
             raise first_error
 
+    async def _clear_stop_waiter_if_current(self, stop_waiter: asyncio.Future[None] | None) -> None:
+        """Clear the shared stop waiter when the caller still owns it."""
+        async with self._state_lock:
+            if self._runtime.stop_waiter is stop_waiter:
+                self._runtime.stop_waiter = None
+                self._runtime.stop_owner_task = None
+
     def _complete_stop_waiter_after_deferred_close(
         self,
         stop_waiter: asyncio.Future[None],
@@ -484,10 +488,7 @@ class _AsyncioDatagramReceiverBase:
                 if not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -531,10 +532,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -588,10 +586,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -274,11 +274,10 @@ class _AsyncioDatagramReceiverBase:
 
         Flow overview:
             lock      : plan snapshot, detach task/socket, compute STOPPING
-            unlock    : emit STOPPING
-            unlock    : cancel task and close socket
-            unlock    : emit ConnectionClosedEvent when this is not startup rollback
-            lock      : compute STOPPED
-            unlock    : emit STOPPED and stop dispatcher
+            ordinary  : emit STOPPING, tear down resources, then publish
+                        ConnectionClosedEvent/STOPPED and stop dispatcher
+            deferred  : tear down resources first, stop handler-origin dispatch,
+                        then publish terminal events after active handlers unwind
         """
         snapshot = await self._plan_stop_snapshot()
         handler_originated_stop = (

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -16,6 +16,7 @@ import socket
 
 import pytest
 
+from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.connection_events import ConnectionClosedEvent
@@ -39,6 +40,7 @@ from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdp
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
+from tests.helpers import wait_for_condition
 
 
 class NoopHandler:
@@ -92,6 +94,52 @@ class StopAgainOnStoppingHandler:
         ):
             await self.receiver.stop()
             self.reentered_stop.set()
+
+
+class SpawnStopOnOpenedHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.receiver: AsyncioUdpReceiver | None = None
+        self.opened_seen = asyncio.Event()
+        self.opened_finished = asyncio.Event()
+        self.closed_seen = asyncio.Event()
+        self.stop_returned = asyncio.Event()
+        self.release_opened = asyncio.Event()
+        self.stop_task: asyncio.Task[None] | None = None
+        self.error: BaseException | None = None
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if isinstance(event, ConnectionClosedEvent):
+            if not self.opened_finished.is_set():
+                self.error = AssertionError("closed event re-entered opened handler")
+                self.release_opened.set()
+                return
+            self.closed_seen.set()
+            return
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            and not self.opened_finished.is_set()
+        ):
+            self.error = AssertionError("lifecycle event re-entered opened handler")
+            self.release_opened.set()
+            return
+        if self.receiver is None or not isinstance(event, ConnectionOpenedEvent):
+            return
+        self.opened_seen.set()
+        try:
+            self.stop_task = asyncio.create_task(self.receiver.stop())
+            await self.stop_task
+            self.stop_returned.set()
+            if self.closed_seen.is_set():
+                raise AssertionError("closed event was published before opened handler returned")
+            await self.release_opened.wait()
+        except BaseException as error:
+            self.error = error
+            self.release_opened.set()
+        finally:
+            self.opened_finished.set()
 
 
 class HoldingOpenEventLockHandler:
@@ -235,15 +283,17 @@ async def test_udp_receiver_background_startup_cancellation_after_opened_event_r
         event_handler=NoopHandler(),
     )
 
-    original_emit = receiver._event_dispatcher.emit  # type: ignore[attr-defined]
+    original_emit_and_wait = receiver._event_dispatcher.emit_and_wait  # type: ignore[attr-defined]
 
-    async def _emit_blocking_opened_event(event) -> None:
+    async def _emit_and_wait_blocking_opened_event(
+        event, *, drop_on_backpressure: bool = True
+    ) -> None:
         if isinstance(event, ConnectionOpenedEvent):
             opened_emit_seen.set()
             await allow_opened_emit_to_return.wait()
-        await original_emit(event)
+        await original_emit_and_wait(event, drop_on_backpressure=drop_on_backpressure)
 
-    receiver._event_dispatcher.emit = _emit_blocking_opened_event  # type: ignore[method-assign]
+    receiver._event_dispatcher.emit_and_wait = _emit_and_wait_blocking_opened_event  # type: ignore[method-assign]
 
     start_task = asyncio.create_task(receiver.start())
     await asyncio.wait_for(opened_emit_seen.wait(), timeout=1.0)
@@ -254,6 +304,73 @@ async def test_udp_receiver_background_startup_cancellation_after_opened_event_r
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_cancelled_external_stop_during_opened_barrier_publishes_terminal_events() -> (
+    None
+):
+    class BlockingOpenedHandler:
+        def __init__(self) -> None:
+            self.events: list[object] = []
+            self.opened_seen = asyncio.Event()
+            self.release_opened = asyncio.Event()
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionOpenedEvent):
+                self.opened_seen.set()
+                await self.release_opened.wait()
+
+    handler = BlockingOpenedHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    start_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    joiner_stop_task: asyncio.Task[None] | None = None
+    try:
+        start_task = asyncio.create_task(receiver.start())
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await wait_for_condition(
+            lambda: receiver.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=1.0,
+        )
+        stop_task.cancel()
+        await assert_awaitable_cancelled(stop_task)
+
+        joiner_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not joiner_stop_task.done()
+
+        handler.release_opened.set()
+        await asyncio.wait_for(joiner_stop_task, timeout=1.0)
+        await asyncio.wait_for(start_task, timeout=1.0)
+    finally:
+        handler.release_opened.set()
+        for task in (stop_task, joiner_stop_task, start_task):
+            if task is not None and not task.done():
+                task.cancel()
+                await drain_awaitable_ignoring_cancelled(task)
+        await receiver.stop()
+
+    lifecycle_states = [
+        event.current
+        for event in handler.events
+        if isinstance(event, ComponentLifecycleChangedEvent)
+    ]
+    assert ComponentLifecycleState.STOPPING in lifecycle_states
+    assert ComponentLifecycleState.STOPPED in lifecycle_states
+    assert any(isinstance(event, ConnectionClosedEvent) for event in handler.events)
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
@@ -955,6 +1072,482 @@ async def test_udp_receiver_inline_stop_reentry_does_not_self_await() -> None:
         ComponentLifecycleState.STOPPED,
     ]
     assert len(closed_events) == 1
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_spawned_stop_from_opened_handler_delivers_terminal_events() -> None:
+    handler = SpawnStopOnOpenedHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    start_task: asyncio.Task[None] | None = None
+
+    try:
+        start_task = asyncio.create_task(receiver.start())
+        await asyncio.wait_for(handler.opened_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+        assert not start_task.done()
+        assert not any(
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            for event in handler.events
+        )
+
+        handler.release_opened.set()
+        assert handler.stop_task is not None
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(start_task, timeout=1.0)
+    finally:
+        handler.release_opened.set()
+        if start_task is not None and not start_task.done():
+            start_task.cancel()
+            await drain_awaitable_ignoring_cancelled(start_task)
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await receiver.stop()
+
+    assert handler.error is None
+    stop_relevant_events = [
+        event
+        for event in handler.events
+        if isinstance(event, ConnectionClosedEvent)
+        or (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
+    ]
+    assert [type(event).__name__ for event in stop_relevant_events] == [
+        "ComponentLifecycleChangedEvent",
+        "ConnectionClosedEvent",
+        "ComponentLifecycleChangedEvent",
+    ]
+    assert isinstance(stop_relevant_events[0], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[0].current == ComponentLifecycleState.STOPPING
+    assert isinstance(stop_relevant_events[1], ConnectionClosedEvent)
+    assert isinstance(stop_relevant_events[2], ComponentLifecycleChangedEvent)
+    assert stop_relevant_events[2].current == ComponentLifecycleState.STOPPED
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_spawned_stop_from_bytes_handler_defers_close_until_handler_returns() -> (
+    None
+):
+    class SpawnStopFromBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.bytes_seen = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+                and not self.bytes_finished.is_set()
+            ):
+                self.error = AssertionError("lifecycle event re-entered bytes handler")
+                self.release_bytes.set()
+                return
+            if self.receiver is None or not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_seen.set()
+            try:
+                self.stop_task = asyncio.create_task(self.receiver.stop())
+                await self.stop_task
+                self.stop_returned.set()
+                if self.closed_seen.is_set():
+                    raise AssertionError("closed event was published before bytes handler returned")
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = SpawnStopFromBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"stop-from-bytes-handler")
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_inherited_handler_stop_does_not_wait_for_owner() -> None:
+    class AwaitChildStopFromBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.bytes_seen = asyncio.Event()
+            self.child_stop_returned = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.child_stop_task: asyncio.Task[None] | None = None
+            self.second_child_stop_returned = asyncio.Event()
+            self.second_child_stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.receiver is None or not isinstance(event, BytesReceivedEvent):
+                return
+
+            async def child_stop(returned: asyncio.Event) -> None:
+                await self.receiver.stop()
+                returned.set()
+
+            self.bytes_seen.set()
+            try:
+                self.child_stop_task = asyncio.create_task(child_stop(self.child_stop_returned))
+                await self.child_stop_task
+                self.second_child_stop_task = asyncio.create_task(
+                    child_stop(self.second_child_stop_returned)
+                )
+                await self.second_child_stop_task
+                await self.release_bytes.wait()
+            except BaseException as error:
+                self.error = error
+                self.release_bytes.set()
+            finally:
+                self.bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = AwaitChildStopFromBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"child-stop-from-handler")
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.child_stop_returned.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.second_child_stop_returned.wait(), timeout=1.0)
+        assert not handler.closed_seen.is_set()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if handler.child_stop_task is not None and not handler.child_stop_task.done():
+            handler.child_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.child_stop_task)
+        if handler.second_child_stop_task is not None and not handler.second_child_stop_task.done():
+            handler.second_child_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.second_child_stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_handler_origin_stop_drops_queued_background_bytes_before_terminal_events() -> (
+    None
+):
+    class StopFromFirstBytesHandler:
+        def __init__(self) -> None:
+            self.receiver: AsyncioUdpReceiver | None = None
+            self.first_bytes_seen = asyncio.Event()
+            self.first_bytes_finished = asyncio.Event()
+            self.allow_stop_to_start = asyncio.Event()
+            self.allow_first_bytes_to_finish = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.events: list[object] = []
+            self.stop_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.first_bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.allow_first_bytes_to_finish.set()
+                self.closed_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            if event.data == b"second":
+                self.error = AssertionError("queued bytes event was delivered after receiver stop")
+                self.allow_first_bytes_to_finish.set()
+                return
+            self.first_bytes_seen.set()
+            try:
+                await self.allow_stop_to_start.wait()
+                if self.receiver is None:
+                    raise AssertionError("receiver reference was not attached")
+                self.stop_task = asyncio.create_task(self.receiver.stop())
+                await self.stop_task
+                self.stop_returned.set()
+                await self.allow_first_bytes_to_finish.wait()
+            except BaseException as error:
+                self.error = error
+                self.allow_first_bytes_to_finish.set()
+            finally:
+                self.first_bytes_finished.set()
+
+    port = _get_unused_udp_port()
+    handler = StopFromFirstBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    try:
+        await receiver.start()
+        await sender.send(b"first")
+        await asyncio.wait_for(handler.first_bytes_seen.wait(), timeout=1.0)
+        await sender.send(b"second")
+        await wait_for_condition(
+            lambda: receiver._event_dispatcher.runtime_stats.queue_depth == 1,  # type: ignore[attr-defined]
+            timeout_seconds=1.0,
+        )
+
+        handler.allow_stop_to_start.set()
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        handler.allow_first_bytes_to_finish.set()
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+    finally:
+        handler.allow_stop_to_start.set()
+        handler.allow_first_bytes_to_finish.set()
+        if handler.stop_task is not None and not handler.stop_task.done():
+            handler.stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(handler.stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert [event.data for event in handler.events if isinstance(event, BytesReceivedEvent)] == [
+        b"first"
+    ]
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_external_inline_stop_waits_for_active_bytes_handler() -> None:
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.events: list[object] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            self.events.append(event)
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                try:
+                    await self.release_bytes.wait()
+                finally:
+                    self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    port = _get_unused_udp_port()
+    handler = BlockingBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        await sender.send(b"external-inline-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert not handler.terminal_event_seen.is_set()
+        assert not handler.bytes_finished.is_set()
+        assert not stop_task.done()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_cancelled_external_inline_stop_keeps_shared_waiter() -> None:
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.terminal_event_seen = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                try:
+                    await self.release_bytes.wait()
+                finally:
+                    self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent) or (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current
+                in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_event_seen.set()
+
+    port = _get_unused_udp_port()
+    handler = BlockingBytesHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    sender = AsyncioUdpSender(
+        settings=UdpSenderSettings(default_host="127.0.0.1", default_port=port)
+    )
+    stop_task: asyncio.Task[None] | None = None
+    joiner_stop_task: asyncio.Task[None] | None = None
+    try:
+        await receiver.start()
+        await sender.send(b"cancel-external-inline-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(receiver.stop())
+        await wait_for_condition(
+            lambda: receiver.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=1.0,
+        )
+        assert not handler.terminal_event_seen.is_set()
+
+        stop_task.cancel()
+        await assert_awaitable_cancelled(stop_task)
+
+        joiner_stop_task = asyncio.create_task(receiver.stop())
+        await asyncio.sleep(0)
+        assert not joiner_stop_task.done()
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(joiner_stop_task, timeout=1.0)
+        await asyncio.wait_for(handler.terminal_event_seen.wait(), timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(stop_task)
+        if joiner_stop_task is not None and not joiner_stop_task.done():
+            joiner_stop_task.cancel()
+            await drain_awaitable_ignoring_cancelled(joiner_stop_task)
+        await sender.stop()
+        await receiver.stop()
+
+    assert handler.error is None
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary

While expanding UDP receiver shutdown regression coverage around handler-origin stop paths, additional interleavings showed that datagram terminal publication was not consistently aligned with the documented per-receiver event-ordering contract.

This PR brings UDP receiver shutdown ordering in line with the handler-origin guarantees covered by the TCP stack: terminal events are deferred until active same-receiver handler work has returned, handler-spawned stop paths avoid self-wait deadlocks, and cancelled external stop callers no longer poison shared deferred completion.

## Problems and approach

### 1. Handler-origin UDP stop could publish terminal events while a handler was still active

Problem:
If `receiver.stop()` was started from a `ConnectionOpenedEvent` or `BytesReceivedEvent` handler, the stop path could publish `STOPPING`, `ConnectionClosedEvent`, or `STOPPED` while the same receiver's current handler was still running. In BACKGROUND mode, terminal events could also be queued behind the handler that was waiting for stop to return.

Approach:
The receiver now detects handler-origin and active inline-handler stop paths and defers terminal event publication until the active handler context has unwound. Deferred close publication is tracked explicitly and emitted through the dispatcher inline-delivery context once it is safe to publish terminal events without re-entering the handler.

Regression coverage now blocks opened and bytes handlers while stop is initiated from the handler path and asserts that terminal events are not observed until the handler has returned.

### 2. Handler-spawned stop tasks needed provenance-safe completion

Problem:
A user handler can spawn and await a child task that calls `receiver.stop()`. That child task inherits handler provenance, but it is not the dispatcher worker task. Treating it like an ordinary external stop caller can deadlock on the owner stop waiter; treating it like a normal stop can publish terminal events too early.

Approach:
The stop path now distinguishes direct handler-origin authority from inherited handler provenance. Handler-provenance callers avoid waiting on the owner they are helping unwind, while the receiver still defers terminal publication until the active handler context is gone.

Regression coverage asserts that handler-spawned child stops return without self-waiting and that close publication still happens only after the handler finishes.

### 3. Queued BACKGROUND datagrams could survive handler-origin stop

Problem:
When a BACKGROUND bytes handler initiated receiver stop while additional datagrams were already queued, the queued payload work could be delivered after the receiver had started terminal shutdown. That would make payload delivery cross the terminal event boundary.

Approach:
Handler-origin shutdown now stops the dispatcher through the handler-origin path, which drops queued same-receiver payload work instead of delivering it after shutdown has begun. Terminal events remain deferred until the active handler returns.

Regression coverage sends a second datagram while the first handler is blocked, initiates stop from the first handler, and asserts that only the first payload event is delivered before terminal publication.

### 4. Caller cancellation could lose deferred stop completion

Problem:
External stop callers can be cancelled while terminal publication is deferred behind an opened-handler barrier or an active inline bytes handler. Without explicit shielding and shared-waiter completion, cancellation can leave terminal events unpublished or leave later stop callers waiting on poisoned state.

Approach:
Deferred close and stop completion now use shielded waiters and background completion paths so terminal publication can finish independently of the cancelled caller. Follow-up stop callers observe the shared completion instead of starting a competing teardown.

Regression coverage cancels external stop callers in both the opened-publication and active INLINE bytes-handler windows, then verifies that later stop callers complete and terminal events are still published.

## Changes

- Defer UDP terminal events until active handler-origin work returns.
- Preserve shared stop completion when an external stop caller is cancelled.
- Avoid handler-spawned stop self-waits while preserving terminal ordering.
- Drop queued same-receiver payload events during handler-origin shutdown.
- Track deferred close publication around opened-handler and active-handler barriers.
- Add targeted regression coverage for the affected UDP shutdown interleavings.
- Update `CHANGELOG.md` for the UDP deferred stop publication fix.


## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not needed: this restores the existing documented ordering guarantee; the generic handler-origin shutdown semantics are covered by the stacked TCP PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface changes introduced.

Local verification:

- `python -m pytest -q tests/unit/test_asyncio_udp_transport.py tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py -p no:cacheprovider --timeout=60`
- `python -m pytest -q -m "integration and not multicast and not slow" -p no:cacheprovider --timeout=60`
- `python -m pytest -q -m "not multicast and not slow and not integration and not hypothesis" -p no:cacheprovider --timeout=60`
- `ruff check . --no-cache`
- `ruff format --check . --no-cache`
- `python -m mypy src`