### PR TITLE
refactor(udp): clarify deferred stop publication flow

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -125,6 +125,14 @@ class _DatagramStopProvenance:
         return self.has_handler_provenance or self.active_inline_handler
 
 
+@dataclass(slots=True)
+class _DatagramStopExecutionState:
+    """Mutable cross-step state for a single stop execution."""
+
+    deferred_close_waiter: asyncio.Future[None] | None = None
+    stop_waiter_completion_deferred: bool = False
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -309,69 +317,32 @@ class _AsyncioDatagramReceiverBase:
             await asyncio.shield(cast("asyncio.Future[None]", snapshot.stop_waiter))
             return
 
-        first_error: BaseException | None = None
         stop_waiter = snapshot.stop_waiter if snapshot.owns_stop else None
-        deferred_close_waiter: asyncio.Future[None] | None = None
-        stop_waiter_completion_deferred = False
+        stop_state = _DatagramStopExecutionState()
         try:
             if provenance.defers_terminal_events:
-                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
-                    snapshot=snapshot,
-                    provenance=provenance,
-                    stop_waiter=stop_waiter,
-                    socket_cleanup=socket_cleanup,
+                stop_state.stop_waiter_completion_deferred = (
+                    await self._prepare_deferred_stop_events(
+                        snapshot=snapshot,
+                        provenance=provenance,
+                        stop_waiter=stop_waiter,
+                        socket_cleanup=socket_cleanup,
+                    )
                 )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
-                try:
-                    await self._publish_stopping_transition(snapshot)
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                try:
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    if first_error is None:
-                        first_error = error
-                if first_error is None:
-                    try:
-                        _, deferred_close_waiter = await self._publish_closed_event_if_needed(
-                            snapshot
-                        )
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                    else:
-                        if deferred_close_waiter is not None:
-                            try:
-                                await asyncio.shield(deferred_close_waiter)
-                            except asyncio.CancelledError:
-                                self._complete_stop_waiter_after_deferred_close_and_stop(
-                                    stop_waiter=stop_waiter,
-                                    snapshot=snapshot,
-                                    deferred_close_waiter=deferred_close_waiter,
-                                )
-                                stop_waiter_completion_deferred = True
-                                raise
-                            except Exception as error:
-                                first_error = error
-                await self._publish_stopped_transition_if_needed(
-                    snapshot, emit_event=first_error is None
+                await self._run_ordinary_stop_path(
+                    snapshot=snapshot,
+                    stop_state=stop_state,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
                 )
-                if snapshot.stop_dispatcher:
-                    try:
-                        await self._event_dispatcher.stop()
-                    except (Exception, asyncio.CancelledError) as error:
-                        if first_error is None:
-                            first_error = error
-                if first_error is not None:
-                    raise first_error
         except (Exception, asyncio.CancelledError) as error:
             if (
                 stop_waiter is not None
                 and not stop_waiter.done()
-                and not stop_waiter_completion_deferred
+                and not stop_state.stop_waiter_completion_deferred
             ):
                 stop_waiter.set_exception(error)
                 # Mark the exception as retrieved so failed owner stops do not
@@ -381,17 +352,17 @@ class _AsyncioDatagramReceiverBase:
             raise
         else:
             if stop_waiter is not None and not stop_waiter.done():
-                if stop_waiter_completion_deferred:
+                if stop_state.stop_waiter_completion_deferred:
                     pass
-                elif provenance.handler_originated and deferred_close_waiter is not None:
+                elif provenance.handler_originated and stop_state.deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
-                        stop_waiter, deferred_close_waiter
+                        stop_waiter, stop_state.deferred_close_waiter
                     )
-                    stop_waiter_completion_deferred = True
+                    stop_state.stop_waiter_completion_deferred = True
                 else:
                     stop_waiter.set_result(None)
         finally:
-            if stop_waiter is not None and not stop_waiter_completion_deferred:
+            if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
                 async with self._state_lock:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
@@ -443,6 +414,56 @@ class _AsyncioDatagramReceiverBase:
             self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
             return True
         raise first_error
+
+    async def _run_ordinary_stop_path(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        stop_state: _DatagramStopExecutionState,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> None:
+        """Run the ordinary stop path that publishes terminal events inline."""
+        first_error: BaseException | None = None
+        try:
+            await self._publish_stopping_transition(snapshot)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        try:
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        if first_error is None:
+            try:
+                _, stop_state.deferred_close_waiter = await self._publish_closed_event_if_needed(
+                    snapshot
+                )
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+            else:
+                if stop_state.deferred_close_waiter is not None:
+                    try:
+                        await asyncio.shield(stop_state.deferred_close_waiter)
+                    except asyncio.CancelledError:
+                        self._complete_stop_waiter_after_deferred_close_and_stop(
+                            stop_waiter=stop_waiter,
+                            snapshot=snapshot,
+                            deferred_close_waiter=stop_state.deferred_close_waiter,
+                        )
+                        stop_state.stop_waiter_completion_deferred = True
+                        raise
+                    except Exception as error:
+                        first_error = error
+        await self._publish_stopped_transition_if_needed(snapshot, emit_event=first_error is None)
+        if snapshot.stop_dispatcher:
+            try:
+                await self._event_dispatcher.stop()
+            except (Exception, asyncio.CancelledError) as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -106,6 +106,25 @@ class _DatagramStopSnapshot:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _DatagramStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    inherited_handler_origin: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def has_handler_provenance(self) -> bool:
+        """Whether the caller is the active handler or inherited handler-origin context."""
+        return self.handler_originated or self.inherited_handler_origin
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.has_handler_provenance or self.active_inline_handler
+
+
 class _AsyncioDatagramReceiverBase:
     """
     Shared internals for asyncio datagram receiver implementations.
@@ -280,22 +299,9 @@ class _AsyncioDatagramReceiverBase:
                         then publish terminal events after active handlers unwind
         """
         snapshot = await self._plan_stop_snapshot()
-        handler_originated_stop = (
-            self._event_dispatcher.current_task_is_dispatching_handler()
-            or self._event_dispatcher.current_task_has_handler_origin_context()
-        )
-        inherited_handler_origin = (
-            self._event_dispatcher.current_task_inherits_handler_origin_context()
-        )
-        handler_provenance_stop = handler_originated_stop or inherited_handler_origin
-        active_inline_handler_stop = (
-            not handler_provenance_stop
-            and self._event_dispatcher.has_active_handler_context()
-            and self._event_dispatcher.current_task_would_deliver_inline()
-        )
-        defer_stop_events = handler_provenance_stop or active_inline_handler_stop
+        provenance = self._capture_stop_provenance()
         if snapshot.waits_for_owner:
-            if handler_provenance_stop:
+            if provenance.has_handler_provenance:
                 return
             # Non-owner stop callers observe the active owner stop path instead
             # of planning another teardown. shield() prevents caller
@@ -308,9 +314,9 @@ class _AsyncioDatagramReceiverBase:
         deferred_close_waiter: asyncio.Future[None] | None = None
         stop_waiter_completion_deferred = False
         try:
-            if defer_stop_events:
+            if provenance.defers_terminal_events:
                 try:
-                    if active_inline_handler_stop:
+                    if provenance.active_inline_handler:
                         snapshot.cancel_task = False
                     await self._teardown_stop_resources(
                         snapshot=snapshot, socket_cleanup=socket_cleanup
@@ -327,7 +333,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter_completion_deferred = True
                 if first_error is not None:
                     raise first_error
-                if not handler_provenance_stop and stop_waiter is not None:
+                if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
                 try:
@@ -389,7 +395,7 @@ class _AsyncioDatagramReceiverBase:
             if stop_waiter is not None and not stop_waiter.done():
                 if stop_waiter_completion_deferred:
                     pass
-                elif handler_originated_stop and deferred_close_waiter is not None:
+                elif provenance.handler_originated and deferred_close_waiter is not None:
                     self._complete_stop_waiter_after_deferred_close(
                         stop_waiter, deferred_close_waiter
                     )
@@ -402,6 +408,27 @@ class _AsyncioDatagramReceiverBase:
                     if self._runtime.stop_waiter is stop_waiter:
                         self._runtime.stop_waiter = None
                         self._runtime.stop_owner_task = None
+
+    def _capture_stop_provenance(self) -> _DatagramStopProvenance:
+        """Capture handler-origin facts for the current stop caller."""
+        handler_originated = (
+            self._event_dispatcher.current_task_is_dispatching_handler()
+            or self._event_dispatcher.current_task_has_handler_origin_context()
+        )
+        inherited_handler_origin = (
+            self._event_dispatcher.current_task_inherits_handler_origin_context()
+        )
+        active_inline_handler = (
+            not handler_originated
+            and not inherited_handler_origin
+            and self._event_dispatcher.has_active_handler_context()
+            and self._event_dispatcher.current_task_would_deliver_inline()
+        )
+        return _DatagramStopProvenance(
+            handler_originated=handler_originated,
+            inherited_handler_origin=inherited_handler_origin,
+            active_inline_handler=active_inline_handler,
+        )
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -315,24 +315,12 @@ class _AsyncioDatagramReceiverBase:
         stop_waiter_completion_deferred = False
         try:
             if provenance.defers_terminal_events:
-                try:
-                    if provenance.active_inline_handler:
-                        snapshot.cancel_task = False
-                    await self._teardown_stop_resources(
-                        snapshot=snapshot, socket_cleanup=socket_cleanup
-                    )
-                except (Exception, asyncio.CancelledError) as error:
-                    first_error = error
-                if first_error is None:
-                    try:
-                        await self._event_dispatcher.stop_from_handler_origin()
-                    except (Exception, asyncio.CancelledError) as error:
-                        first_error = error
-                if first_error is None:
-                    self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
-                    stop_waiter_completion_deferred = True
-                if first_error is not None:
-                    raise first_error
+                stop_waiter_completion_deferred = await self._prepare_deferred_stop_events(
+                    snapshot=snapshot,
+                    provenance=provenance,
+                    stop_waiter=stop_waiter,
+                    socket_cleanup=socket_cleanup,
+                )
                 if not provenance.has_handler_provenance and stop_waiter is not None:
                     await asyncio.shield(stop_waiter)
             else:
@@ -429,6 +417,32 @@ class _AsyncioDatagramReceiverBase:
             inherited_handler_origin=inherited_handler_origin,
             active_inline_handler=active_inline_handler,
         )
+
+    async def _prepare_deferred_stop_events(
+        self,
+        *,
+        snapshot: _DatagramStopSnapshot,
+        provenance: _DatagramStopProvenance,
+        stop_waiter: asyncio.Future[None] | None,
+        socket_cleanup: SocketCleanup | None,
+    ) -> bool:
+        """Tear down resources and schedule terminal publication after handlers unwind."""
+        first_error: BaseException | None = None
+        try:
+            if provenance.active_inline_handler:
+                snapshot.cancel_task = False
+            await self._teardown_stop_resources(snapshot=snapshot, socket_cleanup=socket_cleanup)
+        except (Exception, asyncio.CancelledError) as error:
+            first_error = error
+        if first_error is None:
+            try:
+                await self._event_dispatcher.stop_from_handler_origin()
+            except (Exception, asyncio.CancelledError) as error:
+                first_error = error
+        if first_error is None:
+            self._complete_stop_waiter_after_deferred_stop_events(stop_waiter, snapshot)
+            return True
+        raise first_error
 
     def _complete_stop_waiter_after_deferred_close(
         self,

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -363,10 +363,7 @@ class _AsyncioDatagramReceiverBase:
                     stop_waiter.set_result(None)
         finally:
             if stop_waiter is not None and not stop_state.stop_waiter_completion_deferred:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
     def _capture_stop_provenance(self) -> _DatagramStopProvenance:
         """Capture handler-origin facts for the current stop caller."""
@@ -465,6 +462,13 @@ class _AsyncioDatagramReceiverBase:
         if first_error is not None:
             raise first_error
 
+    async def _clear_stop_waiter_if_current(self, stop_waiter: asyncio.Future[None] | None) -> None:
+        """Clear the shared stop waiter when the caller still owns it."""
+        async with self._state_lock:
+            if self._runtime.stop_waiter is stop_waiter:
+                self._runtime.stop_waiter = None
+                self._runtime.stop_owner_task = None
+
     def _complete_stop_waiter_after_deferred_close(
         self,
         stop_waiter: asyncio.Future[None],
@@ -484,10 +488,7 @@ class _AsyncioDatagramReceiverBase:
                 if not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -531,10 +532,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 
@@ -588,10 +586,7 @@ class _AsyncioDatagramReceiverBase:
                 if stop_waiter is not None and not stop_waiter.done():
                     stop_waiter.set_result(None)
             finally:
-                async with self._state_lock:
-                    if self._runtime.stop_waiter is stop_waiter:
-                        self._runtime.stop_waiter = None
-                        self._runtime.stop_owner_task = None
+                await self._clear_stop_waiter_if_current(stop_waiter)
 
         _ = asyncio.create_task(_complete())
 


### PR DESCRIPTION
## Summary

Refactors the UDP deferred stop internals introduced by the stacked shutdown-ordering fix without changing public API or transport semantics.

This PR keeps the same terminal publication behavior, but makes the implementation easier to review by naming stop provenance decisions, separating ordinary and deferred stop paths, and centralizing shared stop-waiter cleanup.

## Changes

- Name handler-origin, inherited-provenance, and active-inline-handler stop decisions through a private provenance value object.
- Split deferred stop preparation out of the main datagram stop orchestrator.
- Split the ordinary stop execution path out of the main datagram stop orchestrator.
- Centralize shared stop-waiter cleanup across ordinary and deferred completion paths.


## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
  - Not needed: refactor-only change with existing regression coverage preserved.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed: no user-visible behavior change.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not applicable: no documented contract change.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface changes introduced.

Local verification:

- `python -m pytest -q tests/unit/test_asyncio_udp_transport.py tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py -p no:cacheprovider --timeout=60`
- `python -m pytest -q -m "integration and not multicast and not slow" -p no:cacheprovider --timeout=60`
- `python -m pytest -q -m "not multicast and not slow and not integration and not hypothesis" -p no:cacheprovider --timeout=60`
- `ruff check . --no-cache`
- `ruff format --check . --no-cache`
- `python -m mypy src`