### PR TITLE
fix(udp): abort datagram startup after STARTING stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,5 @@ Planned contents for the initial public alpha release (`0.1.0`).
   active same-connection handler has returned.
 - UDP receivers now preserve deferred stop publication when stop originates
   from a handler or when an external stop caller is cancelled.
+- UDP and multicast receivers now abort startup when a STARTING lifecycle
+  handler stops the receiver, preventing stale socket or running state.

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -888,11 +888,20 @@ class _AsyncioDatagramReceiverBase:
             await self._event_dispatcher.start()
             starting_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
         try:
-            await self._emit_lifecycle_event(starting_event)
+            if starting_event is not None:
+                await self._event_dispatcher.emit_and_wait(
+                    starting_event, drop_on_backpressure=False
+                )
         except (Exception, asyncio.CancelledError):
             await self._rollback_failed_starting_publication()
             raise
-        return True
+        async with self._state_lock:
+            if self._lifecycle_state == ComponentLifecycleState.STARTING:
+                return True
+            stop_waiter = self._runtime.stop_waiter
+        if stop_waiter is not None:
+            await asyncio.shield(stop_waiter)
+        return False
 
     async def _complete_startup(
         self,

--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -45,6 +45,21 @@ class FailOnOpenedHandler:
             raise RuntimeError("boom-on-opened")
 
 
+class StopOnStartingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.receiver: AsyncioMulticastReceiver | None = None
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            self.receiver is not None
+            and isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STARTING
+        ):
+            await self.receiver.stop()
+
+
 class BlockingStoppingHandler:
     def __init__(self) -> None:
         self.events: list[object] = []
@@ -194,6 +209,61 @@ async def test_multicast_opened_handler_failure_rolls_back_runtime_resources() -
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]
     assert not receiver._event_dispatcher.is_running  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_multicast_starting_handler_stop_aborts_startup_without_resources(
+    dispatch_mode: EventDispatchMode,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SocketSetupShouldNotRun:
+        AF_INET = socket.AF_INET
+        SOCK_DGRAM = socket.SOCK_DGRAM
+        IPPROTO_UDP = socket.IPPROTO_UDP
+
+        @staticmethod
+        def socket(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("socket setup should not continue after STARTING stop")
+
+    monkeypatch.setattr(multicast_module, "socket", SocketSetupShouldNotRun)
+
+    handler = StopOnStartingHandler()
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.12",
+            port=20112,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+
+    await receiver.start()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    lifecycle_states = [
+        event.current
+        for event in handler.events
+        if isinstance(event, ComponentLifecycleChangedEvent)
+    ]
+    assert lifecycle_states == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert not any(isinstance(event, ConnectionOpenedEvent) for event in handler.events)
+    assert not any(isinstance(event, ConnectionClosedEvent) for event in handler.events)
+    assert not receiver._running  # type: ignore[attr-defined]
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -35,6 +35,7 @@ from aionetx.api.udp import UdpSenderSettings
 from aionetx.implementations.asyncio_impl import (
     _asyncio_datagram_receiver_base as datagram_base_module,
 )
+from aionetx.implementations.asyncio_impl import asyncio_udp_receiver as udp_receiver_module
 from aionetx.implementations.asyncio_impl import asyncio_udp_sender as udp_sender_module
 from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
@@ -61,6 +62,21 @@ class FailOnLifecycleStateHandler:
     async def on_event(self, event) -> None:
         if isinstance(event, ComponentLifecycleChangedEvent) and event.current == self._state:
             raise RuntimeError(f"udp-{self._state.value}-publication-failed")
+
+
+class StopOnStartingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.receiver: AsyncioUdpReceiver | None = None
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            self.receiver is not None
+            and isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STARTING
+        ):
+            await self.receiver.stop()
 
 
 class BlockingStoppingHandler:
@@ -392,6 +408,61 @@ async def test_udp_receiver_starting_lifecycle_failure_rolls_back_dispatcher() -
         await receiver.start()
 
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    [EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND],
+)
+async def test_udp_receiver_starting_handler_stop_aborts_startup_without_resources(
+    dispatch_mode: EventDispatchMode,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    port = _get_unused_udp_port()
+
+    class SocketSetupShouldNotRun:
+        AF_INET = socket.AF_INET
+        SOCK_DGRAM = socket.SOCK_DGRAM
+        IPPROTO_UDP = socket.IPPROTO_UDP
+
+        @staticmethod
+        def socket(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("socket setup should not continue after STARTING stop")
+
+    monkeypatch.setattr(udp_receiver_module, "socket", SocketSetupShouldNotRun)
+
+    handler = StopOnStartingHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=port,
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        event_handler=handler,
+    )
+    handler.receiver = receiver
+
+    await receiver.start()
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+
+    lifecycle_states = [
+        event.current
+        for event in handler.events
+        if isinstance(event, ComponentLifecycleChangedEvent)
+    ]
+    assert lifecycle_states == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert not any(isinstance(event, ConnectionOpenedEvent) for event in handler.events)
+    assert not any(isinstance(event, ConnectionClosedEvent) for event in handler.events)
+    assert not receiver._running  # type: ignore[attr-defined]
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fixes UDP and multicast receiver startup reentrancy when a `STARTING` lifecycle handler stops the receiver.

Startup now waits for `STARTING` handler completion, rechecks lifecycle state before socket setup, and waits for the handler-origin stop path to reach `STOPPED` before `start()` returns.

## Problems and approach

### 1. STARTING stop could race socket setup

Problem:
A `STARTING` lifecycle handler can call `stop()` before UDP or multicast socket setup should continue. In BACKGROUND delivery, `STARTING` could be queued while startup moved on to socket creation.

Approach:
Datagram startup now publishes `STARTING` through a completion barrier and rechecks lifecycle state before any socket setup continues.

### 2. Aborted startup could return before STOPPED

Problem:
Handler-origin stop defers terminal publication until the active handler unwinds, so `start()` could return while the receiver was still `STOPPING`.

Approach:
When startup observes that `STARTING` was displaced by stop, it waits for the shared stop waiter before returning.

## Changes

- Abort UDP and multicast startup after a `STARTING` handler stops the receiver.
- Prevent socket setup, `RUNNING`, opened events, receive tasks, or running state after that stop wins.
- Add UDP and multicast regression tests for INLINE and BACKGROUND dispatch modes.
- Update `CHANGELOG.md`.

## Related issue

Closes #19

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not needed: this restores the documented lifecycle semantics.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface added.

Local verification:

- `python -m pytest -q tests/unit/test_asyncio_udp_transport.py tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py`
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60`
- `ruff check .`
- `ruff format --check .`
- `python -m mypy src`
- `git diff --check`
