### PR TITLE
chore(repo): normalize GitHub label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a defect in aionetx's runtime, lifecycle, or API behavior.
 title: "[bug] "
-labels: ["bug", "triage"]
+labels: ["type:fix", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Propose a concrete behavior change or new capability for aionetx.
 title: "[feature] "
-labels: ["enhancement", "triage"]
+labels: ["type:feat", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
-      - "python"
+      - "type:build"
+      - "area:dependencies"
     # Group all dev dep bumps into a single PR to reduce noise
     groups:
       dev-dependencies:
@@ -22,8 +22,9 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
-      - "github-actions"
+      - "type:ci"
+      - "area:ci"
+      - "area:dependencies"
     groups:
       action-updates:
         patterns:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,22 @@ A good PR should clearly explain:
 - why it was changed
 - any important side effects or constraints
 
+### Labels
+
+Issues and pull requests use scoped labels to describe different review
+questions:
+
+- use exactly one `type:*` label for the intended change kind, matching the
+  Conventional Commit type when possible
+- use zero or more `area:*` labels for the affected subsystem or project
+  surface
+- use `severity:*` labels for defects, findings, security work, or other
+  risk-bearing changes where priority matters
+
+`type:*` and `area:*` labels may intentionally overlap. For example, a CI
+workflow change can use both `type:ci` (the change kind) and `area:ci` (the
+affected project area).
+
 ## Testing
 
 - add tests for new behavior


### PR DESCRIPTION
﻿## Summary

Normalize repository labeling around scoped `type:*`, `area:*`, and `severity:*` labels.

## Changes

- Update Dependabot labels so dependency and GitHub Actions update PRs use the new scoped taxonomy.
- Update bug and feature issue templates to assign `type:fix` and `type:feat` instead of legacy category labels.
- Document how `type:*`, `area:*`, and `severity:*` labels should be used, including why `type:ci` and `area:ci` may intentionally overlap.

## GitHub label migration

Repository labels have been prepared for the new taxonomy. Legacy labels that are still referenced by `main` remain temporarily available until this PR lands.

## Verification

- `git diff --check`
- Parsed `.github/dependabot.yml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, and `.github/ISSUE_TEMPLATE/feature_request.yml` with PyYAML.
- Verified Dependabot and issue-template label references exist in the repository label set.
- Verified open issues and PRs have exactly one `type:*` label.
