### PR TITLE
fix(tcp): suppress stale startup running event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,5 @@ Planned contents for the initial public alpha release (`0.1.0`).
   from a handler or when an external stop caller is cancelled.
 - UDP and multicast receivers now abort startup when a STARTING lifecycle
   handler stops the receiver, preventing stale socket or running state.
+- TCP clients now suppress stale RUNNING lifecycle publication when a
+  STARTING lifecycle handler stops the client.

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -165,6 +165,7 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
         self._logger.debug("Starting TCP client.")
         starting_event: ComponentLifecycleChangedEvent | None = None
         running_event: ComponentLifecycleChangedEvent | None = None
+        stop_waiter: asyncio.Future[None] | None = None
         async with self._state_lock:
             if self._lifecycle_state in (
                 ComponentLifecycleState.STARTING,
@@ -174,16 +175,31 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                 return
             self._last_connect_error = None
             self._has_started = True
-            # Keep dispatcher startup and the initial lifecycle transitions in one
-            # locked section so stop() cannot observe a half-started client.
+            # Keep dispatcher startup and STARTING in one locked section so
+            # stop() cannot observe a half-started client.
             await self._event_dispatcher.start()
             starting_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
-            self._supervisor_task = asyncio.create_task(
-                self._supervise(), name="tcp-client-supervisor"
-            )
-            running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
         try:
-            await self._emit_lifecycle_event(starting_event)
+            if starting_event is not None:
+                await self._event_dispatcher.emit_and_wait(
+                    starting_event, drop_on_backpressure=False
+                )
+        except (Exception, asyncio.CancelledError):
+            await self._rollback_failed_startup()
+            raise
+        async with self._state_lock:
+            if self._lifecycle_state != ComponentLifecycleState.STARTING:
+                stop_waiter = self._stop_waiter
+            else:
+                self._supervisor_task = asyncio.create_task(
+                    self._supervise(), name="tcp-client-supervisor"
+                )
+                running_event = self._apply_lifecycle_state(ComponentLifecycleState.RUNNING)
+        if stop_waiter is not None:
+            await asyncio.shield(stop_waiter)
+        if running_event is None:
+            return
+        try:
             await self._emit_lifecycle_event(running_event)
         except (Exception, asyncio.CancelledError):
             await self._rollback_failed_startup()

--- a/tests/unit/test_tcp_client_lifecycle_state_machine.py
+++ b/tests/unit/test_tcp_client_lifecycle_state_machine.py
@@ -22,6 +22,7 @@ from aionetx.api.event_delivery_settings import (
 )
 from aionetx.api.tcp_client import TcpClientSettings
 from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpClient
+from tests.helpers import wait_for_condition
 
 pytestmark = pytest.mark.behavior_critical
 
@@ -96,6 +97,54 @@ class _FailOnClientStartingLifecycle:
             and event.current == ComponentLifecycleState.STARTING
         ):
             raise RuntimeError("client-lifecycle-handler-failed")
+
+
+class _StopOnClientStartingLifecycle:
+    def __init__(self) -> None:
+        self.client: AsyncioTcpClient | None = None
+        self.lifecycle_events: list[ComponentLifecycleChangedEvent] = []
+        self._stop_requested = False
+
+    async def on_event(self, event) -> None:
+        if not isinstance(event, ComponentLifecycleChangedEvent):
+            return
+        self.lifecycle_events.append(event)
+        if event.current == ComponentLifecycleState.STARTING and not self._stop_requested:
+            self._stop_requested = True
+            assert self.client is not None
+            await self.client.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dispatch_mode",
+    (EventDispatchMode.INLINE, EventDispatchMode.BACKGROUND),
+)
+async def test_client_starting_handler_stop_suppresses_stale_running_event(
+    dispatch_mode: EventDispatchMode,
+) -> None:
+    handler = _StopOnClientStartingLifecycle()
+    client = AsyncioTcpClient(
+        TcpClientSettings(
+            host="127.0.0.1",
+            port=12345,
+            event_delivery=EventDeliverySettings(dispatch_mode=dispatch_mode),
+        ),
+        handler,
+    )
+    handler.client = client
+
+    await asyncio.wait_for(client.start(), timeout=1.0)
+    await wait_for_condition(lambda: len(handler.lifecycle_events) >= 3)
+
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+    assert client.dispatcher_runtime_stats.queue_depth == 0
+    assert [event.current for event in handler.lifecycle_events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes TCP client startup reentrancy when a `STARTING` lifecycle handler stops the client.

Startup now waits for `STARTING` handler completion, rechecks lifecycle state before committing `RUNNING`, and waits for the stop path to reach `STOPPED` before `start()` returns.

## Problems and approach

### 1. STARTING stop could race RUNNING publication

Problem:
A `STARTING` lifecycle handler can call `stop()` before TCP client startup event publication completes. The previous startup path applied `RUNNING` before publishing the queued lifecycle events, so observers could receive a stale `RUNNING` event after terminal stop publication.

Approach:
TCP client startup now publishes `STARTING` through a completion barrier before creating the supervisor and applying `RUNNING`.

### 2. Aborted startup could return before STOPPED

Problem:
Handler-origin stop defers terminal publication until the active handler unwinds, so `start()` needs to join the shared stop path when startup is displaced during `STARTING`.

Approach:
When startup observes that `STARTING` was displaced by stop, it waits for the shared stop waiter and returns without publishing `RUNNING`.

## Changes

- Suppress stale TCP client `RUNNING` lifecycle publication after a `STARTING` handler stops the client.
- Keep final state, connection attachment, and dispatcher queue state coherent with the stopped lifecycle.
- Add TCP client regression tests for INLINE and BACKGROUND dispatch modes.
- Update `CHANGELOG.md`.

## Related issue

Closes #20

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not needed: this restores the documented lifecycle semantics.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface added.

Local verification:

- `python -m pytest -q tests/unit/test_tcp_client_lifecycle_state_machine.py`
- `python -m pytest -q tests/integration/test_client_reconnect.py --timeout=60`
- `python -m pytest -q tests/integration/test_concurrency_scenarios.py --timeout=60`
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60`
- `ruff check .`
- `ruff format --check .`
- `python -m mypy src`
