### PR TITLE
test(dispatcher): add handler-origin cleanup soak coverage

### DIFF
--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -76,6 +76,16 @@ def _opened(idx: int | str) -> ConnectionOpenedEvent:
     return ConnectionOpenedEvent(resource_id=metadata.connection_id, metadata=metadata)
 
 
+def _assert_handler_origin_tracking_empty(dispatcher: AsyncioEventDispatcher) -> None:
+    """Assert handler-origin bookkeeping does not retain stale active entries."""
+
+    assert dispatcher._active_handler_origin_tokens == set()
+    assert dispatcher._active_handler_origin_resources == {}
+    assert dispatcher._active_handler_origin_owner_tasks == {}
+    assert dispatcher._active_handler_origin_child_provenance_tokens == set()
+    assert dispatcher.has_active_handler_origin() is False
+
+
 async def _wait_until_dispatcher_stopping(dispatcher: AsyncioEventDispatcher) -> None:
     """Yield until stop() has entered the dispatcher stopping state."""
 
@@ -2079,6 +2089,49 @@ async def test_stop_component_callback_does_not_expose_inline_context_to_user_ta
     assert observed_inline_context == [False]
     assert observed_origin_context == [True]
     assert child_emit_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_component_handler_origin_tracking_cleanup_stays_bounded_across_cycles() -> None:
+    cycles = 50
+    stop_calls = 0
+    observed_origin_context: list[bool] = []
+
+    class FailEveryOpenedEvent:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, ConnectionOpenedEvent):
+                raise RuntimeError(f"boom {event.metadata.connection_id}")
+
+    async def stop_component() -> None:
+        nonlocal stop_calls
+        stop_calls += 1
+        observed_origin_context.append(dispatcher.current_task_has_handler_origin_context())
+        await dispatcher.stop()
+
+    dispatcher = AsyncioEventDispatcher(
+        FailEveryOpenedEvent(),
+        EventDeliverySettings(
+            dispatch_mode=EventDispatchMode.BACKGROUND,
+            handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+        ),
+        logging.getLogger("test"),
+        stop_policy=DispatcherStopPolicy.stop_component(stop_component),
+    )
+
+    try:
+        for index in range(cycles):
+            await dispatcher.start()
+            await dispatcher.emit_and_wait(_opened(f"cleanup-{index}"))
+            await wait_for_condition(lambda: dispatcher.is_running is False, timeout_seconds=1.0)
+
+            _assert_handler_origin_tracking_empty(dispatcher)
+    finally:
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(dispatcher.stop(), timeout=1.0)
+
+    assert stop_calls == cycles
+    assert observed_origin_context == [True] * cycles
+    _assert_handler_origin_tracking_empty(dispatcher)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds deterministic regression coverage proving dispatcher handler-origin cleanup does not retain active bookkeeping across repeated stop-policy shutdown cycles.

## Changes

- Add assertions that handler-origin token, resource, owner-task, and child-provenance tracking are empty after handler-origin work unwinds.
- Add a repeated STOP_COMPONENT background-dispatch test that restarts the same dispatcher 50 times and checks cleanup after every cycle.

## Related issue

Closes #39

## Checklist

- [x] All commits include a DCO Signed-off-by line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] CHANGELOG.md [Unreleased] section updated if the change is user-visible.
  - Not needed: test-only regression coverage.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not applicable: no public contract change.
- [x] ruff check . passes locally.
- [x] mypy src passes locally.
- [x] Public API changes are reflected in README.md and docs/architecture.md where appropriate.
  - Not applicable: no public API change.

Local verification:

- python -m pytest -q tests/unit/test_event_dispatcher_contract.py::test_stop_component_handler_origin_tracking_cleanup_stays_bounded_across_cycles --timeout=60
- python -m pytest -q tests/unit/test_event_dispatcher_contract.py --timeout=60
- python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60
- ruff check .
- ruff format --check .
- python -m mypy src
- git diff --check
