### PR TITLE
test(lifecycle): cover shutdown handler failures

### DIFF
--- a/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
+++ b/tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py
@@ -23,6 +23,7 @@ from aionetx.api.event_delivery_settings import (
     EventDispatchMode,
     EventHandlerFailurePolicy,
 )
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
 from aionetx.api.multicast_receiver_settings import MulticastReceiverSettings
 from aionetx.implementations.asyncio_impl import (
     _asyncio_datagram_receiver_base as datagram_base_module,
@@ -74,6 +75,19 @@ class BlockingStoppingHandler:
         ):
             self.stopping_seen.set()
             await self.release_stopping.wait()
+
+
+class RecordAndFailOnStoppingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            raise RuntimeError("multicast-stopping-publication-failed")
 
 
 @pytest.mark.asyncio
@@ -382,6 +396,58 @@ async def test_multicast_receiver_stop_from_starting_state_does_not_emit_closed_
     await receiver.stop()
 
     assert awaitable_recording_event_handler.closed_events == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.multicast
+async def test_multicast_receiver_stop_component_failure_during_stopping_publishes_single_terminal_sequence() -> (
+    None
+):
+    handler = RecordAndFailOnStoppingHandler()
+    receiver = AsyncioMulticastReceiver(
+        settings=MulticastReceiverSettings(
+            group_ip="239.255.0.5",
+            port=20007,
+            bind_ip="0.0.0.0",
+            interface_ip="127.0.0.1",
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=handler,
+    )
+
+    await receiver.start()
+    await asyncio.wait_for(receiver.stop(), timeout=1.0)
+
+    stop_relevant_events = [
+        event
+        for event in handler.events
+        if isinstance(event, (ConnectionClosedEvent, HandlerFailurePolicyStopEvent))
+        or (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
+    ]
+
+    assert [
+        (
+            event.current
+            if isinstance(event, ComponentLifecycleChangedEvent)
+            else type(event).__name__
+        )
+        for event in stop_relevant_events
+    ] == [
+        ComponentLifecycleState.STOPPING,
+        "HandlerFailurePolicyStopEvent",
+        "ConnectionClosedEvent",
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -23,6 +23,7 @@ from aionetx.api.event_delivery_settings import (
     EventHandlerFailurePolicy,
 )
 from aionetx.api.error_policy import ErrorPolicy
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
@@ -1060,6 +1061,19 @@ async def test_client_reconnect_wait_returns_early_when_stop_changes_status(
 
 
 # STOP_COMPONENT ordering when handler failures trigger client shutdown.
+class _RecordAndFailOnClientStopping:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            raise RuntimeError("client-stopping-publication-failed")
+
+
 @pytest.mark.asyncio
 async def test_stop_component_policy_stops_heartbeat_before_connection_close() -> None:
     call_order: list[str] = []
@@ -1195,6 +1209,72 @@ async def test_stop_component_policy_from_worker_with_full_queue_stops_client() 
     assert tcp_client_module.ComponentLifecycleState.STOPPED in lifecycle_states
     assert any(type(event).__name__ == "HandlerFailurePolicyStopEvent" for event in observed_events)
     assert stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_tcp_client_stop_component_failure_during_stopping_publishes_single_terminal_sequence() -> (
+    None
+):
+    release_server_connection = asyncio.Event()
+
+    async def _handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await release_server_connection.wait()
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(_handle_client, "127.0.0.1", 0)
+    async with server:
+        port = server.sockets[0].getsockname()[1]
+        handler = _RecordAndFailOnClientStopping()
+        client = AsyncioTcpClient(
+            settings=TcpClientSettings(
+                host="127.0.0.1",
+                port=port,
+                reconnect=TcpReconnectSettings(enabled=False),
+                event_delivery=EventDeliverySettings(
+                    dispatch_mode=EventDispatchMode.BACKGROUND,
+                    handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+                ),
+            ),
+            event_handler=handler,
+        )
+
+        try:
+            await client.start()
+            await client.wait_until_connected(timeout_seconds=1.0)
+            await asyncio.wait_for(client.stop(), timeout=1.0)
+        finally:
+            release_server_connection.set()
+            await client.stop()
+
+    stop_relevant_events = [
+        event
+        for event in handler.events
+        if isinstance(event, (ConnectionClosedEvent, HandlerFailurePolicyStopEvent))
+        or (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
+    ]
+
+    assert [
+        (
+            event.current
+            if isinstance(event, ComponentLifecycleChangedEvent)
+            else type(event).__name__
+        )
+        for event in stop_relevant_events
+    ] == [
+        ComponentLifecycleState.STOPPING,
+        "HandlerFailurePolicyStopEvent",
+        "ConnectionClosedEvent",
+        ComponentLifecycleState.STOPPED,
+    ]
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client._event_dispatcher.is_running is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -28,6 +28,7 @@ from aionetx.api.event_delivery_settings import (
     EventDispatchMode,
     EventHandlerFailurePolicy,
 )
+from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicyStopEvent
 from aionetx.api.udp import UdpInvalidTargetError
 from aionetx.api.udp import UdpReceiverSettings
 from aionetx.api.udp import UdpSenderStoppedError
@@ -62,6 +63,19 @@ class FailOnLifecycleStateHandler:
     async def on_event(self, event) -> None:
         if isinstance(event, ComponentLifecycleChangedEvent) and event.current == self._state:
             raise RuntimeError(f"udp-{self._state.value}-publication-failed")
+
+
+class RecordAndFailOnStoppingHandler:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+        if (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current == ComponentLifecycleState.STOPPING
+        ):
+            raise RuntimeError("udp-stopping-publication-failed")
 
 
 class StopOnStartingHandler:
@@ -517,6 +531,55 @@ async def test_udp_receiver_stop_lifecycle_failure_still_closes_socket_and_stops
     with pytest.raises(RuntimeError, match="udp-stopping-publication-failed"):
         await receiver.stop()
 
+    assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert receiver._socket is None  # type: ignore[attr-defined]
+    assert receiver._task is None  # type: ignore[attr-defined]
+    assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_stop_component_failure_during_stopping_publishes_single_terminal_sequence() -> (
+    None
+):
+    handler = RecordAndFailOnStoppingHandler()
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(
+            host="127.0.0.1",
+            port=_get_unused_udp_port(),
+            event_delivery=EventDeliverySettings(
+                dispatch_mode=EventDispatchMode.BACKGROUND,
+                handler_failure_policy=EventHandlerFailurePolicy.STOP_COMPONENT,
+            ),
+        ),
+        event_handler=handler,
+    )
+
+    await receiver.start()
+    await asyncio.wait_for(receiver.stop(), timeout=1.0)
+
+    stop_relevant_events = [
+        event
+        for event in handler.events
+        if isinstance(event, (ConnectionClosedEvent, HandlerFailurePolicyStopEvent))
+        or (
+            isinstance(event, ComponentLifecycleChangedEvent)
+            and event.current in (ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED)
+        )
+    ]
+
+    assert [
+        (
+            event.current
+            if isinstance(event, ComponentLifecycleChangedEvent)
+            else type(event).__name__
+        )
+        for event in stop_relevant_events
+    ] == [
+        ComponentLifecycleState.STOPPING,
+        "HandlerFailurePolicyStopEvent",
+        "ConnectionClosedEvent",
+        ComponentLifecycleState.STOPPED,
+    ]
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._socket is None  # type: ignore[attr-defined]
     assert receiver._task is None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Adds focused regression coverage for `STOP_COMPONENT` handler failures while shutdown is already publishing `STOPPING`, so terminal lifecycle ordering stays pinned for the managed transport stop paths.

## Changes

- Add TCP client loopback coverage for a handler failure during `STOPPING`.
- Add UDP receiver coverage for the shared datagram stop path.
- Add multicast receiver smoke coverage for the role-specific datagram path.
- Assert the single terminal sequence: `STOPPING`, `HandlerFailurePolicyStopEvent`, `ConnectionClosedEvent`, `STOPPED`.

## Related issue

Closes #32

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed: test-only regression coverage.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not applicable: no documented public contract change.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API surface change.

Local verification:

- `python -m pytest -q tests/unit/test_asyncio_tcp_client_internals.py::test_tcp_client_stop_component_failure_during_stopping_publishes_single_terminal_sequence tests/unit/test_asyncio_udp_transport.py::test_udp_receiver_stop_component_failure_during_stopping_publishes_single_terminal_sequence tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py::test_multicast_receiver_stop_component_failure_during_stopping_publishes_single_terminal_sequence --timeout=60`
- `python -m pytest -q tests/unit/test_asyncio_tcp_client_internals.py tests/unit/test_asyncio_udp_transport.py tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py --timeout=60`
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60`
- `ruff check .`
- `ruff format --check .`
- `python -m mypy src`
- `git diff --check`
