### PR TITLE
ci(release): fail closed on stale CodeQL signal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
         run: python scripts/ci/check_release_codeql_gate.py
 
   verify_and_build:

--- a/scripts/ci/check_release_codeql_gate.py
+++ b/scripts/ci/check_release_codeql_gate.py
@@ -28,29 +28,121 @@ def _parse_next_link(link_header: str | None) -> str | None:
     return None
 
 
-def _iter_open_alerts(*, repository: str, ref: str, token: str) -> list[dict[str, object]]:
-    encoded_ref = urllib.parse.quote(ref, safe="")
-    url = (
-        f"https://api.github.com/repos/{repository}/code-scanning/alerts"
-        f"?state=open&ref={encoded_ref}&per_page=100"
-    )
-    headers = {
+def _github_api_headers(token: str) -> dict[str, str]:
+    return {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "aionetx-release-codeql-gate",
     }
 
-    alerts: list[dict[str, object]] = []
+
+def _fetch_paginated_list(*, url: str, token: str, response_name: str) -> list[dict[str, object]]:
+    headers = _github_api_headers(token)
+
+    items: list[dict[str, object]] = []
     while url:
         request = urllib.request.Request(url, headers=headers)
         with urllib.request.urlopen(request) as response:
             payload = json.loads(response.read().decode("utf-8"))
             if not isinstance(payload, list):
-                raise RuntimeError("Unexpected code scanning alerts response shape.")
-            alerts.extend(item for item in payload if isinstance(item, dict))
+                raise RuntimeError(f"Unexpected {response_name} response shape.")
+            items.extend(item for item in payload if isinstance(item, dict))
             url = _parse_next_link(response.headers.get("Link"))
-    return alerts
+    return items
+
+
+def _fetch_json_object(*, url: str, token: str, response_name: str) -> dict[str, object]:
+    request = urllib.request.Request(url, headers=_github_api_headers(token))
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Unexpected {response_name} response shape.")
+    return payload
+
+
+def _iter_codeql_analyses(*, repository: str, token: str) -> list[dict[str, object]]:
+    url = f"https://api.github.com/repos/{repository}/code-scanning/analyses?per_page=100"
+    return _fetch_paginated_list(url=url, token=token, response_name="code scanning analyses")
+
+
+def _iter_open_alerts(*, repository: str, ref: str, token: str) -> list[dict[str, object]]:
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    url = (
+        f"https://api.github.com/repos/{repository}/code-scanning/alerts"
+        f"?state=open&ref={encoded_ref}&per_page=100"
+    )
+    return _fetch_paginated_list(url=url, token=token, response_name="code scanning alerts")
+
+
+def _tool_name(analysis: dict[str, object]) -> str:
+    tool = analysis.get("tool")
+    if not isinstance(tool, dict):
+        return ""
+    name = tool.get("name")
+    if not isinstance(name, str):
+        return ""
+    return name
+
+
+def _analysis_ref(analysis: dict[str, object]) -> str:
+    ref = analysis.get("ref")
+    if not isinstance(ref, str):
+        return ""
+    return ref.strip()
+
+
+def _is_branch_ref(ref: str) -> bool:
+    return ref.startswith("refs/heads/")
+
+
+def _git_ref_api_path(ref: str) -> str:
+    if not ref.startswith("refs/"):
+        raise RuntimeError(f"CodeQL analysis returned an unsupported ref: {ref!r}")
+    ref_path = ref.removeprefix("refs/").strip()
+    if not ref_path:
+        raise RuntimeError("CodeQL analysis returned an empty analyzed ref.")
+    return urllib.parse.quote(ref_path, safe="/")
+
+
+def _current_ref_sha(*, repository: str, ref: str, token: str) -> str:
+    ref_path = _git_ref_api_path(ref)
+    url = f"https://api.github.com/repos/{repository}/git/ref/{ref_path}"
+    payload = _fetch_json_object(url=url, token=token, response_name="git ref")
+    object_value = payload.get("object")
+    if not isinstance(object_value, dict):
+        raise RuntimeError(f"Unexpected git ref response shape for {ref}.")
+    sha = object_value.get("sha")
+    if not isinstance(sha, str) or not sha.strip():
+        raise RuntimeError(f"Git ref response for {ref} did not include an object SHA.")
+    return sha.strip()
+
+
+def _is_successful_codeql_analysis_for_commit(
+    analysis: dict[str, object],
+    *,
+    release_sha: str,
+) -> bool:
+    if analysis.get("commit_sha") != release_sha:
+        return False
+    if _tool_name(analysis).casefold() != "codeql":
+        return False
+    ref = _analysis_ref(analysis)
+    if not ref or not _is_branch_ref(ref):
+        return False
+    error = analysis.get("error")
+    return not isinstance(error, str) or not error.strip()
+
+
+def _find_release_codeql_analysis(
+    analyses: list[dict[str, object]],
+    *,
+    release_sha: str,
+) -> dict[str, object] | None:
+    for analysis in analyses:
+        if _is_successful_codeql_analysis_for_commit(analysis, release_sha=release_sha):
+            return analysis
+    return None
 
 
 def _severity_rank(severity: str) -> int:
@@ -59,10 +151,40 @@ def _severity_rank(severity: str) -> int:
 
 def main() -> int:
     repository = _require_env("GITHUB_REPOSITORY")
-    ref = _require_env("GITHUB_REF")
+    release_ref = _require_env("GITHUB_REF")
+    release_sha = _require_env("GITHUB_SHA")
     token = _require_env("GITHUB_TOKEN")
 
-    open_alerts = _iter_open_alerts(repository=repository, ref=ref, token=token)
+    analyses = _iter_codeql_analyses(repository=repository, token=token)
+    release_analysis = _find_release_codeql_analysis(analyses, release_sha=release_sha)
+    if release_analysis is None:
+        print(
+            f"No successful CodeQL analysis was found for release commit {release_sha}. "
+            f"Failing closed for {release_ref}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    analyzed_ref = _analysis_ref(release_analysis)
+    try:
+        current_ref_sha = _current_ref_sha(
+            repository=repository,
+            ref=analyzed_ref,
+            token=token,
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if current_ref_sha != release_sha:
+        print(
+            f"Analyzed CodeQL ref {analyzed_ref} does not currently point at release "
+            f"commit {release_sha} (current SHA: {current_ref_sha}). "
+            f"Failing closed for {release_ref}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    open_alerts = _iter_open_alerts(repository=repository, ref=analyzed_ref, token=token)
     blocking_alerts = []
     for alert in open_alerts:
         rule = alert.get("rule")
@@ -74,9 +196,13 @@ def main() -> int:
         if _severity_rank(severity) >= _severity_rank("high"):
             blocking_alerts.append(alert)
 
-    print(f"CodeQL release gate inspected {len(open_alerts)} open alert(s) for {ref}.")
+    print(
+        f"CodeQL release gate inspected {len(open_alerts)} open alert(s) "
+        f"for analyzed ref {analyzed_ref} at release commit {release_sha} "
+        f"(release ref {release_ref})."
+    )
     if not blocking_alerts:
-        print("No open high/critical CodeQL alerts block this release ref.")
+        print("No open high/critical CodeQL alerts block this release commit.")
         return 0
 
     print(

--- a/tests/unit/test_release_codeql_gate_script.py
+++ b/tests/unit/test_release_codeql_gate_script.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import runpy
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "ci" / "check_release_codeql_gate.py"
+SCRIPT_GLOBALS = runpy.run_path(str(SCRIPT_PATH))
+
+main = SCRIPT_GLOBALS["main"]
+
+
+class FakeResponse:
+    def __init__(self, payload: object, link: str | None = None) -> None:
+        self._payload = payload
+        self.headers = {"Link": link} if link else {}
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _set_release_env(monkeypatch: pytest.MonkeyPatch, *, sha: str = "release-sha") -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "MarcusKorinth/aionetx")
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v1.2.3")
+    monkeypatch.setenv("GITHUB_SHA", sha)
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+
+def test_tag_release_fails_closed_without_codeql_analysis_for_release_sha(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch, sha="release-sha")
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        if "/code-scanning/analyses" in request.full_url:
+            return FakeResponse(
+                [
+                    {
+                        "commit_sha": "different-sha",
+                        "ref": "refs/heads/main",
+                        "tool": {"name": "CodeQL"},
+                        "error": "",
+                    }
+                ]
+            )
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "No successful CodeQL analysis was found for release commit release-sha" in (
+        captured.err
+    )
+
+
+def test_tag_release_fails_closed_when_only_codeql_analysis_uses_tag_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch, sha="release-sha")
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        if "/code-scanning/analyses" in request.full_url:
+            return FakeResponse(
+                [
+                    {
+                        "commit_sha": "release-sha",
+                        "ref": "refs/tags/v1.2.3",
+                        "tool": {"name": "CodeQL"},
+                        "error": "",
+                    }
+                ]
+            )
+        if "/git/ref/tags/v1.2.3" in request.full_url:
+            return FakeResponse({"object": {"sha": "release-sha", "type": "commit"}})
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "No successful CodeQL analysis was found for release commit release-sha" in (
+        captured.err
+    )
+
+
+def test_tag_release_queries_alerts_for_analyzed_release_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_release_env(monkeypatch, sha="release-sha")
+    requested_urls: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        requested_urls.append(request.full_url)
+        if "/code-scanning/analyses" in request.full_url:
+            return FakeResponse(
+                [
+                    {
+                        "commit_sha": "release-sha",
+                        "ref": "refs/heads/main",
+                        "tool": {"name": "CodeQL"},
+                        "error": "",
+                    }
+                ]
+            )
+        if "/git/ref/heads/main" in request.full_url:
+            return FakeResponse({"object": {"sha": "release-sha", "type": "commit"}})
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 0
+
+    alert_urls = [url for url in requested_urls if "/code-scanning/alerts" in url]
+    assert alert_urls == [
+        "https://api.github.com/repos/MarcusKorinth/aionetx/"
+        "code-scanning/alerts?state=open&ref=refs%2Fheads%2Fmain&per_page=100"
+    ]
+
+
+def test_tag_release_fails_closed_when_analyzed_ref_moved(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch, sha="release-sha")
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        if "/code-scanning/analyses" in request.full_url:
+            return FakeResponse(
+                [
+                    {
+                        "commit_sha": "release-sha",
+                        "ref": "refs/heads/main",
+                        "tool": {"name": "CodeQL"},
+                        "error": "",
+                    }
+                ]
+            )
+        if "/git/ref/heads/main" in request.full_url:
+            return FakeResponse({"object": {"sha": "newer-sha", "type": "commit"}})
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "does not currently point at release commit release-sha" in captured.err
+
+
+def test_tag_release_blocks_high_or_critical_alerts_for_current_analyzed_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch, sha="release-sha")
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        if "/code-scanning/analyses" in request.full_url:
+            return FakeResponse(
+                [
+                    {
+                        "commit_sha": "release-sha",
+                        "ref": "refs/heads/main",
+                        "tool": {"name": "CodeQL"},
+                        "error": "",
+                    }
+                ]
+            )
+        if "/git/ref/heads/main" in request.full_url:
+            return FakeResponse({"object": {"sha": "release-sha", "type": "commit"}})
+        return FakeResponse(
+            [
+                {
+                    "number": 7,
+                    "html_url": "https://github.com/MarcusKorinth/aionetx/security/code-scanning/7",
+                    "rule": {
+                        "id": "py/example",
+                        "security_severity_level": "high",
+                    },
+                }
+            ]
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "Found 1 blocking CodeQL alert(s)" in captured.err


### PR DESCRIPTION
## Summary

Make the release CodeQL gate fail closed unless it can prove the release commit has a current branch-based CodeQL analysis signal before checking open alerts.

## Changes

- Pass `GITHUB_SHA` into the release CodeQL gate.
- Query CodeQL analyses for a successful branch analysis matching the release commit SHA.
- Verify the analyzed branch ref still points at the release commit before querying open alerts for that ref.
- Keep the existing high/critical alert threshold behavior.
- Add script tests for missing analysis, tag-only analysis, stale branch refs, analyzed branch alert queries, and high-severity blocking.

## Related issue

Closes #33

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not applicable: release CI hardening only.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR. Not applicable: no public runtime/API contract changed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. Not applicable: no public API change.

Local verification:

- `python -m pytest -q tests/unit/test_release_codeql_gate_script.py` -> 5 passed
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 571 passed, 1 skipped, 73 deselected
- `ruff check .` -> passed
- `ruff format --check .` -> passed
- `python -m mypy src` -> passed
