### PR TITLE
fix(tcp): preserve deferred stop after caller cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Planned contents for the initial public alpha release (`0.1.0`).
   preserving per-connection event ordering across dispatch modes.
 - TCP close and stop paths now defer handler-origin terminal events until the
   active same-connection handler has returned.
+- TCP client/server stop paths and connection close paths now preserve deferred
+  terminal publication when an external caller is cancelled while an inline
+  bytes handler is still active.
 - UDP receivers now preserve deferred stop publication when stop originates
   from a handler or when an external stop caller is cancelled.
 - UDP and multicast receivers now abort startup when a STARTING lifecycle

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -49,6 +49,7 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     ReconnectBackoff,
     assert_running_on_owner_loop,
+    await_future_completion_preserving_cancellation,
     await_task_completion_preserving_cancellation,
     validate_heartbeat_provider,
 )
@@ -98,6 +99,7 @@ class _TcpClientStopExecutionState:
 
     deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
     stop_waiter_completion_deferred: bool = False
+    raise_cancel_after_stop_waiter: bool = False
 
 
 class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
@@ -269,7 +271,9 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                 and plan.stop_waiter is not None
                 and not plan.stop_waiter.done()
             ):
-                await asyncio.shield(plan.stop_waiter)
+                await await_future_completion_preserving_cancellation(plan.stop_waiter)
+            if stop_state.raise_cancel_after_stop_waiter:
+                raise asyncio.CancelledError
         except (Exception, asyncio.CancelledError) as error:
             if plan.stop_waiter is not None and not plan.stop_waiter.done():
                 plan.stop_waiter.set_exception(error)
@@ -473,12 +477,20 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
             # A cancelled supervisor wait must not skip local resource cleanup.
             # Preserve the first error, finish teardown, then re-raise below.
             await self._stop_heartbeat_sender()
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        try:
             state.deferred_close_waiters = await self._close_current_connection()
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        try:
             if plan.cancel_supervisor_after_local_cleanup and plan.supervisor_task is not None:
                 plan.supervisor_task.cancel()
         except (Exception, asyncio.CancelledError) as error:
             if first_error is None:
-                return error
+                first_error = error
         return first_error
 
     async def _finish_stop_with_dispatcher(
@@ -497,6 +509,9 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     await self._event_dispatcher.stop_from_handler_origin()
                 except (Exception, asyncio.CancelledError) as error:
                     first_error = error
+            if provenance.active_inline_handler and isinstance(first_error, asyncio.CancelledError):
+                state.raise_cancel_after_stop_waiter = True
+                first_error = None
             if first_error is None:
                 self._schedule_deferred_stop_events(
                     plan=plan,
@@ -504,6 +519,7 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
                     stopped_event=stopped_event,
                     stop_dispatcher=True,
                 )
+                return None
             return first_error
 
         if first_error is None:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -24,6 +24,10 @@ from aionetx.implementations.asyncio_impl._tcp_connection_helpers import (
 )
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.runtime_utils import WarningRateLimiter
+from aionetx.implementations.asyncio_impl.runtime_utils import (
+    await_future_completion_preserving_cancellation,
+    await_task_completion_preserving_cancellation,
+)
 
 ConnectionClosedCallback = Callable[["AsyncioTcpConnection"], Awaitable[None] | None]
 ConnectionReadyCallback = Callable[["AsyncioTcpConnection"], Awaitable[None] | None]
@@ -290,6 +294,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
             self._connection_id
         )
         cancellation_requested = False
+        deferred_waiter: asyncio.Future[None] | None = None
         try:
             await asyncio.shield(close_task)
             deferred_waiter = self._pending_deferred_close_waiter()
@@ -303,7 +308,21 @@ class AsyncioTcpConnection(ConnectionProtocol):
             if close_task.done() and close_task.cancelled():
                 raise
             cancellation_requested = True
-            _ = await cast(Awaitable[object], close_task)
+            try:
+                await await_task_completion_preserving_cancellation(
+                    cast(asyncio.Task[object], close_task)
+                )
+            except asyncio.CancelledError:
+                if close_task.done() and close_task.cancelled():
+                    raise
+            if deferred_waiter is None and not handler_origin_caller:
+                deferred_waiter = self._pending_deferred_close_waiter()
+            if deferred_waiter is not None and not handler_origin_caller:
+                try:
+                    await await_future_completion_preserving_cancellation(deferred_waiter)
+                except asyncio.CancelledError:
+                    if deferred_waiter.done() and deferred_waiter.cancelled():
+                        raise
         if cancellation_requested:
             raise asyncio.CancelledError
 

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -50,6 +50,7 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
 )
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     assert_running_on_owner_loop,
+    await_future_completion_preserving_cancellation,
     configure_listener_bind_socket,
     validate_heartbeat_provider,
 )
@@ -95,6 +96,7 @@ class _TcpServerStopExecutionState:
     deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
     stop_waiter_completion_deferred: bool = False
     dispatcher_stopped_from_handler_origin: bool = False
+    raise_cancel_after_stop_waiter: bool = False
 
 
 class AsyncioTcpServer(TcpServerProtocol):
@@ -260,7 +262,9 @@ class AsyncioTcpServer(TcpServerProtocol):
                 and plan.stop_waiter is not None
                 and not plan.stop_waiter.done()
             ):
-                await asyncio.shield(plan.stop_waiter)
+                await await_future_completion_preserving_cancellation(plan.stop_waiter)
+            if stop_state.raise_cancel_after_stop_waiter:
+                raise asyncio.CancelledError
             self._notify_status_changed()
             self._logger.debug("TCP server stopped.")
         except (Exception, asyncio.CancelledError) as error:
@@ -420,23 +424,35 @@ class AsyncioTcpServer(TcpServerProtocol):
         try:
             if plan.server is not None:
                 plan.server.close()
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        try:
             await stop_server_heartbeat_senders(
                 senders=plan.heartbeat_senders,
                 event_dispatcher=self._event_dispatcher,
                 logger=self._logger,
                 component_id=self._component_id,
             )
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        try:
             if plan.connections:
                 await self._close_stop_plan_connections(
                     plan=plan,
                     provenance=provenance,
                     state=state,
                 )
+        except (Exception, asyncio.CancelledError) as error:
+            if first_error is None:
+                first_error = error
+        try:
             if plan.server is not None:
                 await plan.server.wait_closed()
         except (Exception, asyncio.CancelledError) as error:
             if first_error is None:
-                return error
+                first_error = error
         return first_error
 
     async def _close_stop_plan_connections(
@@ -488,12 +504,16 @@ class AsyncioTcpServer(TcpServerProtocol):
     ) -> BaseException | None:
         """Publish terminal stop events and stop the dispatcher when required."""
         if provenance.defers_terminal_events:
+            if provenance.active_inline_handler and isinstance(first_error, asyncio.CancelledError):
+                state.raise_cancel_after_stop_waiter = True
+                first_error = None
             if first_error is None:
                 self._schedule_deferred_stop_events(
                     plan=plan,
                     state=state,
                     stopped_event=stopped_event,
                 )
+                return None
             return first_error
 
         if first_error is None:

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -200,10 +200,9 @@ async def await_future_completion_preserving_cancellation(
                     break
                 continue
             raise
-    result = future.result()
+    future.result()
     if caller_cancelled:
         raise asyncio.CancelledError
-    del result
 
 
 def is_task_being_cancelled(task: asyncio.Task[object] | None = None) -> bool:

--- a/src/aionetx/implementations/asyncio_impl/runtime_utils.py
+++ b/src/aionetx/implementations/asyncio_impl/runtime_utils.py
@@ -14,6 +14,7 @@ import random
 import socket
 import sys
 import time
+from typing import Any
 
 from aionetx.api.heartbeat import TcpHeartbeatSettings
 from aionetx.api.errors import HeartbeatConfigurationError
@@ -173,6 +174,36 @@ async def await_task_completion_preserving_cancellation(task: asyncio.Task[objec
             break
     if caller_cancelled:
         raise asyncio.CancelledError
+
+
+async def await_future_completion_preserving_cancellation(
+    future: asyncio.Future[Any],
+) -> None:
+    """
+    Await a shared future without letting caller cancellation cancel or poison it.
+
+    This mirrors ``await_task_completion_preserving_cancellation`` for shared
+    coordination futures. The caller observes cancellation only after the
+    shielded future settles, while other waiters continue to observe the
+    future's own result or exception.
+    """
+    caller_cancelled = False
+    while True:
+        try:
+            await asyncio.shield(future)
+            break
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                caller_cancelled = True
+                if future.done():
+                    break
+                continue
+            raise
+    result = future.result()
+    if caller_cancelled:
+        raise asyncio.CancelledError
+    del result
 
 
 def is_task_being_cancelled(task: asyncio.Task[object] | None = None) -> bool:

--- a/tests/integration/test_concurrency_scenarios.py
+++ b/tests/integration/test_concurrency_scenarios.py
@@ -36,7 +36,7 @@ from aionetx.implementations.asyncio_impl.asyncio_tcp_client import AsyncioTcpCl
 from aionetx.implementations.asyncio_impl.asyncio_tcp_server import AsyncioTcpServer
 from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import AsyncioUdpReceiver
 from aionetx.implementations.asyncio_impl.asyncio_udp_sender import AsyncioUdpSender
-from tests.helpers import wait_for_condition
+from tests.helpers import assert_awaitable_cancelled, wait_for_condition
 
 
 def _unused_port(kind: socket.SocketKind = socket.SOCK_STREAM) -> int:
@@ -1480,6 +1480,141 @@ async def test_external_inline_client_stop_waits_for_active_bytes_handler() -> N
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_cancelled_external_inline_client_stop_finishes_after_active_bytes_handler() -> None:
+    port = _unused_port()
+
+    class _BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_lifecycle_started = asyncio.Event()
+            self.release_terminal_lifecycle = asyncio.Event()
+            self.terminal_lifecycle_states: list[ComponentLifecycleState] = []
+            self.closed_events: list[ConnectionClosedEvent] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("close event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_events.append(event)
+                return
+            if isinstance(event, ComponentLifecycleChangedEvent) and event.current in (
+                ComponentLifecycleState.STOPPING,
+                ComponentLifecycleState.STOPPED,
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal lifecycle re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_lifecycle_states.append(event.current)
+                if event.current == ComponentLifecycleState.STOPPING:
+                    self.terminal_lifecycle_started.set()
+                    await self.release_terminal_lifecycle.wait()
+
+    handler = _BlockingBytesHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(host="127.0.0.1", port=port, max_connections=64),
+        event_handler=_NoopHandler(),
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    stop_task: asyncio.Task[None] | None = None
+    joining_stop_task: asyncio.Task[None] | None = None
+    await server.start()
+    try:
+        await client.start()
+        await client.wait_until_connected(timeout_seconds=3.0)
+        await server.broadcast(b"cancelled-external-client-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=3.0)
+
+        stop_task = asyncio.create_task(client.stop())
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=3.0,
+        )
+
+        joining_stop_task = asyncio.create_task(client.stop())
+        await asyncio.sleep(0)
+        assert joining_stop_task.done() is False
+
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+        assert not handler.bytes_finished.is_set()
+        assert handler.terminal_lifecycle_states == []
+        assert handler.closed_events == []
+
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+        assert not handler.bytes_finished.is_set()
+        assert handler.terminal_lifecycle_states == []
+        assert handler.closed_events == []
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.terminal_lifecycle_started.wait(), timeout=3.0)
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+
+        handler.release_terminal_lifecycle.set()
+        await assert_awaitable_cancelled(stop_task)
+        await asyncio.wait_for(joining_stop_task, timeout=3.0)
+        await wait_for_condition(
+            lambda: client.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await wait_for_condition(
+            lambda: (
+                handler.terminal_lifecycle_states
+                == [ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED]
+                and len(handler.closed_events) == 1
+            ),
+            timeout_seconds=3.0,
+        )
+    finally:
+        handler.release_bytes.set()
+        handler.release_terminal_lifecycle.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        if joining_stop_task is not None and not joining_stop_task.done():
+            joining_stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(joining_stop_task, timeout=1.0)
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None
+    assert handler.bytes_finished.is_set()
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+    assert client._stop_waiter is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_external_inline_server_stop_waits_for_active_bytes_handler() -> None:
     port = _unused_port()
 
@@ -1556,3 +1691,142 @@ async def test_external_inline_server_stop_waits_for_active_bytes_handler() -> N
         await server.stop()
 
     assert handler.error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_cancelled_external_inline_server_stop_finishes_after_active_bytes_handler() -> None:
+    port = _unused_port()
+
+    class _BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.terminal_lifecycle_started = asyncio.Event()
+            self.release_terminal_lifecycle = asyncio.Event()
+            self.terminal_lifecycle_states: list[ComponentLifecycleState] = []
+            self.closed_events: list[ConnectionClosedEvent] = []
+            self.error: BaseException | None = None
+
+        async def on_event(self, event: NetworkEvent) -> None:
+            if isinstance(event, BytesReceivedEvent):
+                self.bytes_started.set()
+                await self.release_bytes.wait()
+                self.bytes_finished.set()
+                return
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("close event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_events.append(event)
+                return
+            if isinstance(event, ComponentLifecycleChangedEvent) and event.current in (
+                ComponentLifecycleState.STOPPING,
+                ComponentLifecycleState.STOPPED,
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("terminal lifecycle re-entered bytes handler")
+                    self.release_bytes.set()
+                self.terminal_lifecycle_states.append(event.current)
+                if event.current == ComponentLifecycleState.STOPPING:
+                    self.terminal_lifecycle_started.set()
+                    await self.release_terminal_lifecycle.wait()
+
+    handler = _BlockingBytesHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=port,
+            reconnect=TcpReconnectSettings(enabled=False),
+        ),
+        event_handler=_NoopHandler(),
+    )
+    stop_task: asyncio.Task[None] | None = None
+    joining_stop_task: asyncio.Task[None] | None = None
+    await server.start()
+    try:
+        await client.start()
+        connection = await client.wait_until_connected(timeout_seconds=3.0)
+        await connection.send(b"cancelled-external-server-stop")
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=3.0)
+
+        stop_task = asyncio.create_task(server.stop())
+        await wait_for_condition(
+            lambda: server.lifecycle_state == ComponentLifecycleState.STOPPING,
+            timeout_seconds=3.0,
+        )
+
+        joining_stop_task = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+        assert joining_stop_task.done() is False
+
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+        assert not handler.bytes_finished.is_set()
+        assert handler.terminal_lifecycle_states == []
+        assert handler.closed_events == []
+
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+        assert not handler.bytes_finished.is_set()
+        assert handler.terminal_lifecycle_states == []
+        assert handler.closed_events == []
+
+        handler.release_bytes.set()
+        await asyncio.wait_for(handler.terminal_lifecycle_started.wait(), timeout=3.0)
+        stop_task.cancel()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert joining_stop_task.done() is False
+
+        handler.release_terminal_lifecycle.set()
+        await assert_awaitable_cancelled(stop_task)
+        await asyncio.wait_for(joining_stop_task, timeout=3.0)
+        await wait_for_condition(
+            lambda: server.lifecycle_state == ComponentLifecycleState.STOPPED,
+            timeout_seconds=3.0,
+        )
+        await wait_for_condition(
+            lambda: (
+                handler.terminal_lifecycle_states
+                == [ComponentLifecycleState.STOPPING, ComponentLifecycleState.STOPPED]
+                and len(handler.closed_events) == 1
+            ),
+            timeout_seconds=3.0,
+        )
+    finally:
+        handler.release_bytes.set()
+        handler.release_terminal_lifecycle.set()
+        if stop_task is not None and not stop_task.done():
+            stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(stop_task, timeout=1.0)
+        if joining_stop_task is not None and not joining_stop_task.done():
+            joining_stop_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(joining_stop_task, timeout=1.0)
+        await client.stop()
+        await server.stop()
+
+    assert handler.error is None
+    assert handler.bytes_finished.is_set()
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server.connections == ()
+    assert server._stop_waiter is None

--- a/tests/internal_asyncio_impl_refs.py
+++ b/tests/internal_asyncio_impl_refs.py
@@ -21,6 +21,7 @@ from aionetx.implementations.asyncio_impl.lifecycle_internal import (
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     ReconnectBackoff,
     WarningRateLimiter,
+    await_future_completion_preserving_cancellation,
     await_task_completion_preserving_cancellation,
     validate_heartbeat_provider,
 )
@@ -32,6 +33,7 @@ __all__ = (
     "apply_stopped_transition_if_stopping",
     "apply_stopping_transition_if_active",
     "assert_legal_lifecycle_transition",
+    "await_future_completion_preserving_cancellation",
     "await_task_completion_preserving_cancellation",
     "multicast_receiver_component_id",
     "tcp_client_component_id",

--- a/tests/unit/test_asyncio_tcp_client_internals.py
+++ b/tests/unit/test_asyncio_tcp_client_internals.py
@@ -477,6 +477,114 @@ async def test_client_stop_preserves_caller_cancellation_after_supervisor_cleanu
 
 
 @pytest.mark.asyncio
+async def test_client_cancelled_active_inline_stop_still_closes_connection_after_heartbeat() -> (
+    None
+):
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.stopped_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current == ComponentLifecycleState.STOPPED
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("STOPPED event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.stopped_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            await self.release_bytes.wait()
+            self.bytes_finished.set()
+
+    handler = BlockingBytesHandler()
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=45681,
+            reconnect=TcpReconnectSettings(enabled=False),
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    writer = _BlockingDrainWriter()
+    connection = AsyncioTcpConnection(
+        "tcp/client/127.0.0.1/45681/connection",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        client._event_dispatcher,  # type: ignore[attr-defined]
+        receive_buffer_size=4096,
+    )
+    connection._state = ConnectionState.CONNECTED  # type: ignore[attr-defined]
+    heartbeat_stop_started = asyncio.Event()
+    heartbeat_stop_cancelled = asyncio.Event()
+
+    async def fake_stop_heartbeat() -> None:
+        heartbeat_stop_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            heartbeat_stop_cancelled.set()
+            raise
+
+    client._running = True  # type: ignore[attr-defined]
+    client._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    client._connection = connection  # type: ignore[attr-defined]
+    client._connection_closed_event.clear()  # type: ignore[attr-defined]
+    client._stop_heartbeat_sender = fake_stop_heartbeat  # type: ignore[attr-defined,method-assign]
+    await client._event_dispatcher.start()  # type: ignore[attr-defined]
+
+    emit_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        emit_task = asyncio.create_task(
+            client._event_dispatcher.emit(  # type: ignore[attr-defined]
+                BytesReceivedEvent(resource_id=connection.connection_id, data=b"hold")
+            )
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(client.stop())
+        await asyncio.wait_for(heartbeat_stop_started.wait(), timeout=1.0)
+        stop_task.cancel()
+        await asyncio.wait_for(heartbeat_stop_cancelled.wait(), timeout=1.0)
+        await wait_for_condition(lambda: writer.closed, timeout_seconds=1.0)
+
+        assert stop_task.done() is False
+        assert handler.stopped_seen.is_set() is False
+
+        handler.release_bytes.set()
+        await assert_awaitable_cancelled(stop_task)
+        await asyncio.wait_for(handler.stopped_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        for task in (emit_task, stop_task):
+            if task is not None and not task.done():
+                task.cancel()
+                await drain_awaitable_ignoring_cancelled(task)
+        if connection.state != ConnectionState.CLOSED:
+            await connection.close()
+        if client._event_dispatcher.is_running:  # type: ignore[attr-defined]
+            await client._event_dispatcher.stop()  # type: ignore[attr-defined]
+
+    assert handler.error is None
+    assert connection.state == ConnectionState.CLOSED
+    assert writer.closed
+    assert client._connection is None  # type: ignore[attr-defined]
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
 async def test_client_concurrent_stop_waits_for_owner_without_duplicate_cleanup(
     recording_event_handler,
 ) -> None:

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -31,6 +31,7 @@ from aionetx.api.event_delivery_settings import (
 )
 from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
+from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import wait_for_condition
 
 
@@ -1321,6 +1322,198 @@ async def test_tcp_connection_external_close_joiner_waits_for_deferred_close_eve
         await dispatcher.stop()
 
     assert handler.error is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_cancelled_external_close_joiner_waits_for_deferred_close_event() -> (
+    None
+):
+    class ReentrantCloseWithCancelledJoinerHandler:
+        def __init__(self) -> None:
+            self.connection: AsyncioTcpConnection | None = None
+            self.bytes_started = asyncio.Event()
+            self.handler_close_returned = asyncio.Event()
+            self.callback_started = asyncio.Event()
+            self.release_callback = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.handler_close_task: asyncio.Task[None] | None = None
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.release_bytes.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if self.connection is None or not isinstance(event, BytesReceivedEvent):
+                return
+
+            self.bytes_started.set()
+            try:
+                self.handler_close_task = asyncio.create_task(self.connection.close())
+                await self.handler_close_task
+                self.handler_close_returned.set()
+                await self.release_bytes.wait()
+            except (Exception, asyncio.CancelledError) as error:
+                self.error = error
+                self.release_callback.set()
+                self.release_bytes.set()
+
+    handler = ReentrantCloseWithCancelledJoinerHandler()
+
+    async def on_closed(_connection: AsyncioTcpConnection) -> None:
+        handler.callback_started.set()
+        await handler.release_callback.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:inline-close-cancelled-joiner",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+        on_closed_callback=on_closed,
+    )
+    handler.connection = connection
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    external_close_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"first"))
+        )
+        await asyncio.wait_for(handler.callback_started.wait(), timeout=1.0)
+
+        external_close_task = asyncio.create_task(connection.close())
+        await asyncio.sleep(0)
+        assert external_close_task.done() is False
+
+        handler.release_callback.set()
+        await asyncio.wait_for(handler.handler_close_returned.wait(), timeout=1.0)
+        assert handler.closed_seen.is_set() is False
+        assert external_close_task.done() is False
+
+        external_close_task.cancel()
+        await asyncio.sleep(0)
+        external_close_task.cancel()
+        await asyncio.sleep(0)
+
+        assert external_close_task.done() is False
+        assert handler.closed_seen.is_set() is False
+
+        handler.release_bytes.set()
+        await assert_awaitable_cancelled(external_close_task)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_callback.set()
+        handler.release_bytes.set()
+        for task in (emit_task, handler.handler_close_task, external_close_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_repeated_external_close_cancellation_preserves_deferred_close() -> (
+    None
+):
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.closed_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if isinstance(event, ConnectionClosedEvent):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("closed event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.closed_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            await self.release_bytes.wait()
+            self.bytes_finished.set()
+
+    handler = BlockingBytesHandler()
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=handler,
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    writer = _DummyWriter()
+    connection = AsyncioTcpConnection(
+        "client:repeated-external-close-cancel",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        writer,  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    external_close_task: asyncio.Task[None] | None = None
+    try:
+        await connection.start()
+        emit_task = asyncio.create_task(
+            dispatcher.emit(BytesReceivedEvent(resource_id=connection.connection_id, data=b"first"))
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        external_close_task = asyncio.create_task(connection.close())
+        await asyncio.wait_for(writer.closed_event.wait(), timeout=1.0)
+        assert external_close_task.done() is False
+        assert handler.closed_seen.is_set() is False
+
+        external_close_task.cancel()
+        await asyncio.sleep(0)
+        external_close_task.cancel()
+        await asyncio.sleep(0)
+
+        assert external_close_task.done() is False
+        assert handler.closed_seen.is_set() is False
+
+        handler.release_bytes.set()
+        await assert_awaitable_cancelled(external_close_task)
+        await asyncio.wait_for(handler.closed_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        for task in (emit_task, external_close_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        if connection.state != ConnectionState.CLOSED:
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await connection.close()
+        await dispatcher.stop()
+
+    assert handler.error is None
+    assert connection.state == ConnectionState.CLOSED
+    assert writer.closed
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -218,6 +218,25 @@ class _TeardownSender:
             raise RuntimeError(f"stop-failed:{self.connection_id}")
 
 
+class _CancellingTeardownSender:
+    """Heartbeat-sender double that surfaces caller cancellation during stop."""
+
+    def __init__(self, connection_id: str) -> None:
+        self.connection_id = connection_id
+        self.stop_started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.stop_attempts = 0
+
+    async def stop(self) -> None:
+        self.stop_attempts += 1
+        self.stop_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
 # Broadcast semantics and heartbeat preconditions.
 @pytest.mark.asyncio
 async def test_server_broadcast_continues_when_one_connection_send_fails(
@@ -711,6 +730,109 @@ async def test_server_cancelled_overlapping_stop_does_not_cancel_owner_waiter(
             await drain_awaitable_ignoring_cancelled(first_stop)
 
     assert blocking.close_attempts == 1
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_server_cancelled_active_inline_stop_still_closes_connections_after_heartbeat() -> (
+    None
+):
+    class BlockingBytesHandler:
+        def __init__(self) -> None:
+            self.bytes_started = asyncio.Event()
+            self.release_bytes = asyncio.Event()
+            self.bytes_finished = asyncio.Event()
+            self.stopped_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if (
+                isinstance(event, ComponentLifecycleChangedEvent)
+                and event.current == ComponentLifecycleState.STOPPED
+            ):
+                if not self.bytes_finished.is_set():
+                    self.error = AssertionError("STOPPED event re-entered bytes handler")
+                    self.release_bytes.set()
+                self.stopped_seen.set()
+                return
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_started.set()
+            await self.release_bytes.wait()
+            self.bytes_finished.set()
+
+    handler = BlockingBytesHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12349,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        ),
+        event_handler=handler,
+    )
+    origin_connection = _BlockingCloseConnection("server:cancelled-stop:origin")
+    sibling_connection = _BlockingCloseConnection("server:cancelled-stop:sibling")
+    sender = _CancellingTeardownSender(origin_connection.connection_id)
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    server._connections = {  # type: ignore[attr-defined]
+        origin_connection.connection_id: origin_connection,  # type: ignore[dict-item]
+        sibling_connection.connection_id: sibling_connection,  # type: ignore[dict-item]
+    }
+    server._heartbeat_senders = {  # type: ignore[attr-defined]
+        sender.connection_id: sender  # type: ignore[dict-item]
+    }
+
+    await server._event_dispatcher.start()  # type: ignore[attr-defined]
+    emit_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[None] | None = None
+    try:
+        emit_task = asyncio.create_task(
+            server._event_dispatcher.emit(  # type: ignore[attr-defined]
+                BytesReceivedEvent(resource_id=origin_connection.connection_id, data=b"hold")
+            )
+        )
+        await asyncio.wait_for(handler.bytes_started.wait(), timeout=1.0)
+
+        stop_task = asyncio.create_task(server.stop())
+        await asyncio.wait_for(sender.stop_started.wait(), timeout=1.0)
+        stop_task.cancel()
+        await asyncio.wait_for(sender.cancelled.wait(), timeout=1.0)
+        await asyncio.wait_for(origin_connection.close_started.wait(), timeout=1.0)
+        await asyncio.wait_for(sibling_connection.close_started.wait(), timeout=1.0)
+
+        assert stop_task.done() is False
+        assert handler.stopped_seen.is_set() is False
+
+        origin_connection.release_close.set()
+        sibling_connection.release_close.set()
+        await asyncio.sleep(0)
+
+        assert stop_task.done() is False
+        assert handler.stopped_seen.is_set() is False
+
+        handler.release_bytes.set()
+        await assert_awaitable_cancelled(stop_task)
+        await asyncio.wait_for(handler.stopped_seen.wait(), timeout=1.0)
+        if emit_task is not None:
+            await asyncio.wait_for(emit_task, timeout=1.0)
+    finally:
+        handler.release_bytes.set()
+        origin_connection.release_close.set()
+        sibling_connection.release_close.set()
+        for task in (emit_task, stop_task):
+            if task is not None and not task.done():
+                task.cancel()
+                await drain_awaitable_ignoring_cancelled(task)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+    assert sender.stop_attempts == 1
+    assert origin_connection.close_attempts == 1
+    assert sibling_connection.close_attempts == 1
+    assert origin_connection.state == ConnectionState.CLOSED
+    assert sibling_connection.state == ConnectionState.CLOSED
     assert server.lifecycle_state == ComponentLifecycleState.STOPPED
 
 

--- a/tests/unit/test_runtime_utils.py
+++ b/tests/unit/test_runtime_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.helpers import assert_awaitable_cancelled
 from tests.helpers import drain_awaitable_ignoring_cancelled
+from tests.internal_asyncio_impl_refs import await_future_completion_preserving_cancellation
 from tests.internal_asyncio_impl_refs import await_task_completion_preserving_cancellation
 
 
@@ -47,3 +48,63 @@ async def test_task_await_helper_preserves_caller_cancellation_until_child_settl
         if not child_task.done():
             child_task.cancel()
             await drain_awaitable_ignoring_cancelled(child_task)
+
+
+@pytest.mark.asyncio
+async def test_future_await_helper_preserves_caller_cancellation_until_future_settles() -> None:
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    async def await_shared_future() -> None:
+        await await_future_completion_preserving_cancellation(future)
+
+    cancelled_waiter = asyncio.create_task(await_shared_future())
+    surviving_waiter = asyncio.create_task(await_shared_future())
+
+    try:
+        await asyncio.sleep(0)
+        cancelled_waiter.cancel()
+        await asyncio.sleep(0)
+
+        assert not cancelled_waiter.done()
+        assert not surviving_waiter.done()
+        assert not future.done()
+
+        future.set_result(None)
+
+        await assert_awaitable_cancelled(cancelled_waiter)
+        await asyncio.wait_for(surviving_waiter, timeout=1.0)
+    finally:
+        if not future.done():
+            future.set_result(None)
+        for waiter in (cancelled_waiter, surviving_waiter):
+            if not waiter.done():
+                waiter.cancel()
+                await drain_awaitable_ignoring_cancelled(waiter)
+
+
+@pytest.mark.asyncio
+async def test_future_await_helper_preserves_future_exception_over_caller_cancellation() -> None:
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    async def await_shared_future() -> None:
+        await await_future_completion_preserving_cancellation(future)
+
+    waiter = asyncio.create_task(await_shared_future())
+
+    try:
+        await asyncio.sleep(0)
+        waiter.cancel()
+        await asyncio.sleep(0)
+
+        assert not waiter.done()
+
+        future.set_exception(RuntimeError("shared-future-failed"))
+
+        with pytest.raises(RuntimeError, match="shared-future-failed"):
+            await asyncio.wait_for(waiter, timeout=1.0)
+    finally:
+        if not future.done():
+            future.set_result(None)
+        if not waiter.done():
+            waiter.cancel()
+            await drain_awaitable_ignoring_cancelled(waiter)


### PR DESCRIPTION
## Summary

Preserve TCP deferred terminal publication when an external stop or close caller is cancelled while inline handler work is still active.

## Problems and approach

### 1. Problem: 
Cancelling the owner of a TCP client or server `stop()` during active inline handler work could interrupt deferred terminal publication or leak cancellation through shared stop coordination.
### Approach: 
Wait for shared stop waiters with cancellation preservation, then re-raise owner cancellation only after deferred cleanup has settled.

### 2. Problem: 
Caller cancellation during heartbeat teardown could skip later connection cleanup before terminal stop publication.
### Approach: 
Keep TCP client and server teardown phase-local so heartbeat, connection close, and listener cleanup all run before any deferred terminal success is observed.

### 3. Problem: 
Repeated caller cancellation could reach shared TCP connection `close()` coordination while terminal close publication still had to wait for active handler completion.
### Approach: 
Preserve both the shared close task and any deferred close waiter before re-raising caller cancellation.

## Changes

- Add shared-future cancellation-preserving await support for stop coordination futures.
- Preserve TCP client/server stop waiters and direct connection close waiters until deferred terminal publication settles.
- Add deterministic client, server, connection, runtime helper, and integration regression tests for the cancellation paths.
- Update the `[Unreleased]` changelog entry for the TCP stop/close cancellation fix.

## Related issue

Closes #42

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated.
- [x] No documented public contract change beyond preserving existing lifecycle semantics.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] No public API changes.

## Local verification

- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 577 passed, 1 skipped, 77 deselected
- `python -m pytest -q tests/integration/test_concurrency_scenarios.py tests/unit/test_asyncio_tcp_client_internals.py tests/unit/test_asyncio_tcp_server.py tests/unit/test_runtime_utils.py tests/unit/test_asyncio_tcp_connection.py` -> 160 passed
- `ruff check .` -> passed
- `ruff format --check .` -> passed
- `python -m mypy src` -> passed
- `git diff --check` -> no whitespace errors
