### PR TITLE
test(reconnect): cover repeated failure delay cap

### DIFF
--- a/tests/integration/test_client_reconnect.py
+++ b/tests/integration/test_client_reconnect.py
@@ -193,7 +193,6 @@ async def test_client_stop_during_reconnect_sleep_is_prompt(recording_event_hand
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-@pytest.mark.integration_semantic
 async def test_client_reconnect_failure_delays_reach_and_remain_at_cap(
     recording_event_handler,
     unused_tcp_port: int,

--- a/tests/integration/test_client_reconnect.py
+++ b/tests/integration/test_client_reconnect.py
@@ -193,6 +193,60 @@ async def test_client_stop_during_reconnect_sleep_is_prompt(recording_event_hand
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+@pytest.mark.integration_semantic
+async def test_client_reconnect_failure_delays_reach_and_remain_at_cap(
+    recording_event_handler,
+    unused_tcp_port: int,
+) -> None:
+    async def always_failing_opener(
+        *, host: str, port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        assert host == "127.0.0.1"
+        assert port == unused_tcp_port
+        raise OSError("connect-failed-for-delay-cap-test")
+
+    client = AsyncioTcpClient(
+        settings=TcpClientSettings(
+            host="127.0.0.1",
+            port=unused_tcp_port,
+            reconnect=TcpReconnectSettings(
+                enabled=True,
+                initial_delay_seconds=0.01,
+                max_delay_seconds=0.04,
+                backoff_factor=2.0,
+            ),
+            connect_timeout_seconds=0.5,
+        ),
+        event_handler=recording_event_handler,
+        connection_opener=always_failing_opener,
+    )
+    await client.start()
+
+    await wait_for_condition(
+        lambda: len(recording_event_handler.reconnect_scheduled_events) >= 4,
+        timeout_seconds=1.0,
+    )
+    await asyncio.wait_for(client.stop(), timeout=1.0)
+
+    scheduled_events = recording_event_handler.reconnect_scheduled_events[:4]
+    failed_events = recording_event_handler.reconnect_attempt_failed_events[:4]
+    started_events = recording_event_handler.reconnect_attempt_started_events[:4]
+
+    assert [event.attempt for event in started_events] == [1, 2, 3, 4]
+    assert [event.attempt for event in failed_events] == [1, 2, 3, 4]
+    assert [event.attempt for event in scheduled_events] == [2, 3, 4, 5]
+    assert [event.delay_seconds for event in scheduled_events] == pytest.approx(
+        [0.01, 0.02, 0.04, 0.04]
+    )
+    assert [event.next_delay_seconds for event in failed_events] == pytest.approx(
+        [0.01, 0.02, 0.04, 0.04]
+    )
+    assert client.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert client.connection is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 @pytest.mark.behavior_critical
 async def test_client_stop_during_inflight_heartbeat_send_is_prompt(
     recording_event_handler,


### PR DESCRIPTION
## Summary

Add runtime reconnect coverage for repeated TCP client connection failures reaching the configured reconnect delay cap.

## Changes

- Add a deterministic integration test that forces consecutive reconnect failures with a failing connection opener.
- Assert emitted reconnect attempt and scheduled-event attempt numbers remain observable.
- Assert scheduled delays progress to `max_delay_seconds`, stay capped, and explicit `stop()` reaches `STOPPED` with no active connection.

## Related issue

Closes #45

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section not updated because this is test-only coverage with no user-visible behavior change.
- [x] No documented public contract changed, so README/docs updates are not needed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are not applicable.

Local verification:

- `python scripts\ci\assert_integration_semantic_shard.py` -> shard contract verified
- `python -m pytest -q tests\integration\test_client_reconnect.py::test_client_reconnect_failure_delays_reach_and_remain_at_cap --timeout=60` -> 1 passed
- `python -m pytest -q tests\integration\test_client_reconnect.py --timeout=60` -> 17 passed
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 586 passed, 80 deselected
- `ruff check .` -> passed
- `ruff format --check .` -> 126 files already formatted
- `python -m mypy src` -> success
- `git diff --check` -> passed
