### PR TITLE
test(ci): make Hypothesis marker command skip cleanly

### DIFF
--- a/tests/integration/test_runtime_property_based.py
+++ b/tests/integration/test_runtime_property_based.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import pytest
 
+pytestmark = [pytest.mark.hypothesis, pytest.mark.integration]
+
 hypothesis = pytest.importorskip(
     "hypothesis", reason="hypothesis not installed; skipping runtime property tests"
 )
@@ -33,8 +35,6 @@ from aionetx.implementations.asyncio_impl.asyncio_udp_receiver import (  # noqa:
     AsyncioUdpReceiver,
 )
 from aionetx.testing import RecordingEventHandler, wait_for_condition  # noqa: E402
-
-pytestmark = [pytest.mark.hypothesis, pytest.mark.integration]
 
 TCP_MAX_EXAMPLES = 12
 UDP_MAX_EXAMPLES = 12

--- a/tests/unit/test_hypothesis_optional_dependency.py
+++ b/tests/unit/test_hypothesis_optional_dependency.py
@@ -1,0 +1,15 @@
+"""Regression check for the optional Hypothesis test group."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.hypothesis
+
+
+def test_hypothesis_extra_unavailable_is_reported_as_optional_skip() -> None:
+    """Keep ``pytest -m hypothesis`` green when the optional extra is absent."""
+    pytest.importorskip(
+        "hypothesis",
+        reason="hypothesis not installed; skipping property-based tests",
+    )

--- a/tests/unit/test_settings_property_based.py
+++ b/tests/unit/test_settings_property_based.py
@@ -20,6 +20,8 @@ import sys
 
 import pytest
 
+pytestmark = pytest.mark.hypothesis
+
 hypothesis = pytest.importorskip(
     "hypothesis", reason="hypothesis not installed; skipping property-based tests"
 )
@@ -30,8 +32,6 @@ from hypothesis import strategies as st  # noqa: E402
 from aionetx.api.errors import InvalidNetworkConfigurationError  # noqa: E402
 from aionetx.api.tcp_client import TcpClientSettings  # noqa: E402
 from aionetx.api.tcp_reconnect_settings import TcpReconnectSettings  # noqa: E402
-
-pytestmark = pytest.mark.hypothesis
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

Make the optional Hypothesis marker command report missing Hypothesis as a clean skip instead of pytest's no-tests-selected exit status.

## Changes

- Mark the property-based test modules before their optional Hypothesis import skips run.
- Add a small Hypothesis-marked sentinel test so `pytest -m hypothesis` has a selected skip path when the optional extra is unavailable.
- Keep installed-Hypothesis runs executing the property-based tests normally.

## Related issue

Closes #50

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section not updated because this is test-only verification behavior with no user-visible runtime change.
- [x] No documented public contract changed, so README/docs updates are not needed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are not applicable.

Local verification:

- Fresh dev environment without Hypothesis: `python -m pytest -q -m hypothesis --timeout=60` -> 3 skipped, 656 deselected, exit 0
- `python -m pytest -q -m hypothesis --timeout=60` -> 11 passed, 656 deselected
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 587 passed, 80 deselected
- `ruff check .` -> passed
- `ruff format --check .` -> 127 files already formatted
- `python -m mypy src` -> success
- `git diff --check` -> passed
