### PR TITLE
ci: validate non-v SHA pin refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
 
   # Tier: supply-chain integrity - SHA pin validation (non-blocking, scheduled + workflow changes)
   validate_sha_pins:
-    name: Non-blocking - validate workflow SHA pins match tag comments
+    name: Non-blocking - validate workflow SHA pins match ref comments
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -355,8 +355,8 @@ jobs:
       - name: Warn if SHA pin validation failed
         if: failure()
         run: |
-          echo "WARNING: One or more workflow SHA pins do not match their tag comments."
-          echo "Update the SHA in the uses: line to match the tag's current commit SHA."
+          echo "WARNING: One or more workflow SHA pins do not match their ref comments."
+          echo "Update the SHA in the uses: line to match the ref's current commit SHA."
 
   # Tier: reproducible build verification (weekly schedule only - not required on every PR)
   verify_reproducible_build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,16 +27,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: python
           # Use the default security-and-quality query suite for broad coverage.
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           sarif_file: results.sarif

--- a/scripts/ci/check_sha_pins.py
+++ b/scripts/ci/check_sha_pins.py
@@ -1,15 +1,16 @@
 """
-Validate that every SHA-pinned action in .github/workflows/*.yml matches its tag comment.
+Validate that every SHA-pinned action in .github/workflows/*.yml matches its ref comment.
 
 For each line of the form:
     uses: owner/repo@<40-char-sha>  # vX.Y.Z
+    uses: owner/repo@<40-char-sha>  # release/vX
 
-the script calls the GitHub API to resolve the tag to a commit SHA and compares it
-against the pinned SHA.
+the script calls the GitHub API to resolve the comment's upstream ref to a
+commit SHA and compares it against the pinned SHA.
 
 Exit codes:
-    0 — all pins match (or GH_TOKEN is not set, in which case checks are skipped)
-    1 — one or more pins do not match the expected tag SHA
+    0 - all pins match (or GH_TOKEN is not set, in which case checks are skipped)
+    1 - one or more pins do not match the expected upstream ref SHA
 """
 
 from __future__ import annotations
@@ -19,16 +20,41 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 
-# Regex to capture:  owner/repo@<sha>  # vX.Y.Z
-_PIN_RE = re.compile(
+# Regex to capture every SHA-pinned GitHub action use, with an optional ref comment.
+_PINNED_USES_RE = re.compile(
     r"uses:\s+(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
-    r"@(?P<sha>[0-9a-f]{40})\s+#\s+(?P<tag>v\S+)"
+    r"(?P<path>(?:/[A-Za-z0-9_.-]+)*)@(?P<sha>[0-9a-fA-F]{40})"
+    r"(?:\s+#\s*(?P<ref>\S+))?"
 )
+_TAG_REF_RE = re.compile(r"^v[0-9A-Za-z][0-9A-Za-z._-]*$")
+_RELEASE_HEAD_REF_RE = re.compile(r"^release/v[0-9A-Za-z][0-9A-Za-z._-]*$")
+
+RefKind = Literal["tags", "heads"]
 
 
-def _gh_api(path: str, token: str) -> dict:  # type: ignore[type-arg]
+@dataclass(frozen=True)
+class ActionPin:
+    action: str
+    owner: str
+    repo: str
+    pinned_sha: str
+    ref: str
+    ref_kind: RefKind
+
+
+def _ref_kind_for_comment(ref: str) -> RefKind | None:
+    if _TAG_REF_RE.fullmatch(ref):
+        return "tags"
+    if _RELEASE_HEAD_REF_RE.fullmatch(ref):
+        return "heads"
+    return None
+
+
+def _gh_api(path: str, token: str) -> dict[str, object]:
     """Call `gh api <path>` and return parsed JSON."""
     result = subprocess.run(
         ["gh", "api", path],
@@ -40,49 +66,100 @@ def _gh_api(path: str, token: str) -> dict:  # type: ignore[type-arg]
         raise RuntimeError(
             f"gh api {path!r} failed (exit {result.returncode}):\n{result.stderr.strip()}"
         )
-    return json.loads(result.stdout)  # type: ignore[no-any-return]
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"gh api {path!r} returned unexpected JSON shape.")
+    return cast(dict[str, object], payload)
 
 
-def _resolve_tag_commit_sha(owner: str, repo: str, tag: str, token: str) -> str | None:
-    """Return the commit SHA that *tag* points to, or None if the tag is not found."""
-    path = f"/repos/{owner}/{repo}/git/refs/tags/{tag}"
+def _resolve_ref_commit_sha(
+    owner: str,
+    repo: str,
+    ref: str,
+    ref_kind: RefKind,
+    token: str,
+) -> str | None:
+    """Return the commit SHA that *ref* points to, or None if the ref is not found."""
+    path = f"/repos/{owner}/{repo}/git/refs/{ref_kind}/{ref}"
     try:
         ref_data = _gh_api(path, token)
     except RuntimeError as exc:
-        # 404 → tag not found; surface the error but keep going
+        # 404 means the intended upstream ref is absent; report it as a pin failure.
         if "404" in str(exc) or "Not Found" in str(exc):
             return None
         raise
 
     obj = ref_data.get("object", {})
+    if not isinstance(obj, dict):
+        return None
     obj_type: str = obj.get("type", "")
     obj_sha: str = obj.get("sha", "")
 
     if obj_type == "commit":
-        # Lightweight tag: the ref object IS the commit
+        # Lightweight tag or branch head: the ref object is the commit.
         return obj_sha
 
     if obj_type == "tag":
-        # Annotated tag: dereference the tag object to get the commit SHA
+        # Annotated tag: dereference the tag object to get the commit SHA.
         tag_obj = _gh_api(f"/repos/{owner}/{repo}/git/tags/{obj_sha}", token)
         tagged = tag_obj.get("object", {})
+        if not isinstance(tagged, dict):
+            return None
         tagged_type: str = tagged.get("type", "")
         tagged_sha: str = tagged.get("sha", "")
         if tagged_type == "commit":
             return tagged_sha
-        # Edge case: tag points to another tag (rare); follow one more level
+
+        # Edge case: tag points to another tag (rare); follow one more level.
         tag_obj2 = _gh_api(f"/repos/{owner}/{repo}/git/tags/{tagged_sha}", token)
-        inner: str = tag_obj2.get("object", {}).get("sha", "")
+        inner_obj = tag_obj2.get("object", {})
+        if not isinstance(inner_obj, dict):
+            return None
+        inner: str = inner_obj.get("sha", "")
         return inner
 
     return obj_sha
+
+
+def _parse_action_pin(line: str) -> ActionPin | str | None:
+    match = _PINNED_USES_RE.search(line)
+    if match is None:
+        return None
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+    action = f"{owner}/{repo}{match.group('path')}"
+    pinned_sha = match.group("sha").lower()
+    ref = match.group("ref")
+
+    if ref is None:
+        return (
+            f"missing upstream ref comment for {action}@{pinned_sha[:12]} "
+            "(expected '# v...' or '# release/v...')"
+        )
+
+    ref_kind = _ref_kind_for_comment(ref)
+    if ref_kind is None:
+        return (
+            f"unsupported upstream ref comment {ref!r} for {action}@{pinned_sha[:12]} "
+            "(expected '# v...' or '# release/v...')"
+        )
+
+    return ActionPin(
+        action=action,
+        owner=owner,
+        repo=repo,
+        pinned_sha=pinned_sha,
+        ref=ref,
+        ref_kind=ref_kind,
+    )
 
 
 def main() -> int:
     token = os.environ.get("GH_TOKEN", "")
     if not token:
         print(
-            "GH_TOKEN is not set — skipping SHA pin validation "
+            "GH_TOKEN is not set - skipping SHA pin validation "
             "(set GH_TOKEN to enable checks in local runs).",
             file=sys.stderr,
         )
@@ -97,43 +174,54 @@ def main() -> int:
         return 0
 
     failures: list[str] = []
+    checked_count = 0
 
     for wf_file in workflow_files:
         content = wf_file.read_text(encoding="utf-8")
         for lineno, line in enumerate(content.splitlines(), start=1):
-            m = _PIN_RE.search(line)
-            if not m:
+            action_pin = _parse_action_pin(line)
+            if action_pin is None:
+                continue
+            if isinstance(action_pin, str):
+                failures.append(f"{wf_file.name}:{lineno}: {action_pin}")
                 continue
 
-            owner = m.group("owner")
-            repo = m.group("repo")
-            pinned_sha = m.group("sha")
-            tag = m.group("tag")
-
-            print(f"  checking {owner}/{repo}@{pinned_sha[:12]}… ({tag})")
+            print(
+                f"  checking {action_pin.action}@{action_pin.pinned_sha[:12]}... ({action_pin.ref})"
+            )
 
             try:
-                resolved_sha = _resolve_tag_commit_sha(owner, repo, tag, token)
+                resolved_sha = _resolve_ref_commit_sha(
+                    action_pin.owner,
+                    action_pin.repo,
+                    action_pin.ref,
+                    action_pin.ref_kind,
+                    token,
+                )
             except RuntimeError as exc:
                 failures.append(
-                    f"{wf_file.name}:{lineno}: ERROR resolving {owner}/{repo} {tag}: {exc}"
+                    f"{wf_file.name}:{lineno}: ERROR resolving "
+                    f"{action_pin.owner}/{action_pin.repo} {action_pin.ref}: {exc}"
                 )
                 continue
 
             if resolved_sha is None:
                 failures.append(
-                    f"{wf_file.name}:{lineno}: tag {tag!r} not found for {owner}/{repo}"
+                    f"{wf_file.name}:{lineno}: ref {action_pin.ref!r} not found for "
+                    f"{action_pin.owner}/{action_pin.repo}"
                 )
                 continue
 
-            if resolved_sha != pinned_sha:
+            if resolved_sha != action_pin.pinned_sha:
                 failures.append(
-                    f"{wf_file.name}:{lineno}: SHA mismatch for {owner}/{repo} {tag}\n"
-                    f"    pinned:   {pinned_sha}\n"
+                    f"{wf_file.name}:{lineno}: SHA mismatch for "
+                    f"{action_pin.owner}/{action_pin.repo} {action_pin.ref}\n"
+                    f"    pinned:   {action_pin.pinned_sha}\n"
                     f"    resolved: {resolved_sha}"
                 )
             else:
-                print(f"    OK ({pinned_sha[:12]} == {tag})")
+                checked_count += 1
+                print(f"    OK ({action_pin.pinned_sha[:12]} == {action_pin.ref})")
 
     if failures:
         print("\nSHA pin validation FAILED:", file=sys.stderr)
@@ -141,7 +229,10 @@ def main() -> int:
             print(f"  {msg}", file=sys.stderr)
         return 1
 
-    print(f"\nAll SHA pins validated successfully across {len(workflow_files)} workflow file(s).")
+    print(
+        f"\nAll {checked_count} SHA pins validated successfully across "
+        f"{len(workflow_files)} workflow file(s)."
+    )
     return 0
 
 

--- a/tests/unit/test_check_sha_pins_script.py
+++ b/tests/unit/test_check_sha_pins_script.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import re
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "ci" / "check_sha_pins.py"
+SCRIPT_GLOBALS = runpy.run_path(str(SCRIPT_PATH))
+
+main = SCRIPT_GLOBALS["main"]
+
+PINNED_USES_RE = re.compile(
+    r"uses:\s+(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
+    r"(?:/[A-Za-z0-9_.-]+)*@(?P<sha>[0-9a-f]{40})\s+#\s*(?P<ref>\S+)"
+)
+
+
+def _make_temp_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    workflow_text: str,
+) -> None:
+    script_path = tmp_path / "scripts" / "ci" / "check_sha_pins.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("", encoding="utf-8")
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(workflow_text, encoding="utf-8")
+
+    monkeypatch.setitem(main.__globals__, "__file__", str(script_path))
+
+
+def _pinned_refs_from_workflows() -> dict[tuple[str, str, str], str]:
+    pins: dict[tuple[str, str, str], str] = {}
+    for workflow_path in (PROJECT_ROOT / ".github" / "workflows").glob("*.yml"):
+        for line in workflow_path.read_text(encoding="utf-8").splitlines():
+            match = PINNED_USES_RE.search(line)
+            if match is None:
+                continue
+            pins[
+                (
+                    match.group("owner"),
+                    match.group("repo"),
+                    match.group("ref"),
+                )
+            ] = match.group("sha")
+    return pins
+
+
+def _fake_ref_api(
+    requested_paths: list[str],
+    pins: dict[tuple[str, str, str], str],
+):
+    def fake_gh_api(path: str, token: str) -> dict[str, object]:
+        del token
+        requested_paths.append(path)
+        marker = "/git/refs/"
+        if marker not in path:
+            raise AssertionError(f"unexpected API path: {path}")
+
+        repo_path, ref_path = path.split(marker, maxsplit=1)
+        _, repos_marker, owner, repo = repo_path.split("/")
+        assert repos_marker == "repos"
+        ref_kind, ref_name = ref_path.split("/", maxsplit=1)
+        if ref_kind == "tags":
+            key = (owner, repo, ref_name)
+        elif ref_kind == "heads":
+            key = (owner, repo, ref_name)
+        else:
+            raise AssertionError(f"unexpected ref kind: {ref_kind}")
+
+        try:
+            sha = pins[key]
+        except KeyError as exc:
+            raise AssertionError(f"missing fake SHA for {key}") from exc
+        return {"object": {"type": "commit", "sha": sha}}
+
+    return fake_gh_api
+
+
+def test_current_release_publish_pins_are_validated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    requested_paths: list[str] = []
+    pins = _pinned_refs_from_workflows()
+    monkeypatch.setitem(
+        main.__globals__,
+        "_gh_api",
+        _fake_ref_api(requested_paths, pins),
+    )
+
+    assert main() == 0
+
+    assert any(
+        path.endswith("/repos/actions/checkout/git/refs/tags/v6") for path in requested_paths
+    )
+    assert any(
+        path.endswith("/repos/github/codeql-action/git/refs/tags/v4") for path in requested_paths
+    )
+    assert any(
+        path.endswith("/repos/pypa/gh-action-pypi-publish/git/refs/heads/release/v1")
+        for path in requested_paths
+    )
+
+
+def test_missing_ref_comment_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_temp_repo(
+        monkeypatch,
+        tmp_path,
+        "jobs:\n"
+        "  check:\n"
+        "    steps:\n"
+        "      - uses: example/action@1111111111111111111111111111111111111111\n",
+    )
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "missing upstream ref comment" in captured.err
+
+
+def test_unsupported_ref_comment_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_temp_repo(
+        monkeypatch,
+        tmp_path,
+        "jobs:\n"
+        "  check:\n"
+        "    steps:\n"
+        "      - uses: example/action@1111111111111111111111111111111111111111 # main\n",
+    )
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "unsupported upstream ref comment 'main'" in captured.err


### PR DESCRIPTION
## Summary

Broaden the workflow SHA-pin drift checker so SHA-pinned GitHub Actions `uses:` lines are parsed before validation, including path-qualified actions and `release/v...` refs.

## Changes

- Parse SHA-pinned `uses:` lines separately from their trailing ref comments.
- Resolve `v...` comments through tag refs and `release/v...` comments through branch refs.
- Fail clearly when a SHA-pinned workflow action is missing a supported ref comment.
- Account for path-qualified actions such as `github/codeql-action/init`.
- Update `github/codeql-action@v4` SHA pins to the current dereferenced commit found by the broadened checker.
- Update SHA-pin CI wording from tag comments to ref comments.
- Add unit coverage for `v...` refs, `release/v...` refs, missing comments, and unsupported comments.

## Related issue

Closes #34

## Checklist

- [x] All commits include a DCO `Signed-off-by` line.
- [x] Tests added for the changed checker behavior.
- [x] CHANGELOG not updated; this changes repository CI validation, not package behavior.
- [x] Public API docs not updated; no public API contract changed.
- [x] `ruff check .` passes locally.
- [x] `ruff format --check .` passes locally.
- [x] `mypy src` passes locally.

## Local verification

- `python -m pytest tests/unit/test_check_sha_pins_script.py -q` -> 3 passed
- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 596 passed, 80 deselected
- `ruff check --no-cache .` -> passed
- `ruff format --check --no-cache .` -> passed
- `python -m mypy src` -> passed
- YAML parse check for `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, and `.github/workflows/scorecard.yml` -> passed
- Live SHA-pin validation with `GH_TOKEN` set -> All 96 SHA pins validated successfully across 4 workflow files
