### PR TITLE
feat(api): expose dispatcher runtime stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Planned contents for the initial public alpha release (`0.1.0`).
 - explicit lifecycle events, event delivery settings, and backpressure policies
 - bounded TCP send flushes with configurable per-connection send timeouts
 - optional TCP client reconnect and heartbeat support
+- `DispatcherRuntimeStats` as the public diagnostics snapshot type for managed
+  TCP, UDP, and multicast receiver dispatcher counters
 - tests, examples, typing metadata, and CI/release verification gates
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -445,14 +445,17 @@ Dispatcher phase behavior in `BACKGROUND` mode is explicit:
 This shutdown-phase drop behavior is a documented exception to steady-state
 overload policy.
 
-Operational diagnostics for concrete asyncio implementations now make drop causes
-explicit at runtime:
+Managed TCP clients, TCP servers, UDP receivers, and multicast receivers expose
+dispatcher diagnostics through `dispatcher_runtime_stats`. The snapshot type is
+part of the advanced public API and can be imported as
+`from aionetx.api import DispatcherRuntimeStats`.
+
+The public counters make drop causes explicit at runtime:
 
 - backpressure drops are tracked separately for `DROP_OLDEST` and `DROP_NEWEST`
-- shutdown-phase drops are tracked separately from overload drops
-- dispatcher runtime stats include enqueue volume, handler dispatch attempts, and queue depth peak/current snapshots
-
-Concrete asyncio TCP components expose this as `dispatcher_runtime_stats`.
+- shutdown and terminal cleanup drops are tracked separately from overload drops
+- dispatcher runtime stats include enqueue volume, handler dispatch attempts,
+  handler failures, inline fallback count, and queue depth peak/current snapshots
 
 Use those diagnostics to distinguish overload tuning problems from intentional
 deterministic-shutdown cutoffs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -292,19 +292,22 @@ For `BACKGROUND` dispatch mode, runtime behavior is intentionally phase-aware:
 - during dispatcher shutdown: newly emitted events may be dropped to guarantee deterministic stop completion
 
 This shutdown-phase drop behavior is a deliberate deterministic-shutdown tradeoff and not a hidden overload policy.
-Runtime diagnostics should make this distinction explicit by separating:
+Runtime diagnostics make this distinction explicit by separating:
 
 - overload drops (`DROP_OLDEST`/`DROP_NEWEST`)
-- shutdown-phase drops after stop begins
+- shutdown and terminal cleanup drops after stop begins or resource close
 - queue occupancy snapshots (current + peak)
+- enqueue volume, handler dispatch attempts/failures, and inline fallback count
 
 For handler-failure-driven shutdown, the dispatcher uses an explicit
 `DispatcherStopPolicy` contract. Under
 `handler_failure_policy=STOP_COMPONENT`, it emits
 `HandlerFailurePolicyStopEvent` before invoking the configured stop callback.
 
-In concrete asyncio TCP transports, this diagnostic snapshot is exposed via
-`dispatcher_runtime_stats` on the client/server objects.
+Managed TCP client, TCP server, UDP receiver, and multicast receiver protocols
+expose this diagnostic snapshot via `dispatcher_runtime_stats`. The public
+snapshot type is `DispatcherRuntimeStats`, importable from `aionetx.api`.
+The dispatcher implementation remains internal.
 
 ## 16) Verification posture interpretation
 

--- a/src/aionetx/api/__init__.py
+++ b/src/aionetx/api/__init__.py
@@ -26,6 +26,7 @@ from aionetx.api.lifecycle import (
     ConnectionRole,
     ConnectionState,
 )
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.errors import (
     ConnectionClosedError,
     HeartbeatConfigurationError,
@@ -92,6 +93,7 @@ __all__ = (
     "ConnectionProtocol",
     "ConnectionRole",
     "ConnectionState",
+    "DispatcherRuntimeStats",
     "ErrorPolicy",
     "EventBackpressurePolicy",
     "EventDeliverySettings",

--- a/src/aionetx/api/diagnostics.py
+++ b/src/aionetx/api/diagnostics.py
@@ -1,0 +1,49 @@
+"""
+Public runtime diagnostic snapshot types.
+
+Diagnostics expose operational counters for managed transports without making
+the underlying dispatcher implementation part of the public API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DispatcherRuntimeStats:
+    """
+    Point-in-time dispatcher diagnostics for one managed transport.
+
+    The snapshot is cumulative since the owning transport was constructed,
+    except queue depth values, which describe the queue at snapshot time.
+
+    Attributes:
+        emit_calls_total: Total number of event emission attempts observed.
+        enqueued_total: Events accepted into the background dispatcher queue.
+        handler_dispatch_attempts_total: Attempts to invoke the event handler.
+        handler_failures_total: Handler invocations that raised.
+        inline_fallback_total: Background-mode events delivered inline because
+            no worker could be used for that emission.
+        dropped_backpressure_oldest_total: Events evicted by ``DROP_OLDEST``.
+        dropped_backpressure_newest_total: Events rejected by ``DROP_NEWEST``.
+        dropped_stop_phase_total: Background-mode events ignored after
+            dispatcher shutdown started, plus queued payload events cleared
+            when their resource closes during terminal cleanup.
+        queue_depth: Current queued event count.
+        queue_peak: Highest queued event count observed so far.
+    """
+
+    emit_calls_total: int
+    enqueued_total: int
+    handler_dispatch_attempts_total: int
+    handler_failures_total: int
+    inline_fallback_total: int
+    dropped_backpressure_oldest_total: int
+    dropped_backpressure_newest_total: int
+    dropped_stop_phase_total: int
+    queue_depth: int
+    queue_peak: int
+
+
+__all__ = ("DispatcherRuntimeStats",)

--- a/src/aionetx/api/multicast_receiver_protocol.py
+++ b/src/aionetx/api/multicast_receiver_protocol.py
@@ -1,16 +1,22 @@
 """
 Public protocol for managed UDP multicast receivers.
 
-The protocol adds no new methods beyond ``ManagedTransportProtocol``; its
-purpose is to give multicast receivers an explicit role-specific API type.
+The protocol adds role-specific typing for multicast receivers plus dispatcher
+diagnostics exposed by managed receive transports.
 """
 
 from __future__ import annotations
 
 from typing import Protocol
 
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
 
 
 class MulticastReceiverProtocol(ManagedTransportProtocol, Protocol):
-    """Multicast receiver contract built on managed lifecycle capability."""
+    """Multicast receiver contract built on lifecycle and diagnostics capability."""
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Return a point-in-time dispatcher diagnostics snapshot."""
+        raise NotImplementedError

--- a/src/aionetx/api/tcp_client.py
+++ b/src/aionetx/api/tcp_client.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.error_policy import ErrorPolicy
 from aionetx.api.event_delivery_settings import EventDeliverySettings
 from aionetx.api.heartbeat import TcpHeartbeatSettings
@@ -124,6 +125,11 @@ class TcpClientProtocol(ManagedTransportProtocol, Protocol):
     @property
     def connection(self) -> ConnectionProtocol | None:
         """Return active connection if connected, otherwise ``None``."""
+        raise NotImplementedError
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Return a point-in-time dispatcher diagnostics snapshot."""
         raise NotImplementedError
 
     async def wait_until_connected(

--- a/src/aionetx/api/tcp_server.py
+++ b/src/aionetx/api/tcp_server.py
@@ -12,6 +12,7 @@ from typing import Protocol
 
 from aionetx.api.bytes_like import BytesLike
 from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.event_delivery_settings import EventDeliverySettings
 from aionetx.api.heartbeat import TcpHeartbeatSettings
 from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
@@ -133,6 +134,11 @@ class TcpServerProtocol(ManagedTransportProtocol, Protocol):
 
         Rejected or already-closed connections are never part of this tuple.
         """
+        raise NotImplementedError
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Return a point-in-time dispatcher diagnostics snapshot."""
         raise NotImplementedError
 
     async def wait_until_running(

--- a/src/aionetx/api/udp.py
+++ b/src/aionetx/api/udp.py
@@ -13,6 +13,7 @@ from typing import Protocol
 
 from aionetx.api.byte_sender_protocol import ByteSenderProtocol
 from aionetx.api.bytes_like import BytesLike
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.event_delivery_settings import EventDeliverySettings
 from aionetx.api.managed_transport_protocol import ManagedTransportProtocol
 from aionetx.api.errors import NetworkConfigurationError, NetworkRuntimeError
@@ -146,6 +147,11 @@ class UdpInvalidTargetError(NetworkConfigurationError):
 
 class UdpReceiverProtocol(ManagedTransportProtocol, Protocol):
     """UDP datagram receiver contract built on managed lifecycle capability."""
+
+    @property
+    def dispatcher_runtime_stats(self) -> DispatcherRuntimeStats:
+        """Return a point-in-time dispatcher diagnostics snapshot."""
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -22,11 +22,9 @@ from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_metadata import ConnectionMetadata
 from aionetx.api.connection_lifecycle import ConnectionState
 from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.network_error_event import NetworkErrorEvent
-from aionetx.implementations.asyncio_impl.event_dispatcher import (
-    AsyncioEventDispatcher,
-    DispatcherRuntimeStats,
-)
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
 from aionetx.implementations.asyncio_impl.lifecycle_internal import (
     LifecycleTransitionPublisher,

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -19,6 +19,7 @@ from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChan
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_protocol import ConnectionProtocol
 from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.error_policy import ErrorPolicy
 from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
 from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
@@ -37,10 +38,7 @@ from aionetx.implementations.asyncio_impl._tcp_client_runtime import (
 from aionetx.implementations.asyncio_impl.identifier_utils import (
     tcp_client_component_id,
 )
-from aionetx.implementations.asyncio_impl.event_dispatcher import (
-    AsyncioEventDispatcher,
-    DispatcherRuntimeStats,
-)
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.lifecycle_internal import (
     LifecycleRole,
     LifecycleTransitionPublisher,

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -20,6 +20,7 @@ from aionetx.api.bytes_like import BytesLike
 from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
 from aionetx.api.component_lifecycle_state import ComponentLifecycleState
 from aionetx.api.connection_protocol import ConnectionProtocol
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.heartbeat_provider_protocol import HeartbeatProviderProtocol
 from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
 from aionetx.api.tcp_server import TcpServerProtocol, TcpServerSettings
@@ -37,10 +38,7 @@ from aionetx.implementations.asyncio_impl.identifier_utils import (
     tcp_server_component_id,
     tcp_server_connection_id,
 )
-from aionetx.implementations.asyncio_impl.event_dispatcher import (
-    AsyncioEventDispatcher,
-    DispatcherRuntimeStats,
-)
+from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
 from aionetx.implementations.asyncio_impl.lifecycle_internal import (
     LifecycleTransitionPublisher,

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from aionetx.api.bytes_received_event import BytesReceivedEvent
+from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.event_delivery_settings import (
     EventBackpressurePolicy,
     EventDeliverySettings,
@@ -51,36 +52,6 @@ _handler_origin_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
 
 class _HandlerCancelledError(RuntimeError):
     """Exception wrapper used when a handler raises CancelledError itself."""
-
-
-@dataclass(frozen=True, slots=True)
-class DispatcherRuntimeStats:
-    """
-    Point-in-time operational counters for one dispatcher instance.
-
-    Attributes:
-        emit_calls_total: Total number of ``emit()`` calls observed.
-        enqueued_total: Events accepted into the background queue.
-        handler_dispatch_attempts_total: Attempts to invoke the event handler.
-        handler_failures_total: Handler invocations that raised.
-        inline_fallback_total: Background-mode emits delivered inline because no worker existed yet.
-        dropped_backpressure_oldest_total: Events evicted by ``DROP_OLDEST`` backpressure.
-        dropped_backpressure_newest_total: Events rejected by ``DROP_NEWEST`` backpressure.
-        dropped_stop_phase_total: Background-mode emits ignored after shutdown started.
-        queue_depth: Current queued event count.
-        queue_peak: Highest queue depth observed so far.
-    """
-
-    emit_calls_total: int
-    enqueued_total: int
-    handler_dispatch_attempts_total: int
-    handler_failures_total: int
-    inline_fallback_total: int
-    dropped_backpressure_oldest_total: int
-    dropped_backpressure_newest_total: int
-    dropped_stop_phase_total: int
-    queue_depth: int
-    queue_peak: int
 
 
 @dataclass(slots=True)

--- a/tests/unit/test_api_symbol_sources.py
+++ b/tests/unit/test_api_symbol_sources.py
@@ -60,6 +60,7 @@ def test_api_symbol_api_curated_exports_come_from_grouping_modules() -> None:
         "ConnectionProtocol": "aionetx.api.protocols",
         "ConnectionRole": "aionetx.api.lifecycle",
         "ConnectionState": "aionetx.api.lifecycle",
+        "DispatcherRuntimeStats": "aionetx.api.diagnostics",
         "ErrorPolicy": "aionetx.api.policies",
         "EventDeliverySettings": "aionetx.api.policies",
         "HandlerFailurePolicyStopEvent": "aionetx.api.events",

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -16,6 +16,7 @@ import logging
 
 import pytest
 
+from aionetx.api.bytes_received_event import BytesReceivedEvent
 from aionetx.api.connection_events import ConnectionClosedEvent
 from aionetx.api.connection_events import ConnectionOpenedEvent
 from aionetx.api.connection_metadata import ConnectionMetadata
@@ -1899,6 +1900,42 @@ async def test_runtime_stats_characterize_stop_with_pending_queue_work() -> None
     assert stats.dropped_stop_phase_total == 1
     assert stats.queue_depth == 0
     assert stats.queue_peak == 2
+
+
+@pytest.mark.asyncio
+async def test_runtime_stats_capture_resource_close_queue_cleanup_drop_counts() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if (
+                isinstance(event, ConnectionOpenedEvent)
+                and event.metadata.connection_id == "blocker"
+            ):
+                first_started.set()
+                await release_first.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened("blocker"))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    await dispatcher.emit(BytesReceivedEvent(resource_id="closing", data=b"drop"))
+    await dispatcher.emit(BytesReceivedEvent(resource_id="staying", data=b"keep"))
+    dropped = await dispatcher.drop_queued_events_for_resource("closing")
+
+    stats = dispatcher.runtime_stats
+    assert dropped == 1
+    assert stats.dropped_stop_phase_total == 1
+    assert stats.queue_depth == 1
+
+    release_first.set()
+    await dispatcher.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 from types import ModuleType
+from typing import get_type_hints
 
 import pytest
 
@@ -84,6 +85,29 @@ def test_aionetx_api_exports_exception_bases_and_typed_router() -> None:
     assert api.TypedEventRouter is TypedEventRouter
 
 
+def test_aionetx_api_exports_dispatcher_runtime_stats_for_advanced_usage() -> None:
+    api = _api_module()
+
+    assert hasattr(api, "DispatcherRuntimeStats")
+    assert "DispatcherRuntimeStats" in api.PUBLIC_API
+
+
+def test_managed_receiver_protocols_expose_dispatcher_runtime_stats() -> None:
+    api = _api_module()
+    expected_stats_type = api.DispatcherRuntimeStats
+
+    for protocol in (
+        api.TcpClientProtocol,
+        api.TcpServerProtocol,
+        api.UdpReceiverProtocol,
+        api.MulticastReceiverProtocol,
+    ):
+        stats_property = getattr(protocol, "dispatcher_runtime_stats", None)
+
+        assert isinstance(stats_property, property), protocol.__name__
+        assert get_type_hints(stats_property.fget)["return"] is expected_stats_type
+
+
 def test_recording_event_handler_is_available_only_from_testing_namespace() -> None:
     aionetx = _root_module()
 
@@ -105,6 +129,7 @@ def test_recording_event_handler_is_available_only_from_testing_namespace() -> N
         "UdpSenderProtocol",
         "MulticastReceiverProtocol",
         "ConnectionClosedEvent",
+        "DispatcherRuntimeStats",
     ],
 )
 def test_root_import_does_not_expose_advanced_or_internal_symbols(


### PR DESCRIPTION
## Summary

Promote dispatcher runtime diagnostics into the advanced public API so documented diagnostics have a stable import path and protocol typing.

## Changes

- Add `DispatcherRuntimeStats` as a public diagnostics snapshot type from `aionetx.api`.
- Expose `dispatcher_runtime_stats` on TCP client/server and UDP/multicast receiver protocols.
- Keep the asyncio dispatcher implementation internal while returning the public snapshot type.
- Document counter semantics, including terminal cleanup drops, and update the changelog.
- Add API export/protocol checks and runtime stats coverage for resource-close queue cleanup.

## Related issue

Closes #35

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated for the user-visible API change.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md`.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` (600 passed, 80 deselected)
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy src`
