### PR TITLE
docs(security): remove email fallback references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
 
         Before filing, please check:
         - **Questions or usage help** belong in [Discussions -> Q&A](https://github.com/MarcusKorinth/aionetx/discussions/categories/q-a), not here.
-        - **Security vulnerabilities** must be reported privately via [GitHub Private Vulnerability Reporting](https://github.com/MarcusKorinth/aionetx/security/advisories/new) or the email fallback in `SECURITY.md`. Do not file them as public issues.
+        - **Security vulnerabilities** must be reported privately via [GitHub Private Vulnerability Reporting](https://github.com/MarcusKorinth/aionetx/security/advisories/new). Do not file them as public issues.
         - Search [existing issues](https://github.com/MarcusKorinth/aionetx/issues?q=is%3Aissue) to see if the bug is already tracked.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,4 +8,4 @@ contact_links:
     about: For early-stage ideas that are not yet a concrete feature proposal, use Discussions. Open a feature request here only when you have a specific behavior change in mind.
   - name: Report a security vulnerability
     url: https://github.com/MarcusKorinth/aionetx/security/advisories/new
-    about: Do not file public issues for suspected vulnerabilities. Use GitHub Private Vulnerability Reporting, or see SECURITY.md for the email fallback.
+    about: Do not file public issues for suspected vulnerabilities. Use GitHub Private Vulnerability Reporting.


### PR DESCRIPTION
## Summary

Remove the email fallback wording from the public issue templates so security-reporting guidance matches `SECURITY.md`.

## Changes

- Point the security contact link at GitHub Private Vulnerability Reporting without promising an email fallback.
- Keep the bug-report warning that suspected vulnerabilities must not be filed as public issues.

## Related issue

Closes #36

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior (not needed; this is wording-only template alignment).
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible (not needed; this changes repository issue-template guidance, not package behavior).
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR (not needed; `SECURITY.md` already defines the supported private reporting path).
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate (not applicable).

Local verification:

- `python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 600 passed, 80 deselected
- `ruff check .` -> passed
- `ruff format --check .` -> 133 files already formatted
- `python -m mypy src` -> success
- `git diff --check` -> passed
- YAML parse check for `.github/ISSUE_TEMPLATE/config.yml` and `.github/ISSUE_TEMPLATE/bug_report.yml` -> passed
- Search for removed email-fallback wording in public security-reporting entry points -> no matches
