### PR TITLE
docs(dispatcher): document emit_and_wait stop drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Planned contents for the initial public alpha release (`0.1.0`).
 
 - README and reconnect heartbeat example wording now describe heartbeat bytes
   as advisory application-level probes, not built-in peer-health detection.
+- Dispatcher documentation now describes the `emit_and_wait()` stop/drop
+  `RuntimeError` path for completion-barrier callers.
 - TCP connections now wait for opened-event handlers before starting reads,
   preserving per-connection event ordering across dispatch modes.
 - TCP close and stop paths now defer handler-origin terminal events until the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,7 +291,15 @@ For `BACKGROUND` dispatch mode, runtime behavior is intentionally phase-aware:
 - steady-state: dispatcher worker delivers queued events
 - during dispatcher shutdown: newly emitted events may be dropped to guarantee deterministic stop completion
 
-This shutdown-phase drop behavior is a deliberate deterministic-shutdown tradeoff and not a hidden overload policy.
+This shutdown-phase drop behavior is a deliberate deterministic-shutdown
+tradeoff and not a hidden overload policy. The normal `emit()` path is
+best-effort at this boundary: once stop begins, a new BACKGROUND-mode event
+records a stop-phase drop and returns without handler execution. The
+completion-barrier path, `emit_and_wait()`, is stricter: if stop has already
+begun, or if stop drops a queued barrier event before handler execution, the
+waiter receives `RuntimeError` after the drop is recorded. This keeps
+completion-sensitive lifecycle publication from silently treating a discarded
+event as handled.
 Runtime diagnostics make this distinction explicit by separating:
 
 - overload drops (`DROP_OLDEST`/`DROP_NEWEST`)
@@ -318,4 +326,3 @@ Verification signals are interpreted in tiers:
 - semantic behavioral confidence (lifecycle/ordering/cancellation/reconnect) is prioritized over raw coverage alone
 
 The architecture goal is trustworthy runtime semantics, not process-heavy governance signaling.
-

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -315,6 +315,14 @@ class AsyncioEventDispatcher:
         This preserves normal ``emit()`` behavior for callers that only need
         queue acceptance, while giving lifecycle-sensitive transports a narrow
         internal hook for event-completion barriers.
+
+        In BACKGROUND mode, shutdown drop semantics intentionally differ from
+        ``emit()``. If dispatcher stop has already started, this records a
+        stop-phase drop and raises ``RuntimeError`` instead of returning. If a
+        queued barrier event is later dropped by stop before handler execution,
+        its waiter is completed with ``RuntimeError``. This prevents
+        completion-sensitive lifecycle publication from silently treating a
+        discarded event as handled.
         """
         self._emit_calls_total += 1
         if self._delivery.dispatch_mode == EventDispatchMode.INLINE:


### PR DESCRIPTION
## Summary

Document the dispatcher shutdown behavior for `emit_and_wait()` so completion-barrier callers can distinguish a discarded event from a handled event.

## Changes

- Clarify the `emit_and_wait()` docstring for stop-phase drops and queued barrier drops.
- Update the architecture dispatcher phase section to distinguish best-effort `emit()` from stricter `emit_and_wait()` behavior during stop.
- Add an unreleased changelog note for the documentation correction.

## Related issue

Closes #38

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior (docs-only change; existing dispatcher contract tests cover the documented behavior).
- [x] `CHANGELOG.md` `[Unreleased]` section updated for the user-visible documentation correction.
- [x] Relevant architecture docs and source docstring updated.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

- `.venv/bin/python -m pytest -q tests/unit/test_event_dispatcher_contract.py -k "emit_and_wait and dropped" --timeout=60` (2 passed, 67 deselected)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m mypy src`
- `.venv/bin/python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` (591 passed, 3 skipped, 78 deselected)
