### PR TITLE
docs(security): clarify tcp tls scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,8 @@ body:
 
         Before filing, please check:
         - **Early-stage ideas and "wouldn't it be cool if..."** belong in [Discussions → Ideas](https://github.com/MarcusKorinth/aionetx/discussions). Open a feature request issue only when you have a concrete behavior change in mind (you can describe inputs, outputs, and user-visible API).
-        - aionetx is a deliberately narrow **raw-byte asyncio transport library**. Features that belong in higher-layer frameworks (HTTP, messaging, TLS, service-mesh concerns) are generally out of scope — see the "What this library is not for" section in README.
+        - aionetx is a deliberately narrow **raw-byte asyncio transport library**. Features that belong in higher-layer frameworks (HTTP, messaging, authentication policy, certificate lifecycle management, DTLS, service-mesh concerns) are generally out of scope - see the "What this library is not for" section in README.
+        - Narrow TCP TLS transport wiring proposals can be in scope when they are limited to exposing `ssl.SSLContext` / `ssl=` support on TCP transports. Requests for authentication, authorization, certificate rotation, trust-store management, DTLS, service-mesh integration, or application security semantics belong above this library.
         - Search [existing issues](https://github.com/MarcusKorinth/aionetx/issues?q=is%3Aissue) to avoid duplicates.
 
   - type: textarea
@@ -62,5 +63,5 @@ body:
       options:
         - label: I have searched existing issues and discussions and confirmed this is not already proposed.
           required: true
-        - label: This proposal is about raw-byte transport behavior (lifecycle, events, backpressure, reconnect, multicast, typing) — not a higher-layer protocol concern.
+        - label: This proposal is about raw-byte transport behavior (lifecycle, events, backpressure, reconnect, multicast, typing, or narrow TCP `ssl=` wiring) - not a higher-layer protocol or security-policy concern.
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Planned contents for the initial public alpha release (`0.1.0`).
 ### Changed
 
 - require Python 3.11 or newer for the initial public alpha release
+- Documentation now distinguishes possible future narrow TCP `ssl=` /
+  `ssl.SSLContext` transport wiring from higher-layer authentication,
+  certificate-management, DTLS, service-mesh, and application-security scope.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Use `aionetx` when you want:
 - configurable dispatch mode and backpressure policy
 - optional reconnect for TCP clients and optional heartbeat for managed TCP roles
 
+Planned TCP TLS work, if added, is limited to narrow transport-level
+`ssl=` / `ssl.SSLContext` wiring. Authentication policy, certificate lifecycle
+management, DTLS, service-mesh integration, protocol security, and application
+semantics stay above this library.
+
 Canonical scope reference: `docs/architecture.md` (**Purpose and boundary**).
 
 ---
@@ -98,6 +103,8 @@ Canonical scope reference: `docs/architecture.md` (**Purpose and boundary**).
 - message framing or protocol boundaries for TCP
 - protocol parsers/state machines (MQTT/Modbus/HTTP/etc.)
 - serialization/deserialization
+- authentication policy, certificate lifecycle management, DTLS, or
+  service-mesh integration
 - business logic and domain workflows
 
 Those belong in higher layers. For detailed in-scope/out-of-scope and deferred-area criteria, see `docs/architecture.md` (**Purpose and boundary** + **Current limitations and explicit non-goals**).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,9 +134,12 @@ publishing, artifact attestations, and branch protection rules.
 
 The project's security assurance case is based on a deliberately narrow
 scope: `aionetx` provides transport primitives and lifecycle/event
-semantics, but does not provide authentication, authorization,
-encryption, message framing, payload validation, or application
-protocol security.
+semantics. The current release line does not provide built-in
+transport-layer encryption. A future TCP `ssl=` / `ssl.SSLContext`
+integration may expose asyncio's TLS transport wiring, but that would
+not make `aionetx` responsible for authentication policy, certificate
+lifecycle management, message framing, payload validation, or
+application protocol security.
 
 Security requirements:
 
@@ -163,7 +166,8 @@ Trust boundaries:
 Secure design arguments:
 
 - the transport-only boundary avoids mixing network I/O with application
-  protocol, authentication, authorization, or business logic
+  protocol, authentication policy, authorization, certificate lifecycle
+  management, or business logic
 - lifecycle state transitions are explicit and covered by automated
   tests, reducing ambiguity around startup, shutdown, and cleanup
 - event backpressure is configurable and bounded by default settings
@@ -194,13 +198,16 @@ The following are **not** treated as security vulnerabilities because
 they reflect deliberate architectural choices of a raw-byte transport
 library, not defects:
 
-- **No authentication, authorization, or transport-layer encryption.**
-  `aionetx` exposes raw TCP/UDP/multicast byte streams. Peer identity,
-  integrity, and confidentiality are the responsibility of the
-  application layer built on top (for example, TLS via
-  `asyncio.start_tls`, DTLS, or application-level signing). Reports of
-  the form "an attacker can send bytes to an open port" will be
-  closed as out of scope.
+- **No current built-in authentication, authorization, or
+  transport-layer encryption.** `aionetx` currently exposes raw
+  TCP/UDP/multicast byte streams. Missing TLS support in the current
+  raw-byte transports is not treated as a vulnerability by itself. A
+  narrowly scoped future TCP `ssl=` / `ssl.SSLContext` integration may
+  be considered as transport wiring, but peer identity policy,
+  certificate issuance, certificate rotation, trust-store management,
+  DTLS, service-mesh integration, and application-level signing remain
+  higher-layer responsibilities. Reports of the form "an attacker can
+  send bytes to an open port" will be closed as out of scope.
 - **Denial of service from malformed or flooding peer traffic on
   untrusted transports.** Backpressure, rate limiting, and peer-trust
   decisions are delegated to the user's event handler and higher-layer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,20 @@ Core principle: **hide plumbing, not semantics**.
 - protocol framing/parsing
 - serialization/deserialization
 - message schemas
+- authentication policy
+- certificate issuance, rotation, and trust-store management
+- DTLS and service-mesh integration
+- application security semantics
 - business/domain logic
 - application-level retry orchestration
 - hidden recovery/implicit lifecycle transitions
+
+### Possible future transport capability
+
+Narrow TCP TLS wiring can fit this boundary when it is limited to exposing
+asyncio-compatible `ssl=` / `ssl.SSLContext` transport settings. That possible
+future scope does not include authentication policy, certificate lifecycle
+management, DTLS, service-mesh integration, or application security semantics.
 
 ## 2) Lifecycle contract (authoritative)
 
@@ -233,6 +244,8 @@ Required discipline:
 
 - No built-in framing/parsing helpers in transport core
 - No protocol adapters/codecs in this repository
+- No authentication policy, certificate lifecycle management, DTLS, or
+  service-mesh integration
 - No hidden recovery automation beyond explicit settings
 - No application-level policy engine (retry/routing/business orchestration)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,14 +10,18 @@ items may be reprioritized, postponed, or removed.
 ### TLS support for TCP (`ssl=` parameter)
 
 `asyncio.open_connection()` and `asyncio.start_server()` already support
-transport-level TLS. The main open work is exposing that cleanly through
-`TcpClientSettings` / `TcpServerSettings` without compromising lifecycle,
-reconnect, or transport-boundary clarity.
+transport-level TLS. A possible future `aionetx` change is limited to exposing
+that capability cleanly through `TcpClientSettings` / `TcpServerSettings`, most
+likely by accepting an `ssl.SSLContext`-compatible `ssl=` setting without
+compromising lifecycle, reconnect, or transport-boundary clarity.
+
+This would be transport wiring only. It would not make `aionetx` responsible
+for authentication policy, certificate issuance or rotation, trust-store
+management, DTLS, service-mesh integration, or application security semantics.
 
 Open questions:
 
 - expose `ssl.SSLContext` directly or wrap it in a dedicated settings object
-- certificate reload strategy for long-lived servers
 - typing shape for optional TLS settings
 
 ### UDP sender auto-rebind evaluation


### PR DESCRIPTION
## Summary

Clarifies the public TLS scope boundary across the roadmap, feature-request template, security policy, README, and architecture docs.

## Changes

- Describes future TCP TLS work as narrow `ssl=` / `ssl.SSLContext` transport wiring, not a broader security framework.
- Allows narrowly scoped TCP TLS transport proposals in the feature-request template while keeping authentication, certificate lifecycle management, DTLS, service-mesh integration, and application security semantics out of scope.
- Keeps missing TLS support in the current raw-byte transports outside vulnerability-reporting scope by itself.
- Updates README, architecture, and changelog wording so they do not contradict that boundary.

## Related issue

Closes #40

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed). Docs-only wording change; no runtime behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.

Local verification:

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m mypy src`
- `.venv/bin/python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60`
