### PR TITLE
refactor: split asyncio implementation helpers

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import socket
-from collections.abc import Callable
-from dataclasses import dataclass
 from logging import Logger, LoggerAdapter
 from typing import cast
 
@@ -24,6 +22,13 @@ from aionetx.api.connection_lifecycle import ConnectionState
 from aionetx.api.connection_events import ConnectionClosedEvent, ConnectionOpenedEvent
 from aionetx.api.diagnostics import DispatcherRuntimeStats
 from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.implementations.asyncio_impl._datagram_receiver_state import (
+    DatagramRuntimeState as _DatagramRuntimeState,
+    DatagramStopExecutionState as _DatagramStopExecutionState,
+    DatagramStopProvenance as _DatagramStopProvenance,
+    DatagramStopSnapshot as _DatagramStopSnapshot,
+    SocketCleanup,
+)
 from aionetx.implementations.asyncio_impl.event_dispatcher import AsyncioEventDispatcher
 from aionetx.implementations.asyncio_impl.lifecycle_internal import LifecycleRole
 from aionetx.implementations.asyncio_impl.lifecycle_internal import (
@@ -36,99 +41,7 @@ from aionetx.implementations.asyncio_impl.runtime_utils import (
     await_task_completion_preserving_cancellation,
 )
 
-SocketCleanup = Callable[[socket.socket], None]
 _recv_fallback_warning_limiter = WarningRateLimiter(interval_seconds=300.0)
-
-
-@dataclass(slots=True)
-class _DatagramRuntimeState:
-    """Mutable runtime fields shared by datagram receiver implementations."""
-
-    running: bool = False
-    sock: socket.socket | None = None
-    task: asyncio.Task[None] | None = None
-    lifecycle_state: ComponentLifecycleState = ComponentLifecycleState.STOPPED
-    connection_state: ConnectionState = ConnectionState.CREATED
-    metadata: ConnectionMetadata | None = None
-    recv_fallback_warning_emitted: bool = False
-    stop_waiter: asyncio.Future[None] | None = None
-    stop_owner_task: asyncio.Task[object] | None = None
-    opening_event_task: asyncio.Task[object] | None = None
-    deferred_close_event: ConnectionClosedEvent | None = None
-    deferred_close_event_waiter: asyncio.Future[None] | None = None
-    deferred_close_publish_task: asyncio.Task[None] | None = None
-
-
-@dataclass(slots=True)
-class _DatagramStopSnapshot:
-    """
-    Detached stop plan consumed after leaving the state lock.
-
-    Attributes:
-        stop_dispatcher: Whether dispatcher shutdown must run after stop-path events.
-        should_transition_to_stopped: Whether STOPPED should be published after teardown.
-        should_emit_closed_event: Whether the stop path should publish ``ConnectionClosedEvent``.
-        previous_connection_state: Connection state to report in the close event.
-        task: Receive task detached from runtime state.
-        sock: Socket detached from runtime state.
-        stopping_event: Precomputed STOPPING lifecycle event, if any.
-        stop_waiter: Shared waiter for overlapping stop callers.
-        owns_stop: Whether this snapshot owns teardown and terminal publication.
-    """
-
-    stop_dispatcher: bool = False
-    should_transition_to_stopped: bool = False
-    should_emit_closed_event: bool = False
-    previous_connection_state: ConnectionState = ConnectionState.CREATED
-    task: asyncio.Task[None] | None = None
-    sock: socket.socket | None = None
-    cancel_task: bool = True
-    stopping_event: ComponentLifecycleChangedEvent | None = None
-    stop_waiter: asyncio.Future[None] | None = None
-    owns_stop: bool = False
-
-    @property
-    def waits_for_owner(self) -> bool:
-        """Whether this stop call should wait for an already-running stop path."""
-        return self.stop_waiter is not None and not self.owns_stop
-
-    @property
-    def is_noop(self) -> bool:
-        """Whether stop planning found the receiver already fully stopped."""
-        return (
-            self.stopping_event is None
-            and not self.should_transition_to_stopped
-            and not self.should_emit_closed_event
-            and self.task is None
-            and self.sock is None
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class _DatagramStopProvenance:
-    """Where the current stop request originated relative to active handlers."""
-
-    handler_originated: bool = False
-    inherited_handler_origin: bool = False
-    active_inline_handler: bool = False
-
-    @property
-    def has_handler_provenance(self) -> bool:
-        """Whether the caller is the active handler or inherited handler-origin context."""
-        return self.handler_originated or self.inherited_handler_origin
-
-    @property
-    def defers_terminal_events(self) -> bool:
-        """Whether terminal publication must wait for active handler work to unwind."""
-        return self.has_handler_provenance or self.active_inline_handler
-
-
-@dataclass(slots=True)
-class _DatagramStopExecutionState:
-    """Mutable cross-step state for a single stop execution."""
-
-    deferred_close_waiter: asyncio.Future[None] | None = None
-    stop_waiter_completion_deferred: bool = False
 
 
 class _AsyncioDatagramReceiverBase:

--- a/src/aionetx/implementations/asyncio_impl/_datagram_receiver_state.py
+++ b/src/aionetx/implementations/asyncio_impl/_datagram_receiver_state.py
@@ -1,0 +1,112 @@
+"""
+Internal datagram receiver runtime and stop-planning state.
+
+The receiver base owns behavior; this module owns the mutable state containers
+and stop-plan value objects shared by UDP and multicast receivers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_events import ConnectionClosedEvent
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.api.connection_metadata import ConnectionMetadata
+
+SocketCleanup = Callable[[socket.socket], None]
+
+
+@dataclass(slots=True)
+class DatagramRuntimeState:
+    """Mutable runtime fields shared by datagram receiver implementations."""
+
+    running: bool = False
+    sock: socket.socket | None = None
+    task: asyncio.Task[None] | None = None
+    lifecycle_state: ComponentLifecycleState = ComponentLifecycleState.STOPPED
+    connection_state: ConnectionState = ConnectionState.CREATED
+    metadata: ConnectionMetadata | None = None
+    recv_fallback_warning_emitted: bool = False
+    stop_waiter: asyncio.Future[None] | None = None
+    stop_owner_task: asyncio.Task[object] | None = None
+    opening_event_task: asyncio.Task[object] | None = None
+    deferred_close_event: ConnectionClosedEvent | None = None
+    deferred_close_event_waiter: asyncio.Future[None] | None = None
+    deferred_close_publish_task: asyncio.Task[None] | None = None
+
+
+@dataclass(slots=True)
+class DatagramStopSnapshot:
+    """
+    Detached stop plan consumed after leaving the state lock.
+
+    Attributes:
+        stop_dispatcher: Whether dispatcher shutdown must run after stop-path events.
+        should_transition_to_stopped: Whether STOPPED should be published after teardown.
+        should_emit_closed_event: Whether the stop path should publish ``ConnectionClosedEvent``.
+        previous_connection_state: Connection state to report in the close event.
+        task: Receive task detached from runtime state.
+        sock: Socket detached from runtime state.
+        stopping_event: Precomputed STOPPING lifecycle event, if any.
+        stop_waiter: Shared waiter for overlapping stop callers.
+        owns_stop: Whether this snapshot owns teardown and terminal publication.
+    """
+
+    stop_dispatcher: bool = False
+    should_transition_to_stopped: bool = False
+    should_emit_closed_event: bool = False
+    previous_connection_state: ConnectionState = ConnectionState.CREATED
+    task: asyncio.Task[None] | None = None
+    sock: socket.socket | None = None
+    cancel_task: bool = True
+    stopping_event: ComponentLifecycleChangedEvent | None = None
+    stop_waiter: asyncio.Future[None] | None = None
+    owns_stop: bool = False
+
+    @property
+    def waits_for_owner(self) -> bool:
+        """Whether this stop call should wait for an already-running stop path."""
+        return self.stop_waiter is not None and not self.owns_stop
+
+    @property
+    def is_noop(self) -> bool:
+        """Whether stop planning found the receiver already fully stopped."""
+        return (
+            self.stopping_event is None
+            and not self.should_transition_to_stopped
+            and not self.should_emit_closed_event
+            and self.task is None
+            and self.sock is None
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DatagramStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    inherited_handler_origin: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def has_handler_provenance(self) -> bool:
+        """Whether the caller is the active handler or inherited handler-origin context."""
+        return self.handler_originated or self.inherited_handler_origin
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.has_handler_provenance or self.active_inline_handler
+
+
+@dataclass(slots=True)
+class DatagramStopExecutionState:
+    """Mutable cross-step state for a single stop execution."""
+
+    deferred_close_waiter: asyncio.Future[None] | None = None
+    stop_waiter_completion_deferred: bool = False

--- a/src/aionetx/implementations/asyncio_impl/_event_dispatcher_policy.py
+++ b/src/aionetx/implementations/asyncio_impl/_event_dispatcher_policy.py
@@ -1,0 +1,56 @@
+"""
+Internal event-dispatcher stop policy.
+
+The policy is intentionally small: it validates the callback contract used by
+handler-failure shutdown without owning any dispatcher lifecycle behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DispatcherStopPolicy:
+    """
+    Callback policy used by ``STOP_COMPONENT`` handler-failure behavior.
+
+    Attributes:
+        enabled: Whether handler failures may request component shutdown.
+        callback: Awaitable shutdown callback invoked when the policy is active.
+    """
+
+    enabled: bool
+    callback: Callable[[], Awaitable[None]] | None = None
+
+    @classmethod
+    def disabled(cls) -> DispatcherStopPolicy:
+        """Build a policy that never requests component shutdown."""
+        return cls(enabled=False, callback=None)
+
+    @classmethod
+    def stop_component(cls, callback: Callable[[], Awaitable[None]]) -> DispatcherStopPolicy:
+        """
+        Build a policy that stops the owning component on handler failure.
+
+        Args:
+            callback: Awaitable shutdown callback owned by the component.
+
+        Returns:
+            DispatcherStopPolicy: Enabled stop policy bound to ``callback``.
+        """
+        return cls(enabled=True, callback=callback)
+
+    def validate(self) -> None:
+        """
+        Validate the internal consistency of the configured stop policy.
+
+        Raises:
+            ValueError: If ``enabled`` and ``callback`` disagree about whether
+                shutdown is supported.
+        """
+        if self.enabled and self.callback is None:
+            raise ValueError("DispatcherStopPolicy with enabled=True requires a callback.")
+        if not self.enabled and self.callback is not None:
+            raise ValueError("DispatcherStopPolicy with enabled=False must not provide a callback.")

--- a/src/aionetx/implementations/asyncio_impl/_event_dispatcher_queue.py
+++ b/src/aionetx/implementations/asyncio_impl/_event_dispatcher_queue.py
@@ -1,0 +1,43 @@
+"""
+Internal event-dispatcher queue item helpers.
+
+This module owns queue item shape and waiter completion semantics so the
+dispatcher can keep queue policy decisions separate from waiter bookkeeping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from aionetx.api.network_event import NetworkEvent
+
+
+@dataclass(slots=True)
+class QueuedEvent:
+    """One pending event plus optional emit-and-wait completion barrier."""
+
+    event: NetworkEvent
+    handled: asyncio.Future[None] | None = None
+    drop_on_backpressure: bool = True
+
+
+def complete_queued_event(queued_event: QueuedEvent) -> None:
+    """Wake an emit-and-wait caller after successful handling or intentional drop."""
+    handled = queued_event.handled
+    if handled is not None and not handled.done():
+        handled.set_result(None)
+
+
+def drop_queued_event(queued_event: QueuedEvent, *, reason: str) -> None:
+    """Wake an emit-and-wait caller when its barrier event was dropped."""
+    handled = queued_event.handled
+    if handled is not None and not handled.done():
+        handled.set_exception(RuntimeError(f"Queued event was {reason}."))
+
+
+def fail_queued_event(queued_event: QueuedEvent, error: BaseException) -> None:
+    """Wake an emit-and-wait caller when worker delivery fails unexpectedly."""
+    handled = queued_event.handled
+    if handled is not None and not handled.done():
+        handled.set_exception(error)

--- a/src/aionetx/implementations/asyncio_impl/_tcp_client_stop_state.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_client_stop_state.py
@@ -1,0 +1,55 @@
+"""
+Internal TCP client stop-planning state.
+
+The client owns lifecycle behavior; these value objects hold the detached stop
+plan and execution flags built while coordinating concurrent stop callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+
+
+@dataclass(slots=True)
+class TcpClientStopPlan:
+    """Detached stop-time decisions made while holding the client state lock."""
+
+    stop_waiter: asyncio.Future[None] | None = None
+    owns_stop: bool = False
+    stopping_event: ComponentLifecycleChangedEvent | None = None
+    supervisor_task: asyncio.Task[None] | None = None
+    should_stop_dispatcher: bool = False
+    await_supervisor_completion_only: bool = False
+    skip_await_supervisor: bool = False
+    stop_called_from_supervisor: bool = False
+    cancel_supervisor_after_local_cleanup: bool = False
+
+    @property
+    def waits_for_owner(self) -> bool:
+        """Whether this stop call should wait for an already-running stop path."""
+        return self.stop_waiter is not None and not self.owns_stop
+
+
+@dataclass(frozen=True, slots=True)
+class TcpClientStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.handler_originated or self.active_inline_handler
+
+
+@dataclass(slots=True)
+class TcpClientStopExecutionState:
+    """Mutable cross-step state for a single TCP client stop execution."""
+
+    deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
+    stop_waiter_completion_deferred: bool = False
+    raise_cancel_after_stop_waiter: bool = False

--- a/src/aionetx/implementations/asyncio_impl/_tcp_server_stop_state.py
+++ b/src/aionetx/implementations/asyncio_impl/_tcp_server_stop_state.py
@@ -1,0 +1,56 @@
+"""
+Internal TCP server stop-planning state.
+
+The server owns lifecycle and resource teardown behavior; these value objects
+hold the stop plan and execution flags shared across stop helper phases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from aionetx.api.component_lifecycle_changed_event import ComponentLifecycleChangedEvent
+from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
+from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
+
+
+@dataclass(slots=True)
+class TcpServerStopPlan:
+    """Detached stop-time decisions made while holding the server state lock."""
+
+    stop_waiter: asyncio.Future[None] | None = None
+    owns_stop: bool = False
+    server: asyncio.AbstractServer | None = None
+    stopping_event: ComponentLifecycleChangedEvent | None = None
+    should_transition_to_stopped: bool = False
+    heartbeat_senders: tuple[AsyncioHeartbeatSender, ...] = ()
+    connections: tuple[AsyncioTcpConnection, ...] = ()
+
+    @property
+    def waits_for_owner(self) -> bool:
+        """Whether this stop call should wait for an already-running stop path."""
+        return self.stop_waiter is not None and not self.owns_stop
+
+
+@dataclass(frozen=True, slots=True)
+class TcpServerStopProvenance:
+    """Where the current stop request originated relative to active handlers."""
+
+    handler_originated: bool = False
+    active_inline_handler: bool = False
+
+    @property
+    def defers_terminal_events(self) -> bool:
+        """Whether terminal publication must wait for active handler work to unwind."""
+        return self.handler_originated or self.active_inline_handler
+
+
+@dataclass(slots=True)
+class TcpServerStopExecutionState:
+    """Mutable cross-step state for a single TCP server stop execution."""
+
+    deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
+    stop_waiter_completion_deferred: bool = False
+    dispatcher_stopped_from_handler_origin: bool = False
+    raise_cancel_after_stop_waiter: bool = False

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -11,7 +11,6 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from types import TracebackType
 from typing import cast
 
@@ -35,6 +34,11 @@ from aionetx.implementations.asyncio_impl._tcp_client_runtime import (
     _ClientRuntimeAccessors,
     _ClientRuntimeState,
 )
+from aionetx.implementations.asyncio_impl._tcp_client_stop_state import (
+    TcpClientStopExecutionState as _TcpClientStopExecutionState,
+    TcpClientStopPlan as _TcpClientStopPlan,
+    TcpClientStopProvenance as _TcpClientStopProvenance,
+)
 from aionetx.implementations.asyncio_impl.identifier_utils import (
     tcp_client_component_id,
 )
@@ -56,48 +60,6 @@ from aionetx.implementations.asyncio_impl.tcp_client_supervision import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class _TcpClientStopPlan:
-    """Detached stop-time decisions made while holding the client state lock."""
-
-    stop_waiter: asyncio.Future[None] | None = None
-    owns_stop: bool = False
-    stopping_event: ComponentLifecycleChangedEvent | None = None
-    supervisor_task: asyncio.Task[None] | None = None
-    should_stop_dispatcher: bool = False
-    await_supervisor_completion_only: bool = False
-    skip_await_supervisor: bool = False
-    stop_called_from_supervisor: bool = False
-    cancel_supervisor_after_local_cleanup: bool = False
-
-    @property
-    def waits_for_owner(self) -> bool:
-        """Whether this stop call should wait for an already-running stop path."""
-        return self.stop_waiter is not None and not self.owns_stop
-
-
-@dataclass(frozen=True, slots=True)
-class _TcpClientStopProvenance:
-    """Where the current stop request originated relative to active handlers."""
-
-    handler_originated: bool = False
-    active_inline_handler: bool = False
-
-    @property
-    def defers_terminal_events(self) -> bool:
-        """Whether terminal publication must wait for active handler work to unwind."""
-        return self.handler_originated or self.active_inline_handler
-
-
-@dataclass(slots=True)
-class _TcpClientStopExecutionState:
-    """Mutable cross-step state for a single TCP client stop execution."""
-
-    deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
-    stop_waiter_completion_deferred: bool = False
-    raise_cancel_after_stop_waiter: bool = False
 
 
 class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -12,7 +12,6 @@ import contextlib
 import logging
 import socket
 from collections.abc import Awaitable
-from dataclasses import dataclass
 from types import TracebackType
 from typing import cast
 
@@ -31,6 +30,11 @@ from aionetx.implementations.asyncio_impl._tcp_server_helpers import (
     start_server_heartbeat_if_needed,
     stop_server_heartbeat_senders,
     wait_until_server_running,
+)
+from aionetx.implementations.asyncio_impl._tcp_server_stop_state import (
+    TcpServerStopExecutionState as _TcpServerStopExecutionState,
+    TcpServerStopPlan as _TcpServerStopPlan,
+    TcpServerStopProvenance as _TcpServerStopProvenance,
 )
 from aionetx.implementations.asyncio_impl.asyncio_heartbeat_sender import AsyncioHeartbeatSender
 from aionetx.implementations.asyncio_impl.asyncio_tcp_connection import AsyncioTcpConnection
@@ -54,47 +58,6 @@ from aionetx.implementations.asyncio_impl.runtime_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class _TcpServerStopPlan:
-    """Detached stop-time decisions made while holding the server state lock."""
-
-    stop_waiter: asyncio.Future[None] | None = None
-    owns_stop: bool = False
-    server: asyncio.AbstractServer | None = None
-    stopping_event: ComponentLifecycleChangedEvent | None = None
-    should_transition_to_stopped: bool = False
-    heartbeat_senders: tuple[AsyncioHeartbeatSender, ...] = ()
-    connections: tuple[AsyncioTcpConnection, ...] = ()
-
-    @property
-    def waits_for_owner(self) -> bool:
-        """Whether this stop call should wait for an already-running stop path."""
-        return self.stop_waiter is not None and not self.owns_stop
-
-
-@dataclass(frozen=True, slots=True)
-class _TcpServerStopProvenance:
-    """Where the current stop request originated relative to active handlers."""
-
-    handler_originated: bool = False
-    active_inline_handler: bool = False
-
-    @property
-    def defers_terminal_events(self) -> bool:
-        """Whether terminal publication must wait for active handler work to unwind."""
-        return self.handler_originated or self.active_inline_handler
-
-
-@dataclass(slots=True)
-class _TcpServerStopExecutionState:
-    """Mutable cross-step state for a single TCP server stop execution."""
-
-    deferred_close_waiters: tuple[asyncio.Future[None], ...] = ()
-    stop_waiter_completion_deferred: bool = False
-    dispatcher_stopped_from_handler_origin: bool = False
-    raise_cancel_after_stop_waiter: bool = False
 
 
 class AsyncioTcpServer(TcpServerProtocol):

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -13,7 +13,6 @@ import logging
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import cast
 
 from aionetx.api.bytes_received_event import BytesReceivedEvent
@@ -28,6 +27,15 @@ from aionetx.api.handler_failure_policy_stop_event import HandlerFailurePolicySt
 from aionetx.api.network_error_event import NetworkErrorEvent
 from aionetx.api.network_event import NetworkEvent
 from aionetx.api.network_event_handler_protocol import NetworkEventHandlerProtocol
+from aionetx.implementations.asyncio_impl._event_dispatcher_policy import (
+    DispatcherStopPolicy,
+)
+from aionetx.implementations.asyncio_impl._event_dispatcher_queue import (
+    QueuedEvent,
+    complete_queued_event,
+    drop_queued_event,
+    fail_queued_event,
+)
 from aionetx.implementations.asyncio_impl.runtime_utils import (
     WarningRateLimiter,
     is_task_being_cancelled,
@@ -52,58 +60,6 @@ _handler_origin_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = (
 
 class _HandlerCancelledError(RuntimeError):
     """Exception wrapper used when a handler raises CancelledError itself."""
-
-
-@dataclass(slots=True)
-class _QueuedEvent:
-    event: NetworkEvent
-    handled: asyncio.Future[None] | None = None
-    drop_on_backpressure: bool = True
-
-
-@dataclass(frozen=True, slots=True)
-class DispatcherStopPolicy:
-    """
-    Callback policy used by ``STOP_COMPONENT`` handler-failure behavior.
-
-    Attributes:
-        enabled: Whether handler failures may request component shutdown.
-        callback: Awaitable shutdown callback invoked when the policy is active.
-    """
-
-    enabled: bool
-    callback: Callable[[], Awaitable[None]] | None = None
-
-    @classmethod
-    def disabled(cls) -> DispatcherStopPolicy:
-        """Build a policy that never requests component shutdown."""
-        return cls(enabled=False, callback=None)
-
-    @classmethod
-    def stop_component(cls, callback: Callable[[], Awaitable[None]]) -> DispatcherStopPolicy:
-        """
-        Build a policy that stops the owning component on handler failure.
-
-        Args:
-            callback: Awaitable shutdown callback owned by the component.
-
-        Returns:
-            DispatcherStopPolicy: Enabled stop policy bound to ``callback``.
-        """
-        return cls(enabled=True, callback=callback)
-
-    def validate(self) -> None:
-        """
-        Validate the internal consistency of the configured stop policy.
-
-        Raises:
-            ValueError: If ``enabled`` and ``callback`` disagree about whether
-                shutdown is supported.
-        """
-        if self.enabled and self.callback is None:
-            raise ValueError("DispatcherStopPolicy with enabled=True requires a callback.")
-        if not self.enabled and self.callback is not None:
-            raise ValueError("DispatcherStopPolicy with enabled=False must not provide a callback.")
 
 
 class AsyncioEventDispatcher:
@@ -155,7 +111,7 @@ class AsyncioEventDispatcher:
         self._stop_policy_enabled = stop_policy.enabled
         self._stop_component_callback = stop_policy.callback
         self._worker_task: asyncio.Task[None] | None = None
-        self._queue: deque[_QueuedEvent] = deque()
+        self._queue: deque[QueuedEvent] = deque()
         self._queue_not_empty = asyncio.Condition()
         self._queue_not_full = asyncio.Condition()
         self._stopping = False
@@ -259,7 +215,7 @@ class AsyncioEventDispatcher:
         if current_task is worker_task or self._is_in_stop_await_bypass_context():
             self._dropped_stop_phase_total += len(self._queue)
             for queued_event in self._queue:
-                self._drop_queued_event(queued_event, reason="dropped because dispatcher stopped")
+                drop_queued_event(queued_event, reason="dropped because dispatcher stopped")
             self._queue.clear()
             return
         _ = await asyncio.shield(cast(Awaitable[object], worker_task))
@@ -304,7 +260,7 @@ class AsyncioEventDispatcher:
             self._inline_fallback_total += 1
             await self._emit_now(event)
             return
-        await self._enqueue(_QueuedEvent(event=event))
+        await self._enqueue(QueuedEvent(event=event))
 
     async def emit_and_wait(
         self, event: NetworkEvent, *, drop_on_backpressure: bool = True
@@ -348,7 +304,7 @@ class AsyncioEventDispatcher:
         loop = current_task.get_loop() if current_task is not None else worker_task.get_loop()
         handled = loop.create_future()
         await self._enqueue(
-            _QueuedEvent(
+            QueuedEvent(
                 event=event,
                 handled=handled,
                 drop_on_backpressure=drop_on_backpressure,
@@ -373,8 +329,8 @@ class AsyncioEventDispatcher:
 
     async def drop_queued_events_for_resource(self, resource_id: str) -> int:
         """Drop queued payload events for one resource and release any waiters."""
-        dropped_events: list[_QueuedEvent] = []
-        kept_events: deque[_QueuedEvent] = deque()
+        dropped_events: list[QueuedEvent] = []
+        kept_events: deque[QueuedEvent] = deque()
         for queued_event in self._queue:
             if (
                 isinstance(queued_event.event, BytesReceivedEvent)
@@ -388,14 +344,12 @@ class AsyncioEventDispatcher:
         self._queue = kept_events
         self._dropped_stop_phase_total += len(dropped_events)
         for queued_event in dropped_events:
-            self._drop_queued_event(
-                queued_event, reason=f"dropped because resource {resource_id} closed"
-            )
+            drop_queued_event(queued_event, reason=f"dropped because resource {resource_id} closed")
         async with self._queue_not_full:
             self._queue_not_full.notify_all()
         return len(dropped_events)
 
-    async def _enqueue(self, queued_event: _QueuedEvent) -> None:
+    async def _enqueue(self, queued_event: QueuedEvent) -> None:
         """
         Queue one event for background delivery under backpressure rules.
 
@@ -407,9 +361,7 @@ class AsyncioEventDispatcher:
             async with self._queue_not_full:
                 if not self._accepting_background_events():
                     self._record_stop_phase_drop(event)
-                    self._drop_queued_event(
-                        queued_event, reason="dropped because dispatcher stopped"
-                    )
+                    drop_queued_event(queued_event, reason="dropped because dispatcher stopped")
                     return
                 if len(self._queue) < self._delivery.max_pending_events:
                     self._queue.append(queued_event)
@@ -435,11 +387,11 @@ class AsyncioEventDispatcher:
                             continue
                         self._dropped_backpressure_newest_total += 1
                         self._warn_backpressure_drop(policy=EventBackpressurePolicy.DROP_NEWEST)
-                        self._drop_queued_event(queued_event, reason="dropped by backpressure")
+                        drop_queued_event(queued_event, reason="dropped by backpressure")
                         return
                     dropped_event = self._queue[droppable_index]
                     del self._queue[droppable_index]
-                    self._drop_queued_event(dropped_event, reason="dropped by backpressure")
+                    drop_queued_event(dropped_event, reason="dropped by backpressure")
                     self._queue.append(queued_event)
                     self._dropped_backpressure_oldest_total += 1
                     self._enqueued_total += 1
@@ -451,7 +403,7 @@ class AsyncioEventDispatcher:
                     continue
                 self._dropped_backpressure_newest_total += 1
                 self._warn_backpressure_drop(policy=policy)
-                self._drop_queued_event(queued_event, reason="dropped by backpressure")
+                drop_queued_event(queued_event, reason="dropped by backpressure")
                 return
 
         async with self._queue_not_empty:
@@ -709,7 +661,7 @@ class AsyncioEventDispatcher:
         termination_error: BaseException | None = None
         try:
             while True:
-                queued_event: _QueuedEvent | None = None
+                queued_event: QueuedEvent | None = None
                 async with self._queue_not_empty:
                     while not self._queue and not self._stopping:
                         await self._queue_not_empty.wait()
@@ -724,36 +676,18 @@ class AsyncioEventDispatcher:
                         await self._emit_now(queued_event.event)
                     except BaseException as delivery_error:
                         termination_error = delivery_error
-                        self._fail_queued_event(queued_event, delivery_error)
+                        fail_queued_event(queued_event, delivery_error)
                         raise
                     else:
-                        self._complete_queued_event(queued_event)
+                        complete_queued_event(queued_event)
         finally:
             if self._queue:
                 pending_error = termination_error or asyncio.CancelledError()
                 for queued_event in self._queue:
-                    self._fail_queued_event(queued_event, pending_error)
+                    fail_queued_event(queued_event, pending_error)
                 self._queue.clear()
             if self._worker_task is current_task:
                 self._worker_task = None
-
-    def _complete_queued_event(self, queued_event: _QueuedEvent) -> None:
-        """Wake an emit-and-wait caller after successful handling or intentional drop."""
-        handled = queued_event.handled
-        if handled is not None and not handled.done():
-            handled.set_result(None)
-
-    def _drop_queued_event(self, queued_event: _QueuedEvent, *, reason: str) -> None:
-        """Wake an emit-and-wait caller when its barrier event was dropped."""
-        handled = queued_event.handled
-        if handled is not None and not handled.done():
-            handled.set_exception(RuntimeError(f"Queued event was {reason}."))
-
-    def _fail_queued_event(self, queued_event: _QueuedEvent, error: BaseException) -> None:
-        """Wake an emit-and-wait caller when worker delivery fails unexpectedly."""
-        handled = queued_event.handled
-        if handled is not None and not handled.done():
-            handled.set_exception(error)
 
     async def _emit_now(self, event: NetworkEvent) -> None:
         """Deliver one event to the handler and route failures through policy handling.

--- a/tests/unit/test_datagram_receiver_state.py
+++ b/tests/unit/test_datagram_receiver_state.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+
+from aionetx.api.component_lifecycle_state import ComponentLifecycleState
+from aionetx.api.connection_lifecycle import ConnectionState
+from aionetx.implementations.asyncio_impl._datagram_receiver_state import (
+    DatagramRuntimeState,
+    DatagramStopProvenance,
+    DatagramStopSnapshot,
+)
+
+
+def test_datagram_runtime_state_defaults_to_stopped_created() -> None:
+    state = DatagramRuntimeState()
+
+    assert state.running is False
+    assert state.sock is None
+    assert state.task is None
+    assert state.lifecycle_state is ComponentLifecycleState.STOPPED
+    assert state.connection_state is ConnectionState.CREATED
+    assert state.metadata is None
+
+
+def test_datagram_stop_snapshot_identifies_noop_stop_plan() -> None:
+    snapshot = DatagramStopSnapshot()
+
+    assert snapshot.is_noop is True
+    assert snapshot.waits_for_owner is False
+
+
+def test_datagram_stop_snapshot_identifies_non_owner_wait() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        waiter = loop.create_future()
+        snapshot = DatagramStopSnapshot(stop_waiter=waiter, owns_stop=False)
+
+        assert snapshot.waits_for_owner is True
+        assert snapshot.is_noop is True
+    finally:
+        loop.close()
+
+
+def test_datagram_stop_snapshot_owner_does_not_wait_for_itself() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        waiter = loop.create_future()
+        snapshot = DatagramStopSnapshot(stop_waiter=waiter, owns_stop=True)
+
+        assert snapshot.waits_for_owner is False
+    finally:
+        loop.close()
+
+
+def test_datagram_stop_provenance_reports_deferred_terminal_events() -> None:
+    assert DatagramStopProvenance().defers_terminal_events is False
+    assert DatagramStopProvenance(handler_originated=True).has_handler_provenance is True
+    assert DatagramStopProvenance(handler_originated=True).defers_terminal_events is True
+    assert DatagramStopProvenance(inherited_handler_origin=True).has_handler_provenance is True
+    assert DatagramStopProvenance(inherited_handler_origin=True).defers_terminal_events is True
+    assert DatagramStopProvenance(active_inline_handler=True).has_handler_provenance is False
+    assert DatagramStopProvenance(active_inline_handler=True).defers_terminal_events is True

--- a/tests/unit/test_event_dispatcher_queue.py
+++ b/tests/unit/test_event_dispatcher_queue.py
@@ -48,5 +48,5 @@ async def test_fail_queued_event_releases_waiter_with_original_error() -> None:
     fail_queued_event(queued_event, error)
 
     with pytest.raises(RuntimeError, match="worker stopped") as exc_info:
-        await handled
+        handled.result()
     assert exc_info.value is error

--- a/tests/unit/test_event_dispatcher_queue.py
+++ b/tests/unit/test_event_dispatcher_queue.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aionetx.api.network_error_event import NetworkErrorEvent
+from aionetx.implementations.asyncio_impl._event_dispatcher_queue import (
+    QueuedEvent,
+    complete_queued_event,
+    drop_queued_event,
+    fail_queued_event,
+)
+
+
+def _event() -> NetworkErrorEvent:
+    return NetworkErrorEvent(resource_id="dispatcher", error=RuntimeError("boom"))
+
+
+@pytest.mark.asyncio
+async def test_complete_queued_event_releases_waiter_successfully() -> None:
+    handled = asyncio.get_running_loop().create_future()
+    queued_event = QueuedEvent(event=_event(), handled=handled)
+
+    complete_queued_event(queued_event)
+
+    assert handled.done()
+    assert await handled is None
+
+
+@pytest.mark.asyncio
+async def test_drop_queued_event_releases_waiter_with_reason() -> None:
+    handled = asyncio.get_running_loop().create_future()
+    queued_event = QueuedEvent(event=_event(), handled=handled)
+
+    drop_queued_event(queued_event, reason="dropped by backpressure")
+
+    with pytest.raises(RuntimeError, match="Queued event was dropped by backpressure\\."):
+        await handled
+
+
+@pytest.mark.asyncio
+async def test_fail_queued_event_releases_waiter_with_original_error() -> None:
+    handled = asyncio.get_running_loop().create_future()
+    queued_event = QueuedEvent(event=_event(), handled=handled)
+    error = RuntimeError("worker stopped")
+
+    fail_queued_event(queued_event, error)
+
+    with pytest.raises(RuntimeError, match="worker stopped") as exc_info:
+        await handled
+    assert exc_info.value is error

--- a/tests/unit/test_event_dispatcher_queue.py
+++ b/tests/unit/test_event_dispatcher_queue.py
@@ -36,7 +36,7 @@ async def test_drop_queued_event_releases_waiter_with_reason() -> None:
     drop_queued_event(queued_event, reason="dropped by backpressure")
 
     with pytest.raises(RuntimeError, match="Queued event was dropped by backpressure\\."):
-        await handled
+        handled.result()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tcp_stop_state.py
+++ b/tests/unit/test_tcp_stop_state.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+
+from aionetx.implementations.asyncio_impl._tcp_client_stop_state import (
+    TcpClientStopExecutionState,
+    TcpClientStopPlan,
+    TcpClientStopProvenance,
+)
+from aionetx.implementations.asyncio_impl._tcp_server_stop_state import (
+    TcpServerStopExecutionState,
+    TcpServerStopPlan,
+    TcpServerStopProvenance,
+)
+
+
+def test_tcp_client_stop_plan_waits_only_for_non_owner_waiter() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        waiter = loop.create_future()
+
+        assert TcpClientStopPlan().waits_for_owner is False
+        assert TcpClientStopPlan(stop_waiter=waiter, owns_stop=False).waits_for_owner is True
+        assert TcpClientStopPlan(stop_waiter=waiter, owns_stop=True).waits_for_owner is False
+    finally:
+        loop.close()
+
+
+def test_tcp_client_stop_provenance_defers_for_handler_or_inline_origin() -> None:
+    assert TcpClientStopProvenance().defers_terminal_events is False
+    assert TcpClientStopProvenance(handler_originated=True).defers_terminal_events is True
+    assert TcpClientStopProvenance(active_inline_handler=True).defers_terminal_events is True
+
+
+def test_tcp_client_stop_execution_state_defaults_to_inline_completion() -> None:
+    state = TcpClientStopExecutionState()
+
+    assert state.deferred_close_waiters == ()
+    assert state.stop_waiter_completion_deferred is False
+    assert state.raise_cancel_after_stop_waiter is False
+
+
+def test_tcp_server_stop_plan_waits_only_for_non_owner_waiter() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        waiter = loop.create_future()
+
+        assert TcpServerStopPlan().waits_for_owner is False
+        assert TcpServerStopPlan(stop_waiter=waiter, owns_stop=False).waits_for_owner is True
+        assert TcpServerStopPlan(stop_waiter=waiter, owns_stop=True).waits_for_owner is False
+    finally:
+        loop.close()
+
+
+def test_tcp_server_stop_provenance_defers_for_handler_or_inline_origin() -> None:
+    assert TcpServerStopProvenance().defers_terminal_events is False
+    assert TcpServerStopProvenance(handler_originated=True).defers_terminal_events is True
+    assert TcpServerStopProvenance(active_inline_handler=True).defers_terminal_events is True
+
+
+def test_tcp_server_stop_execution_state_defaults_to_inline_completion() -> None:
+    state = TcpServerStopExecutionState()
+
+    assert state.deferred_close_waiters == ()
+    assert state.stop_waiter_completion_deferred is False
+    assert state.dispatcher_stopped_from_handler_origin is False
+    assert state.raise_cancel_after_stop_waiter is False


### PR DESCRIPTION
## Summary

Split role-owned internal state/helper objects out of large asyncio implementation modules so dispatcher, datagram receiver, TCP client, and TCP server files have less embedded stop/queue bookkeeping while preserving behavior.

## Changes

- Moved dispatcher stop policy and queued-event waiter handling into focused internal modules.
- Moved datagram receiver runtime and stop-plan state into a shared UDP/multicast internal module.
- Moved TCP client and server stop-plan state into transport-specific internal modules.
- Added characterization tests for extracted internal state/helper semantics.

## Related issue

Closes #41

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed).
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. Not user-visible; internal refactor only.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR. No public contract change.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. No public API change.

Local verification:

- `.venv/bin/python -m pytest -q`: 683 passed, 3 skipped
- `.venv/bin/python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60`: 605 passed, 3 skipped, 78 deselected
- `.venv/bin/python -m ruff check .`: All checks passed
- `.venv/bin/python -m ruff format --check .`: 141 files already formatted
- `.venv/bin/python -m mypy`: Success: no issues found in 67 source files
