### PR TITLE
refactor(dispatcher): wait for handler context without polling

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -579,8 +579,7 @@ class _AsyncioDatagramReceiverBase:
         async def _complete() -> None:
             first_error: BaseException | None = None
             try:
-                while self._event_dispatcher.has_active_handler_context():
-                    await asyncio.sleep(0)
+                await self._event_dispatcher.wait_for_handler_context()
                 with self._event_dispatcher.inline_delivery_context():
                     try:
                         await self._publish_stopping_transition(snapshot)
@@ -745,8 +744,7 @@ class _AsyncioDatagramReceiverBase:
         """Publish a deferred close once the handler-origin context has unwound."""
         current_task = asyncio.current_task()
         try:
-            while self._event_dispatcher.has_active_handler_context():
-                await asyncio.sleep(0)
+            await self._event_dispatcher.wait_for_handler_context()
             await self._publish_deferred_close_after_opened_event()
         except (Exception, asyncio.CancelledError) as error:
             async with self._state_lock:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_client.py
@@ -711,8 +711,7 @@ class AsyncioTcpClient(_ClientRuntimeAccessors, TcpClientProtocol):
 
         async def _complete() -> None:
             try:
-                while self._event_dispatcher.has_active_handler_context():
-                    await asyncio.sleep(0)
+                await self._event_dispatcher.wait_for_handler_context()
                 with self._event_dispatcher.inline_delivery_context():
                     await self._emit_lifecycle_event(stopping_event)
                     if deferred_close_waiters:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -590,8 +590,7 @@ class AsyncioTcpConnection(ConnectionProtocol):
         """Publish a deferred close once active connection handlers have unwound."""
         current_task = asyncio.current_task()
         try:
-            while self._event_dispatcher.has_active_handler_context(self._connection_id):
-                await asyncio.sleep(0)
+            await self._event_dispatcher.wait_for_handler_context(self._connection_id)
             await self._publish_deferred_close_after_opened_event()
         except (Exception, asyncio.CancelledError) as error:
             async with self._close_lock:

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -542,8 +542,7 @@ class AsyncioTcpServer(TcpServerProtocol):
 
         async def _complete() -> None:
             try:
-                while self._event_dispatcher.has_active_handler_context():
-                    await asyncio.sleep(0)
+                await self._event_dispatcher.wait_for_handler_context()
                 with self._event_dispatcher.inline_delivery_context():
                     await self._emit_lifecycle_event(stopping_event)
                     if deferred_close_waiters:

--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -129,6 +129,7 @@ class AsyncioEventDispatcher:
         self._active_handler_origin_owner_tasks: dict[int, int | None] = {}
         self._active_handler_origin_child_provenance_tokens: set[int] = set()
         self._next_handler_origin_token = 0
+        self._handler_context_changed_waiter: asyncio.Future[None] | None = None
         self._active_stop_await_bypass_tokens: set[int] = set()
         self._active_stop_await_bypass_owner_tasks: dict[int, int] = {}
         self._next_stop_await_bypass_token = 0
@@ -519,6 +520,25 @@ class AsyncioEventDispatcher:
             for active_resource_id in self._active_handler_origin_resources.values()
         )
 
+    async def wait_for_handler_context(self, resource_id: str | None = None) -> None:
+        """Wait until no active handler-origin barrier remains."""
+        while self.has_active_handler_context(resource_id):
+            waiter = self._handler_context_changed_waiter
+            if waiter is None or waiter.done():
+                waiter = asyncio.get_running_loop().create_future()
+                self._handler_context_changed_waiter = waiter
+            await asyncio.shield(waiter)
+
+    def _notify_handler_context_changed(self) -> None:
+        """Wake tasks waiting for active handler-origin barriers to clear."""
+        waiter = self._handler_context_changed_waiter
+        if waiter is None:
+            return
+        if not waiter.done():
+            waiter.set_result(None)
+        if self._handler_context_changed_waiter is waiter:
+            self._handler_context_changed_waiter = None
+
     def has_active_handler_origin(self) -> bool:
         """Return whether this dispatcher currently has an active handler-origin barrier."""
         return self.has_active_handler_context()
@@ -560,6 +580,7 @@ class AsyncioEventDispatcher:
             self._active_handler_origin_resources.pop(origin_token, None)
             self._active_handler_origin_owner_tasks.pop(origin_token, None)
             self._active_handler_origin_child_provenance_tokens.discard(origin_token)
+            self._notify_handler_context_changed()
             _handler_dispatch_context.reset(reset_token)
             _handler_origin_context.reset(origin_reset_token)
 
@@ -585,6 +606,7 @@ class AsyncioEventDispatcher:
             self._active_handler_origin_resources.pop(origin_token, None)
             self._active_handler_origin_owner_tasks.pop(origin_token, None)
             self._active_handler_origin_child_provenance_tokens.discard(origin_token)
+            self._notify_handler_context_changed()
             _handler_origin_context.reset(origin_reset_token)
 
     def _is_in_stop_await_bypass_context(self) -> bool:

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -272,6 +272,46 @@ async def test_handler_origin_context_expires_when_handler_returns() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_handler_context_blocks_until_matching_handler_returns() -> None:
+    handler_started = asyncio.Event()
+    allow_handler_to_finish = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            del event
+            handler_started.set()
+            await allow_handler_to_finish.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    emit_task: asyncio.Task[None] | None = None
+    wait_task: asyncio.Task[None] | None = None
+    try:
+        emit_task = asyncio.create_task(dispatcher.emit_and_wait(_opened("blocked")))
+        await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+
+        wait_task = asyncio.create_task(dispatcher.wait_for_handler_context("blocked"))
+        await asyncio.sleep(0)
+        assert wait_task.done() is False
+
+        allow_handler_to_finish.set()
+        await asyncio.wait_for(emit_task, timeout=1.0)
+        await asyncio.wait_for(wait_task, timeout=1.0)
+    finally:
+        allow_handler_to_finish.set()
+        for task in (wait_task, emit_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=1.0)
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
 async def test_handler_origin_context_is_not_inherited_by_child_tasks() -> None:
     child_ready = asyncio.Event()
     allow_child_to_check = asyncio.Event()


### PR DESCRIPTION
## Summary

Replace deferred terminal-publication polling with an explicit dispatcher waiter for active handler context.

## Changes

- Add `AsyncioEventDispatcher.wait_for_handler_context()` as the shared internal barrier for handler-origin unwind.
- Use the barrier from deferred TCP client/server stop publication, TCP connection close publication, and datagram receiver stop/close publication.
- Add regression coverage showing the waiter blocks behind a long-running background handler and completes when that handler returns.

## Related issue

Closes #52

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible. This refactor preserves public behavior, so no changelog entry is needed.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR. No public contract changed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate. No public API changed.

Local verification:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_event_dispatcher_contract.py::test_wait_for_handler_context_blocks_until_matching_handler_returns` -> 1 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_event_dispatcher_contract.py tests/unit/test_asyncio_tcp_connection.py tests/unit/test_asyncio_tcp_client_internals.py tests/unit/test_asyncio_tcp_server.py tests/unit/test_asyncio_udp_transport.py --timeout=60` -> 244 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60` -> 611 passed, 3 skipped, 78 deselected
- `.venv/bin/ruff check .` -> All checks passed
- `.venv/bin/ruff format --check .` -> 142 files already formatted
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m mypy src` -> Success: no issues found in 67 source files
- `rg -n "while .*has_active_handler_context|await asyncio\.sleep\(0\)" src/aionetx/implementations/asyncio_impl` -> only the dispatcher waiter predicate loop remains
