### PR TITLE
ci(release): extract reusable setup phases

### DIFF
--- a/.github/actions/capture-build-epoch/action.yml
+++ b/.github/actions/capture-build-epoch/action.yml
@@ -1,0 +1,17 @@
+name: Capture deterministic build timestamp
+description: Capture the current commit timestamp for reproducible release builds.
+
+outputs:
+  epoch:
+    description: Unix timestamp for the current release commit.
+    value: ${{ steps.capture.outputs.epoch }}
+
+runs:
+  using: composite
+  steps:
+    - name: Capture commit timestamp
+      id: capture
+      shell: bash
+      run: |
+        epoch="$(git log -1 --format=%ct "$GITHUB_SHA")"
+        echo "epoch=${epoch}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/install-dev-dependencies/action.yml
+++ b/.github/actions/install-dev-dependencies/action.yml
@@ -1,0 +1,30 @@
+name: Install project development dependencies
+description: Install the editable development package for release trust gates.
+
+inputs:
+  upgrade-pip:
+    description: Upgrade pip before installing editable development dependencies.
+    required: false
+    default: "true"
+  use-python-module:
+    description: Install through python -m pip instead of the pip executable.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Upgrade pip
+      if: ${{ inputs.upgrade-pip == 'true' }}
+      shell: bash
+      run: python -m pip install --upgrade pip
+
+    - name: Install project development dependencies with pip
+      if: ${{ inputs.use-python-module != 'true' }}
+      shell: bash
+      run: pip install -e .[dev]
+
+    - name: Install project development dependencies with python -m pip
+      if: ${{ inputs.use-python-module == 'true' }}
+      shell: bash
+      run: python -m pip install -e .[dev]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,7 @@ jobs:
 
       - name: Capture deterministic build timestamp
         id: build_epoch
-        shell: bash
-        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/capture-build-epoch
 
       - name: Install pinned build tools
         run: |
@@ -116,9 +115,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run API symbol stability test
         run: pytest tests/unit/test_api_symbol_sources.py -k "api_symbol" --tb=short -q
 
@@ -133,9 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Ruff lint
         run: ruff check .
       - name: Ruff format check
@@ -155,9 +150,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Mypy
         run: mypy src
 
@@ -176,9 +169,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run required behavior test slice
         run: pytest -q -m "not multicast and not slow and not integration" --timeout=60
 
@@ -196,9 +187,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run behavior_critical adversarial lifecycle tests
         run: pytest -m behavior_critical --tb=short -q --timeout=60
 
@@ -217,9 +206,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run integration tests on supported bounds (exclude environment-sensitive multicast)
         run: pytest -q -m "integration and not multicast and not slow" --timeout=60
 
@@ -237,9 +224,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run required integration smoke slice on intermediate supported versions
         run: pytest -q -m "integration_smoke and not multicast and not slow" --timeout=60
 
@@ -257,9 +242,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Validate required integration semantic shard contract
         run: python scripts/ci/assert_integration_semantic_shard.py
       - name: Run required integration semantic shard on intermediate supported versions
@@ -277,9 +260,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run required reliability smoke tests
         run: pytest -q -m "reliability_smoke" --timeout=60
 
@@ -294,9 +275,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run required deterministic multicast contract
         run: pytest -q tests/unit/test_asyncio_multicast_receiver_startup_cleanup.py::test_multicast_start_failure_cleans_dispatcher_and_state --timeout=60
 
@@ -312,9 +291,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
       - name: Run required test suite with coverage
         run: pytest -q -m "not multicast and not slow" --cov=aionetx --cov-report=term-missing --cov-fail-under=85 --timeout=60
 
@@ -333,8 +310,7 @@ jobs:
         run: python -m pip install --require-hashes -r requirements/ci-build-tools.txt
       - name: Capture deterministic build timestamp
         id: build_epoch
-        shell: bash
-        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/capture-build-epoch
       - name: First wheel build
         env:
           SOURCE_DATE_EPOCH: ${{ steps.build_epoch.outputs.epoch }}
@@ -396,8 +372,7 @@ jobs:
 
       - name: Capture deterministic build timestamp
         id: build_epoch
-        shell: bash
-        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/capture-build-epoch
       - name: Skip CodeQL release gate for non-tag runs
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: echo "Skipping CodeQL release gate because this run is not publishing a tagged release ref."
@@ -424,13 +399,16 @@ jobs:
 
       - name: Capture deterministic build timestamp
         id: build_epoch
-        shell: bash
-        run: echo "epoch=$(git log -1 --format=%ct "${GITHUB_SHA}")" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/capture-build-epoch
+
+      - name: Install pinned build tools
+        run: python -m pip install --require-hashes -r requirements/ci-build-tools.txt
 
       - name: Install dependencies
-        run: |
-          python -m pip install --require-hashes -r requirements/ci-build-tools.txt
-          python -m pip install -e .[dev]
+        uses: ./.github/actions/install-dev-dependencies
+        with:
+          upgrade-pip: "false"
+          use-python-module: "true"
 
       - name: Build artifacts from source
         env:

--- a/tests/unit/test_release_workflow_structure.py
+++ b/tests/unit/test_release_workflow_structure.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+BUILD_EPOCH_ACTION_PATH = REPO_ROOT / ".github" / "actions" / "capture-build-epoch" / "action.yml"
+DEV_INSTALL_ACTION_PATH = (
+    REPO_ROOT / ".github" / "actions" / "install-dev-dependencies" / "action.yml"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _job_block(workflow_text: str, job_name: str) -> str:
+    header = f"  {job_name}:\n"
+    start = workflow_text.index(header)
+    body_start = start + len(header)
+    next_job = re.search(r"^  [A-Za-z0-9_-]+:\n", workflow_text[body_start:], re.MULTILINE)
+    end = body_start + next_job.start() if next_job is not None else len(workflow_text)
+    return workflow_text[start:end]
+
+
+def _action_step_block(action_text: str, step_name: str) -> str:
+    header = f"    - name: {step_name}\n"
+    start = action_text.index(header)
+    body_start = start + len(header)
+    next_step = action_text.find("\n    - name: ", body_start)
+    end = next_step if next_step != -1 else len(action_text)
+    return action_text[start:end]
+
+
+def _assert_local_actions_run_after_checkout(job_block: str) -> None:
+    local_action_uses = [
+        match.start() for match in re.finditer(r"uses: \./\.github/actions/", job_block)
+    ]
+    if not local_action_uses:
+        return
+
+    checkout_position = job_block.find("uses: actions/checkout@")
+    assert checkout_position != -1
+    assert all(checkout_position < action_position for action_position in local_action_uses)
+
+
+def test_release_reuses_setup_phases_without_hiding_publish_steps() -> None:
+    workflow_text = _read(RELEASE_WORKFLOW_PATH)
+
+    jobs_that_capture_build_epoch = {
+        "cross_platform_portability_smoke",
+        "verify_reproducible_build",
+        "release_codeql_gate",
+        "verify_and_build",
+    }
+    jobs_that_install_dev_dependencies = {
+        "api_symbol_stability",
+        "ruff_checks",
+        "mypy_supported_bounds",
+        "required_behavior_tests",
+        "behavior_critical_tests",
+        "integration_tests_supported_bounds",
+        "integration_smoke_tests_intermediate_versions",
+        "integration_semantic_tests_intermediate_versions",
+        "reliability_smoke_tests",
+        "multicast_contract_required",
+        "required_suite_with_coverage",
+        "verify_and_build",
+    }
+
+    for job_name in jobs_that_capture_build_epoch:
+        job = _job_block(workflow_text, job_name)
+        assert "uses: ./.github/actions/capture-build-epoch" in job
+        _assert_local_actions_run_after_checkout(job)
+
+    for job_name in jobs_that_install_dev_dependencies:
+        job = _job_block(workflow_text, job_name)
+        assert "uses: ./.github/actions/install-dev-dependencies" in job
+        _assert_local_actions_run_after_checkout(job)
+
+    verify_and_build = _job_block(workflow_text, "verify_and_build")
+    assert 'upgrade-pip: "false"' in verify_and_build
+    assert 'use-python-module: "true"' in verify_and_build
+    assert "git log -1 --format=%ct" not in workflow_text
+    assert "pip install -e .[dev]" not in workflow_text
+
+    assert "uses: pypa/gh-action-pypi-publish@" in _job_block(workflow_text, "publish")
+    assert "uses: pypa/gh-action-pypi-publish@" in _job_block(workflow_text, "publish_testpypi")
+    assert "uses: softprops/action-gh-release@" in _job_block(workflow_text, "github_release")
+    assert "uses: softprops/action-gh-release@" in _job_block(
+        workflow_text,
+        "github_release_dry_run",
+    )
+    assert "uses: anchore/sbom-action@" in _job_block(workflow_text, "generate_sbom")
+    assert "uses: actions/attest-build-provenance@" in _job_block(
+        workflow_text,
+        "attest_provenance",
+    )
+
+
+def test_capture_build_epoch_action_has_narrow_release_contract() -> None:
+    action_text = _read(BUILD_EPOCH_ACTION_PATH)
+
+    assert "name: Capture deterministic build timestamp" in action_text
+    assert "description: Capture the current commit timestamp for reproducible release builds." in (
+        action_text
+    )
+    assert "epoch:" in action_text
+    assert 'git log -1 --format=%ct "$GITHUB_SHA"' in action_text
+    assert 'echo "epoch=${epoch}" >> "$GITHUB_OUTPUT"' in action_text
+
+
+def test_install_dev_dependencies_action_has_narrow_release_contract() -> None:
+    action_text = _read(DEV_INSTALL_ACTION_PATH)
+    default_install_step = _action_step_block(
+        action_text,
+        "Install project development dependencies with pip",
+    )
+    python_module_install_step = _action_step_block(
+        action_text,
+        "Install project development dependencies with python -m pip",
+    )
+
+    assert "name: Install project development dependencies" in action_text
+    assert "description: Install the editable development package for release trust gates." in (
+        action_text
+    )
+    assert "python -m pip install --upgrade pip" in action_text
+    assert "run: pip install -e .[dev]" in default_install_step
+    assert "python -m pip install -e .[dev]" not in default_install_step
+    assert "run: python -m pip install -e .[dev]" in python_module_install_step
+    assert "requirements/ci-build-tools.txt" not in action_text


### PR DESCRIPTION
## Summary

Extracts two narrow release setup phases into local composite actions so repeated setup is easier to review while release-critical jobs remain visible in `.github/workflows/release.yml`.

## Changes

- Add `.github/actions/capture-build-epoch` for reproducible build timestamp capture.
- Add `.github/actions/install-dev-dependencies` for editable development dependency installation while preserving the original command forms.
- Replace repeated release workflow setup blocks with those actions, leaving publish, TestPyPI, SBOM, attestation, GitHub release, permissions, environments, artifact names, and job dependencies in the entry workflow.
- Add static tests for checkout-before-local-action ordering, setup command forms, and visible publish/SBOM/attestation steps.

## Related issue

Closes #53

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] No documented public contract changed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] No public API changes.

Local verification:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60` - 614 passed, 3 skipped, 78 deselected
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m mypy src`