### PR TITLE
fix(tcp): join active server stop waiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Planned contents for the initial public alpha release (`0.1.0`).
 - TCP client/server stop paths and connection close paths now preserve deferred
   terminal publication when an external caller is cancelled while an inline
   bytes handler is still active.
+- TCP server `stop()` now joins an active handler-origin deferred stop waiter
+  even after lifecycle state has reached `STOPPED`, so overlapping callers do
+  not return before terminal publication and dispatcher shutdown finish.
 - UDP receivers now preserve deferred stop publication when stop originates
   from a handler or when an external stop caller is cancelled.
 - UDP and multicast receivers now abort startup when a STARTING lifecycle

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -256,10 +256,7 @@ class AsyncioTcpServer(TcpServerProtocol):
         plan = _TcpServerStopPlan()
         async with self._state_lock:
             self._logger.debug("Stopping TCP server.")
-            if (
-                self._lifecycle_state == ComponentLifecycleState.STOPPING
-                and self._stop_waiter is not None
-            ):
+            if self._stop_waiter is not None:
                 plan.stop_waiter = self._stop_waiter
                 return plan
 

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -577,6 +577,75 @@ async def test_server_handler_origin_stop_drops_queued_background_bytes() -> Non
 
 
 @pytest.mark.asyncio
+async def test_server_late_external_stop_joins_deferred_handler_stop_waiter() -> None:
+    class StopServerAndHoldHandler:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.bytes_seen = asyncio.Event()
+            self.stop_returned = asyncio.Event()
+            self.release_handler = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if not isinstance(event, BytesReceivedEvent):
+                return
+            self.bytes_seen.set()
+            try:
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+                self.stop_returned.set()
+                await self.release_handler.wait()
+            except (Exception, asyncio.CancelledError) as error:
+                self.error = error
+                self.release_handler.set()
+
+    handler = StopServerAndHoldHandler()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=12348,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.server = server
+    server._lifecycle_state = ComponentLifecycleState.RUNNING  # type: ignore[attr-defined]
+    await server._event_dispatcher.start()  # type: ignore[attr-defined]
+    external_stop: asyncio.Task[None] | None = None
+    try:
+        await server._event_dispatcher.emit(  # type: ignore[attr-defined]
+            BytesReceivedEvent(resource_id="server:late-overlap-stop:1", data=b"stop")
+        )
+        await asyncio.wait_for(handler.bytes_seen.wait(), timeout=1.0)
+        await asyncio.wait_for(handler.stop_returned.wait(), timeout=1.0)
+        assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+
+        stop_waiter = server._stop_waiter  # type: ignore[attr-defined]
+        assert stop_waiter is not None
+        assert stop_waiter.done() is False
+
+        external_stop = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+
+        assert external_stop.done() is False
+
+        handler.release_handler.set()
+        await asyncio.wait_for(external_stop, timeout=1.0)
+        assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    finally:
+        handler.release_handler.set()
+        if external_stop is not None and not external_stop.done():
+            external_stop.cancel()
+            await drain_awaitable_ignoring_cancelled(external_stop)
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(server.stop(), timeout=1.0)
+
+    assert handler.error is None
+
+
+@pytest.mark.asyncio
 async def test_server_spawned_handler_stop_preserves_close_events_for_all_connections() -> None:
     class SpawnStopFromFirstBytes:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Make overlapping TCP server `stop()` callers join an active stop waiter even after the lifecycle state has already reached `STOPPED` during handler-origin deferred terminal publication.

Closes #80

## Problems and approach

1. Problem: a handler-origin server stop can apply `STOPPED` before deferred terminal lifecycle publication and dispatcher shutdown finish.
   Approach: `_plan_stop()` now returns the active `_stop_waiter` whenever one exists, matching the TCP client and datagram receiver stop-planning shape.

2. Problem: a late external `stop()` could previously miss that waiter and return early.
   Approach: add a deterministic background-dispatch regression that holds the handler open, verifies the external stop remains pending, then releases the handler and confirms dispatcher shutdown is complete.

## Changes

- Make TCP server stop planning join an existing stop waiter before checking lifecycle state.
- Add regression coverage for the late overlap window during handler-origin deferred stop completion.
- Document the fixed stop completion behavior in `CHANGELOG.md`.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated for the user-visible stop behavior fix.
- [x] No documented public contract changed beyond enforcing the existing lifecycle invariant.
- [x] `ruff check .` passes locally.
- [x] `ruff format --check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

```text
.venv/bin/python -m pytest -q tests/unit/test_asyncio_tcp_server.py::test_server_late_external_stop_joins_deferred_handler_stop_waiter --timeout=60
1 passed in 0.10s

.venv/bin/python -m pytest -q tests/unit/test_asyncio_tcp_server.py --timeout=60
40 passed in 0.35s

PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60
615 passed, 3 skipped, 78 deselected in 2.22s

.venv/bin/ruff check .
All checks passed!

.venv/bin/ruff format --check .
143 files already formatted

.venv/bin/python -m mypy src
Success: no issues found in 67 source files
```
