### PR TITLE
fix(tcp): make server STARTING a startup barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Planned contents for the initial public alpha release (`0.1.0`).
 - TCP server `stop()` now joins an active handler-origin deferred stop waiter
   even after lifecycle state has reached `STOPPED`, so overlapping callers do
   not return before terminal publication and dispatcher shutdown finish.
+- TCP servers now suppress stale `RUNNING` lifecycle publication when a
+  `STARTING` lifecycle handler stops startup.
 - UDP receivers now preserve deferred stop publication when stop originates
   from a handler or when an external stop caller is cancelled.
 - UDP and multicast receivers now abort startup when a STARTING lifecycle

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_server.py
@@ -155,10 +155,23 @@ class AsyncioTcpServer(TcpServerProtocol):
             lifecycle_event = self._apply_lifecycle_state(ComponentLifecycleState.STARTING)
             self._notify_status_changed()
         try:
-            await self._emit_lifecycle_event(lifecycle_event)
+            if lifecycle_event is not None:
+                await self._event_dispatcher.emit_and_wait(
+                    lifecycle_event, drop_on_backpressure=False
+                )
         except (Exception, asyncio.CancelledError):
             await self._rollback_failed_startup()
             raise
+        startup_was_stopped = False
+        stop_waiter: asyncio.Future[None] | None = None
+        async with self._state_lock:
+            if self._lifecycle_state != ComponentLifecycleState.STARTING:
+                startup_was_stopped = True
+                stop_waiter = self._stop_waiter
+        if startup_was_stopped:
+            if stop_waiter is not None:
+                await asyncio.shield(stop_waiter)
+            return
         server: asyncio.AbstractServer | None = None
         listening_socket: socket.socket | None = None
         try:

--- a/tests/unit/test_asyncio_tcp_server.py
+++ b/tests/unit/test_asyncio_tcp_server.py
@@ -930,6 +930,59 @@ async def test_server_lifecycle_events_preserve_start_stop_order(recording_event
 
 
 @pytest.mark.asyncio
+async def test_server_starting_handler_stop_aborts_startup_before_running() -> None:
+    class StopOnStartingHandler:
+        def __init__(self) -> None:
+            self.server: AsyncioTcpServer | None = None
+            self.events: list[ComponentLifecycleChangedEvent] = []
+            self.stopped_seen = asyncio.Event()
+            self.error: BaseException | None = None
+
+        async def on_event(self, event) -> None:
+            if not isinstance(event, ComponentLifecycleChangedEvent):
+                return
+            self.events.append(event)
+            if event.current == ComponentLifecycleState.STOPPED:
+                self.stopped_seen.set()
+            if event.current != ComponentLifecycleState.STARTING:
+                return
+            try:
+                if self.server is None:
+                    raise AssertionError("server reference was not attached")
+                await self.server.stop()
+            except (Exception, asyncio.CancelledError) as error:
+                self.error = error
+
+    handler = StopOnStartingHandler()
+    port = _unused_tcp_port()
+    server = AsyncioTcpServer(
+        settings=TcpServerSettings(
+            host="127.0.0.1",
+            port=port,
+            max_connections=64,
+            event_delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        ),
+        event_handler=handler,
+    )
+    handler.server = server
+
+    await server.start()
+    await asyncio.wait_for(handler.stopped_seen.wait(), timeout=1.0)
+
+    assert handler.error is None
+    assert server.lifecycle_state == ComponentLifecycleState.STOPPED
+    assert server._server is None  # type: ignore[attr-defined]
+    assert server._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+    assert [event.current for event in handler.events] == [
+        ComponentLifecycleState.STARTING,
+        ComponentLifecycleState.STOPPING,
+        ComponentLifecycleState.STOPPED,
+    ]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", port))
+
+
+@pytest.mark.asyncio
 async def test_server_start_rolls_back_state_and_allows_retry(
     recording_event_handler, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Make TCP server startup wait for `STARTING` lifecycle handlers before continuing, so a handler-originated stop cannot be followed by stale `RUNNING` publication.

## Changes

- Publish TCP server `STARTING` through the dispatcher completion barrier.
- Re-check lifecycle after `STARTING` handlers complete and join any in-flight stop before returning.
- Add a deterministic regression test for the `BACKGROUND` dispatch path where a `STARTING` handler stops startup before `RUNNING`.
- Document the user-visible fix in `CHANGELOG.md`.

## Related issue

Closes #82
Closes #83

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior (or explicitly explain why none are needed).
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.

Verification:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_asyncio_tcp_server.py::test_server_starting_handler_stop_aborts_startup_before_running tests/unit/test_asyncio_tcp_server.py::test_server_late_external_stop_joins_deferred_handler_stop_waiter tests/unit/test_asyncio_tcp_server.py::test_server_start_rolls_back_state_and_allows_retry tests/unit/test_asyncio_tcp_server.py::test_server_start_cancellation_rolls_back_state_and_closes_listener tests/unit/test_asyncio_tcp_server.py::test_server_start_cancellation_finishes_dispatcher_stop_when_cancelled_again --timeout=60`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m mypy src`
- `git diff --check`
