### PR TITLE
fix(lifecycle): retrieve deferred close waiter exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,6 @@ Planned contents for the initial public alpha release (`0.1.0`).
   handler stops the receiver, preventing stale socket or running state.
 - TCP clients now suppress stale RUNNING lifecycle publication when a
   STARTING lifecycle handler stops the client.
+- TCP and datagram deferred-close failure paths now retrieve deferred waiter
+  exceptions before re-raising, avoiding asyncio unretrieved-future shutdown
+  warnings while preserving the original close-publication error.

--- a/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
+++ b/src/aionetx/implementations/asyncio_impl/_asyncio_datagram_receiver_base.py
@@ -800,6 +800,8 @@ class _AsyncioDatagramReceiverBase:
         except (Exception, asyncio.CancelledError) as error:
             if deferred_waiter is not None and not deferred_waiter.done():
                 deferred_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    deferred_waiter.exception()
             raise
         else:
             if deferred_waiter is not None and not deferred_waiter.done():

--- a/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
+++ b/src/aionetx/implementations/asyncio_impl/asyncio_tcp_connection.py
@@ -641,6 +641,8 @@ class AsyncioTcpConnection(ConnectionProtocol):
         except (Exception, asyncio.CancelledError) as error:
             if deferred_waiter is not None and not deferred_waiter.done():
                 deferred_waiter.set_exception(error)
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    deferred_waiter.exception()
             raise
         else:
             if deferred_waiter is not None and not deferred_waiter.done():

--- a/tests/unit/test_asyncio_tcp_connection.py
+++ b/tests/unit/test_asyncio_tcp_connection.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import gc
 import logging
 
 import pytest
@@ -1514,6 +1515,70 @@ async def test_tcp_connection_repeated_external_close_cancellation_preserves_def
     assert handler.error is None
     assert connection.state == ConnectionState.CLOSED
     assert writer.closed
+
+
+@pytest.mark.asyncio
+async def test_tcp_connection_deferred_close_failure_retrieves_waiter_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NoopHandler:
+        async def on_event(self, event) -> None:
+            return None
+
+    loop = asyncio.get_running_loop()
+    exception_contexts: list[dict[str, object]] = []
+    previous_exception_handler = loop.get_exception_handler()
+
+    def record_exception_context(_loop, context: dict[str, object]) -> None:
+        exception_contexts.append(context)
+
+    dispatcher = AsyncioEventDispatcher(
+        event_handler=NoopHandler(),
+        delivery=EventDeliverySettings(dispatch_mode=EventDispatchMode.INLINE),
+        logger=logging.getLogger("test"),
+    )
+    connection = AsyncioTcpConnection(
+        "client:deferred-close-failure",
+        ConnectionRole.CLIENT,
+        asyncio.StreamReader(),
+        _DummyWriter(),  # type: ignore[arg-type]
+        dispatcher,
+        4096,
+    )
+    waiter = loop.create_future()
+    connection._close_event_deferred_until_opened_event_completes = True  # type: ignore[attr-defined]
+    connection._deferred_close_event_waiter = waiter  # type: ignore[attr-defined]
+    close_publication_error = RuntimeError("tcp-close-publication-failed")
+
+    async def fail_finalize_close() -> None:
+        raise close_publication_error
+
+    monkeypatch.setattr(connection, "_finalize_close", fail_finalize_close)
+
+    loop.set_exception_handler(record_exception_context)
+    caught_error: RuntimeError | None = None
+    try:
+        try:
+            await connection._publish_deferred_close_after_opened_event()  # type: ignore[attr-defined]
+        except RuntimeError as error:
+            caught_error = error
+
+        assert caught_error is close_publication_error
+        assert connection._deferred_close_event_waiter is None  # type: ignore[attr-defined]
+
+        if caught_error is not None:
+            caught_error.__traceback__ = None
+        del caught_error
+        del waiter
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    assert not any(
+        context.get("message") == "Future exception was never retrieved"
+        for context in exception_contexts
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asyncio_udp_transport.py
+++ b/tests/unit/test_asyncio_udp_transport.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import gc
 import logging
 import socket
 
@@ -402,6 +403,60 @@ async def test_udp_receiver_cancelled_external_stop_during_opened_barrier_publis
     assert any(isinstance(event, ConnectionClosedEvent) for event in handler.events)
     assert receiver.lifecycle_state == ComponentLifecycleState.STOPPED
     assert receiver._event_dispatcher.is_running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_udp_receiver_deferred_close_failure_retrieves_waiter_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = asyncio.get_running_loop()
+    exception_contexts: list[dict[str, object]] = []
+    previous_exception_handler = loop.get_exception_handler()
+
+    def record_exception_context(_loop, context: dict[str, object]) -> None:
+        exception_contexts.append(context)
+
+    receiver = AsyncioUdpReceiver(
+        settings=UdpReceiverSettings(host="127.0.0.1", port=_get_unused_udp_port()),
+        event_handler=NoopHandler(),
+    )
+    waiter = loop.create_future()
+    receiver._runtime.deferred_close_event = ConnectionClosedEvent(  # type: ignore[attr-defined]
+        resource_id="udp:deferred-close-failure",
+        previous_state=ConnectionState.CONNECTED,
+    )
+    receiver._runtime.deferred_close_event_waiter = waiter  # type: ignore[attr-defined]
+    close_publication_error = RuntimeError("udp-close-publication-failed")
+
+    async def fail_emit(event) -> None:
+        raise close_publication_error
+
+    monkeypatch.setattr(receiver._event_dispatcher, "emit", fail_emit)  # type: ignore[attr-defined]
+
+    loop.set_exception_handler(record_exception_context)
+    caught_error: RuntimeError | None = None
+    try:
+        try:
+            await receiver._publish_deferred_close_after_opened_event()  # type: ignore[attr-defined]
+        except RuntimeError as error:
+            caught_error = error
+
+        assert caught_error is close_publication_error
+        assert receiver._runtime.deferred_close_event_waiter is None  # type: ignore[attr-defined]
+
+        if caught_error is not None:
+            caught_error.__traceback__ = None
+        del caught_error
+        del waiter
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    assert not any(
+        context.get("message") == "Future exception was never retrieved"
+        for context in exception_contexts
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Retrieve deferred-close waiter exceptions in TCP and datagram close-publication failure paths before re-raising the original error.

## Problems and approach

1. Problem: Deferred close publication can set the propagated error on an internal waiter and then re-raise the same error.
   Approach: After setting the waiter exception, read it back with `exception()` so asyncio does not later report an unretrieved future exception.

2. Problem: The warning path was not covered directly for the TCP connection and UDP receiver helpers.
   Approach: Add focused regression tests that force close-publication failure, preserve the original raised error, and assert the event loop does not receive `Future exception was never retrieved`.

## Changes

- Retrieve deferred waiter exceptions in `AsyncioTcpConnection` opened-event deferred close failure handling.
- Retrieve deferred waiter exceptions in datagram receiver opened-event deferred close failure handling.
- Add TCP and UDP unit regressions for the loop exception-handler warning path.
- Document the fix in `CHANGELOG.md`.

## Related issue

Closes #85

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated.
- [x] No documented public contract changes were needed.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

- `.venv/bin/python -m pytest -q tests/unit/test_asyncio_tcp_connection.py::test_tcp_connection_deferred_close_failure_retrieves_waiter_exception tests/unit/test_asyncio_udp_transport.py::test_udp_receiver_deferred_close_failure_retrieves_waiter_exception --timeout=60` -> 2 passed
- `.venv/bin/python -m pytest -q tests/unit/test_asyncio_tcp_connection.py --timeout=60` -> 62 passed
- `.venv/bin/python -m pytest -q tests/unit/test_asyncio_udp_transport.py --timeout=60` -> 42 passed
- `.venv/bin/python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` -> 618 passed, 3 skipped, 78 deselected
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/ruff format --check .` -> 143 files already formatted
- `.venv/bin/python -m mypy src` -> success