### PR TITLE
test(ci): fail on unretrieved asyncio futures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ aionetx = ["py.typed"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterator
+import gc
 from inspect import iscoroutinefunction
 import socket
+from typing import Any
 
 import pytest
+import pytest_asyncio
 
 from aionetx.testing import AwaitableRecordingEventHandler, RecordingEventHandler
+
+pytest_plugins = ("pytester",)
+
+_UNRETRIEVED_FUTURE_EXCEPTION_MESSAGE = "Future exception was never retrieved"
 
 
 @pytest.fixture
@@ -30,6 +39,63 @@ def _is_async_test(item: pytest.Item) -> bool:
     return item.get_closest_marker("asyncio") is not None or (
         test_function is not None and iscoroutinefunction(test_function)
     )
+
+
+def _is_unretrieved_future_exception_context(context: dict[str, Any]) -> bool:
+    return context.get("message") == _UNRETRIEVED_FUTURE_EXCEPTION_MESSAGE and isinstance(
+        context.get("future"), asyncio.Future
+    )
+
+
+def _format_unretrieved_future_exception_context(context: dict[str, Any]) -> str:
+    future = context.get("future")
+    exception = context.get("exception")
+    return f"{_UNRETRIEVED_FUTURE_EXCEPTION_MESSAGE}: {exception!r} from {future!r}"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fail_on_unretrieved_asyncio_future_diagnostics(
+    request: pytest.FixtureRequest,
+) -> AsyncIterator[None]:
+    if not _is_async_test(request.node):
+        yield
+        return
+
+    loop = asyncio.get_running_loop()
+    previous_exception_handler = loop.get_exception_handler()
+    unretrieved_future_contexts: list[dict[str, Any]] = []
+
+    def record_unretrieved_future_diagnostics(
+        current_loop: asyncio.AbstractEventLoop,
+        context: dict[str, Any],
+    ) -> None:
+        if _is_unretrieved_future_exception_context(context):
+            unretrieved_future_contexts.append(dict(context))
+            return
+        if previous_exception_handler is not None:
+            previous_exception_handler(current_loop, context)
+            return
+        current_loop.default_exception_handler(context)
+
+    loop.set_exception_handler(record_unretrieved_future_diagnostics)
+    try:
+        yield
+        gc.collect()
+        await asyncio.sleep(0)
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    if unretrieved_future_contexts:
+        details = "\n".join(
+            f"- {_format_unretrieved_future_exception_context(context)}"
+            for context in unretrieved_future_contexts
+        )
+        pytest.fail(
+            f"asyncio reported unretrieved Future exception diagnostics:\n{details}",
+            pytrace=False,
+        )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/tests/unit/test_asyncio_future_diagnostics_guard.py
+++ b/tests/unit/test_asyncio_future_diagnostics_guard.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_unretrieved_deferred_close_future_diagnostic_fails_async_test(pytester) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    pytester.syspathinsert(str(repo_root))
+    pytester.syspathinsert(str(repo_root / "src"))
+    pytester.makeini(
+        """
+        [pytest]
+        asyncio_default_fixture_loop_scope = function
+        """
+    )
+    pytester.makeconftest((repo_root / "tests" / "conftest.py").read_text())
+    pytester.makepyfile(
+        """
+        from __future__ import annotations
+
+        import asyncio
+        import gc
+
+        import pytest
+
+
+        @pytest.mark.asyncio
+        async def test_deferred_close_unretrieved_future_exception() -> None:
+            loop = asyncio.get_running_loop()
+            deferred_close_waiter = loop.create_future()
+            deferred_close_waiter.set_exception(
+                RuntimeError("deferred-close-publication-failed")
+            )
+            del deferred_close_waiter
+            gc.collect()
+            await asyncio.sleep(0)
+        """
+    )
+
+    result = pytester.runpytest("-q")
+
+    result.assert_outcomes(passed=1, errors=1)
+    result.stdout.fnmatch_lines(["*asyncio reported unretrieved Future exception diagnostics*"])


### PR DESCRIPTION
## Summary

Fail async tests when the event loop reports an unretrieved `Future` exception diagnostic during teardown. This closes the gap where deferred-close regressions could pass CI while still logging `Future exception was never retrieved`.

## Changes

- Add a narrow autouse async pytest guard for the exact `Future exception was never retrieved` loop exception-handler message.
- Add a `pytester` regression proving an unretrieved deferred-close waiter exception fails a child pytest run.
- Set pytest-asyncio fixture loop scope to `function` so the new harness fixture has explicit loop-scope behavior.

## Related issue

Closes #86

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section not updated; this is a CI/test-harness change, not a user-visible runtime change.
- [x] No documented public contract changes were needed.
- [x] `ruff check .` passes locally.
- [x] `ruff format --check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_asyncio_future_diagnostics_guard.py --timeout=60` -> 1 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_asyncio_future_diagnostics_guard.py tests/unit/test_asyncio_tcp_connection.py::test_tcp_connection_deferred_close_failure_retrieves_waiter_exception tests/unit/test_asyncio_udp_transport.py::test_udp_receiver_deferred_close_failure_retrieves_waiter_exception --timeout=60` -> 3 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60` -> 619 passed, 3 skipped, 78 deselected
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/ruff format --check .` -> 144 files already formatted
- `.venv/bin/mypy src` -> success