### PR TITLE
refactor(dispatcher): preserve queue identity on resource drops

### DIFF
--- a/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
+++ b/src/aionetx/implementations/asyncio_impl/event_dispatcher.py
@@ -342,7 +342,8 @@ class AsyncioEventDispatcher:
                 kept_events.append(queued_event)
         if not dropped_events:
             return 0
-        self._queue = kept_events
+        self._queue.clear()
+        self._queue.extend(kept_events)
         self._dropped_stop_phase_total += len(dropped_events)
         for queued_event in dropped_events:
             drop_queued_event(queued_event, reason=f"dropped because resource {resource_id} closed")

--- a/tests/unit/test_event_dispatcher_contract.py
+++ b/tests/unit/test_event_dispatcher_contract.py
@@ -1979,6 +1979,43 @@ async def test_runtime_stats_capture_resource_close_queue_cleanup_drop_counts() 
 
 
 @pytest.mark.asyncio
+async def test_resource_close_queue_cleanup_preserves_queue_identity() -> None:
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingHandler:
+        async def on_event(self, event: NetworkEvent) -> None:
+            if (
+                isinstance(event, ConnectionOpenedEvent)
+                and event.metadata.connection_id == "blocker"
+            ):
+                first_started.set()
+                await release_first.wait()
+
+    dispatcher = AsyncioEventDispatcher(
+        BlockingHandler(),
+        EventDeliverySettings(dispatch_mode=EventDispatchMode.BACKGROUND),
+        logging.getLogger("test"),
+    )
+    await dispatcher.start()
+    await dispatcher.emit(_opened("blocker"))
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    await dispatcher.emit(BytesReceivedEvent(resource_id="closing", data=b"drop"))
+    await dispatcher.emit(BytesReceivedEvent(resource_id="staying", data=b"keep"))
+    original_queue = dispatcher._queue
+    try:
+        dropped = await dispatcher.drop_queued_events_for_resource("closing")
+
+        assert dropped == 1
+        assert dispatcher._queue is original_queue
+        assert [queued.event.resource_id for queued in dispatcher._queue] == ["staying"]
+    finally:
+        release_first.set()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
 async def test_stop_phase_drops_emit_distinct_warning_signal(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

Preserve the dispatcher queue object when resource-specific queued payload events are dropped. This closes a fragile internal lifecycle edge without changing drop counts, waiter wakeups, or retained-event behavior.

## Changes

- Mutate the existing dispatcher queue in place during resource-specific payload cleanup.
- Add a dispatcher contract test that pins queue identity while verifying the dropped count and retained queued event.

## Related issue

Closes #81

## Checklist

- [x] All commits include a DCO Signed-off-by line or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] CHANGELOG.md Unreleased section updated if the change is user-visible. Not user-visible.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR. Not a public contract change.
- [x] ruff check . passes locally.
- [x] mypy src passes locally.
- [x] Public API changes are reflected in README.md and docs/architecture.md where appropriate. Not applicable.

Local verification:

- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_event_dispatcher_contract.py::test_resource_close_queue_cleanup_preserves_queue_identity --timeout=60
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_event_dispatcher_contract.py --timeout=60
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60
- .venv/bin/ruff check . --no-cache
- .venv/bin/ruff format --check . --no-cache
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m mypy src