### PR TITLE
ci(release): enforce dependency vulnerability gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,9 +385,38 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: python scripts/ci/check_release_codeql_gate.py
 
+  # Tier: release dependency policy
+  # PRs use dependency-review to inspect changed dependencies. Releases do not
+  # have a PR diff, so this gate blocks artifact builds when GitHub Dependabot
+  # reports a high/critical alert without an accepted non-exploitability
+  # rationale.
+  release_dependency_audit:
+    name: Release trust gate - dependency vulnerability audit
+    needs: [verify_tag_version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      vulnerability-alerts: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Fail on high/critical dependency alerts without rationale
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          # High and critical dependency vulnerability findings block releases
+          # unless an explicit non-exploitability rationale exists.
+          python scripts/ci/check_release_dependency_gate.py
+
   verify_and_build:
     name: Verify and build release artifacts
-    needs: [release_profile_gate, release_codeql_gate]
+    needs: [release_profile_gate, release_codeql_gate, release_dependency_audit]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/scripts/ci/check_release_dependency_gate.py
+++ b/scripts/ci/check_release_dependency_gate.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from json import JSONDecodeError
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Required environment variable is missing: {name}")
+    return value
+
+
+def _parse_next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for segment in link_header.split(","):
+        candidate = segment.strip()
+        if 'rel="next"' not in candidate:
+            continue
+        start = candidate.find("<")
+        end = candidate.find(">", start + 1)
+        if start != -1 and end != -1:
+            return candidate[start + 1 : end]
+    return None
+
+
+def _github_api_headers(token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "aionetx-release-dependency-gate",
+    }
+
+
+def _fetch_paginated_list(*, url: str, token: str, response_name: str) -> list[dict[str, object]]:
+    headers = _github_api_headers(token)
+
+    items: list[dict[str, object]] = []
+    next_url: str | None = url
+    while next_url:
+        request = urllib.request.Request(next_url, headers=headers)
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, list):
+                raise RuntimeError(f"Unexpected {response_name} response shape.")
+            items.extend(item for item in payload if isinstance(item, dict))
+            next_url = _parse_next_link(response.headers.get("Link"))
+    return items
+
+
+def _iter_open_blocking_alerts(*, repository: str, token: str) -> list[dict[str, object]]:
+    url = (
+        f"https://api.github.com/repos/{repository}/dependabot/alerts"
+        "?state=open,dismissed,auto_dismissed&severity=high,critical&per_page=100"
+    )
+    return _fetch_paginated_list(url=url, token=token, response_name="Dependabot alerts")
+
+
+def _alert_package(alert: dict[str, object]) -> str:
+    dependency = alert.get("dependency")
+    if not isinstance(dependency, dict):
+        return "<unknown>"
+    package = dependency.get("package")
+    if not isinstance(package, dict):
+        return "<unknown>"
+    ecosystem = package.get("ecosystem")
+    name = package.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return "<unknown>"
+    if isinstance(ecosystem, str) and ecosystem.strip():
+        return f"{ecosystem}/{name}"
+    return name
+
+
+def _alert_severity(alert: dict[str, object]) -> str:
+    vulnerability = alert.get("security_vulnerability")
+    if not isinstance(vulnerability, dict):
+        return "<unknown>"
+    severity = vulnerability.get("severity")
+    return severity if isinstance(severity, str) and severity.strip() else "<unknown>"
+
+
+def _alert_advisory_id(alert: dict[str, object]) -> str:
+    advisory = alert.get("security_advisory")
+    if not isinstance(advisory, dict):
+        return "<unknown>"
+    ghsa_id = advisory.get("ghsa_id")
+    return ghsa_id if isinstance(ghsa_id, str) and ghsa_id.strip() else "<unknown>"
+
+
+def _alert_version_range(alert: dict[str, object]) -> str:
+    vulnerability = alert.get("security_vulnerability")
+    if not isinstance(vulnerability, dict):
+        return "<unknown>"
+    version_range = vulnerability.get("vulnerable_version_range")
+    return (
+        version_range if isinstance(version_range, str) and version_range.strip() else "<unknown>"
+    )
+
+
+def _alert_state(alert: dict[str, object]) -> str:
+    state = alert.get("state")
+    return state if isinstance(state, str) and state.strip() else "<unknown>"
+
+
+def _dismissal_has_non_exploitability_rationale(alert: dict[str, object]) -> bool:
+    reason = alert.get("dismissed_reason")
+    comment = alert.get("dismissed_comment")
+    return (
+        reason in {"not_used", "inaccurate"} and isinstance(comment, str) and bool(comment.strip())
+    )
+
+
+def _is_blocking_alert(alert: dict[str, object]) -> bool:
+    state = _alert_state(alert)
+    if state == "open":
+        return True
+    if state in {"dismissed", "auto_dismissed"}:
+        return not _dismissal_has_non_exploitability_rationale(alert)
+    return True
+
+
+def main() -> int:
+    try:
+        repository = _require_env("GITHUB_REPOSITORY")
+        release_ref = _require_env("GITHUB_REF")
+        token = _require_env("GITHUB_TOKEN")
+        inspected_alerts = _iter_open_blocking_alerts(repository=repository, token=token)
+    except (RuntimeError, urllib.error.HTTPError, urllib.error.URLError, JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    blocking_alerts = [alert for alert in inspected_alerts if _is_blocking_alert(alert)]
+    print(
+        f"Dependency release gate inspected {len(inspected_alerts)} "
+        f"high/critical Dependabot alert(s) for {repository} at {release_ref}."
+    )
+    if not blocking_alerts:
+        print("No high/critical Dependabot alerts without accepted rationale block this release.")
+        return 0
+
+    print(
+        f"Found {len(blocking_alerts)} blocking dependency alert(s) with severity high/critical:",
+        file=sys.stderr,
+    )
+    for alert in blocking_alerts:
+        number = alert.get("number", "?")
+        html_url = str(alert.get("html_url", ""))
+        rationale_note = ""
+        if _alert_state(alert) in {"dismissed", "auto_dismissed"}:
+            rationale_note = " missing an explicit non-exploitability rationale"
+        print(
+            f"- alert #{number}: package={_alert_package(alert)} "
+            f"severity={_alert_severity(alert)} advisory={_alert_advisory_id(alert)} "
+            f"range={_alert_version_range(alert)} state={_alert_state(alert)}"
+            f"{rationale_note} {html_url}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_release_dependency_gate.py
+++ b/scripts/ci/check_release_dependency_gate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from json import JSONDecodeError
 import os
 import sys
 import urllib.error
@@ -132,7 +131,12 @@ def main() -> int:
         release_ref = _require_env("GITHUB_REF")
         token = _require_env("GITHUB_TOKEN")
         inspected_alerts = _iter_open_blocking_alerts(repository=repository, token=token)
-    except (RuntimeError, urllib.error.HTTPError, urllib.error.URLError, JSONDecodeError) as exc:
+    except (
+        RuntimeError,
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+    ) as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/tests/unit/test_release_dependency_gate_script.py
+++ b/tests/unit/test_release_dependency_gate_script.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+from json import JSONDecodeError
+from email.message import Message
+import runpy
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "ci" / "check_release_dependency_gate.py"
+SCRIPT_GLOBALS = runpy.run_path(str(SCRIPT_PATH))
+
+main = SCRIPT_GLOBALS["main"]
+
+
+class FakeResponse:
+    def __init__(self, payload: object, link: str | None = None) -> None:
+        self._payload = payload
+        self.headers = {"Link": link} if link else {}
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _set_release_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "MarcusKorinth/aionetx")
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v1.2.3")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+
+def test_release_dependency_gate_queries_open_high_critical_alerts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_release_env(monkeypatch)
+    requested_urls: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        requested_urls.append(request.full_url)
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 0
+
+    assert requested_urls == [
+        "https://api.github.com/repos/MarcusKorinth/aionetx/dependabot/alerts"
+        "?state=open,dismissed,auto_dismissed&severity=high,critical&per_page=100"
+    ]
+
+
+def test_release_dependency_gate_passes_when_no_blocking_alerts(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        return FakeResponse([])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 0
+
+    captured = capsys.readouterr()
+    assert "No high/critical Dependabot alerts without accepted rationale" in captured.out
+
+
+@pytest.mark.parametrize(
+    ("ecosystem", "package_name"),
+    [
+        ("pip", "example-package"),
+        ("github_actions", "actions/checkout"),
+    ],
+)
+def test_release_dependency_gate_blocks_high_or_critical_alerts(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    ecosystem: str,
+    package_name: str,
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        return FakeResponse(
+            [
+                {
+                    "number": 8,
+                    "state": "open",
+                    "html_url": "https://github.com/MarcusKorinth/aionetx/security/dependabot/8",
+                    "dependency": {
+                        "package": {
+                            "ecosystem": ecosystem,
+                            "name": package_name,
+                        }
+                    },
+                    "security_advisory": {"ghsa_id": "GHSA-test"},
+                    "security_vulnerability": {
+                        "package": {
+                            "ecosystem": ecosystem,
+                            "name": package_name,
+                        },
+                        "severity": "critical",
+                        "vulnerable_version_range": "< 2.0",
+                    },
+                }
+            ]
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "Found 1 blocking dependency alert(s)" in captured.err
+    assert f"{ecosystem}/{package_name}" in captured.err
+    assert "critical" in captured.err
+
+
+@pytest.mark.parametrize("dismissed_reason", ["not_used", "inaccurate"])
+def test_release_dependency_gate_accepts_dismissed_non_exploitable_alert_with_comment(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    dismissed_reason: str,
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        return FakeResponse(
+            [
+                {
+                    "number": 9,
+                    "state": "dismissed",
+                    "dismissed_reason": dismissed_reason,
+                    "dismissed_comment": "This package is not present in release artifacts.",
+                    "dependency": {
+                        "package": {
+                            "ecosystem": "pip",
+                            "name": "unused-package",
+                        }
+                    },
+                    "security_advisory": {"ghsa_id": "GHSA-unused"},
+                    "security_vulnerability": {
+                        "package": {
+                            "ecosystem": "pip",
+                            "name": "unused-package",
+                        },
+                        "severity": "high",
+                        "vulnerable_version_range": "< 3.0",
+                    },
+                }
+            ]
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 0
+
+    captured = capsys.readouterr()
+    assert "No high/critical Dependabot alerts without accepted rationale" in captured.out
+
+
+@pytest.mark.parametrize(
+    ("dismissed_reason", "dismissed_comment"),
+    [
+        ("tolerable_risk", "Accepted until next dependency refresh."),
+        ("not_used", ""),
+        ("auto_dismissed", ""),
+    ],
+)
+def test_release_dependency_gate_blocks_dismissed_alert_without_non_exploitability_rationale(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    dismissed_reason: str,
+    dismissed_comment: str,
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        return FakeResponse(
+            [
+                {
+                    "number": 10,
+                    "state": (
+                        "auto_dismissed" if dismissed_reason == "auto_dismissed" else "dismissed"
+                    ),
+                    "dismissed_reason": (
+                        None if dismissed_reason == "auto_dismissed" else dismissed_reason
+                    ),
+                    "dismissed_comment": dismissed_comment,
+                    "html_url": "https://github.com/MarcusKorinth/aionetx/security/dependabot/10",
+                    "dependency": {
+                        "package": {
+                            "ecosystem": "pip",
+                            "name": "dismissed-package",
+                        }
+                    },
+                    "security_advisory": {"ghsa_id": "GHSA-dismissed"},
+                    "security_vulnerability": {
+                        "package": {
+                            "ecosystem": "pip",
+                            "name": "dismissed-package",
+                        },
+                        "severity": "high",
+                        "vulnerable_version_range": "< 4.0",
+                    },
+                }
+            ]
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "dismissed-package" in captured.err
+    assert "missing an explicit non-exploitability rationale" in captured.err
+
+
+def test_release_dependency_gate_fails_closed_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        raise urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "HTTP Error 403: Forbidden" in captured.err
+
+
+def test_release_dependency_gate_fails_closed_on_url_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        raise urllib.error.URLError("network unavailable")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "network unavailable" in captured.err
+
+
+def test_release_dependency_gate_fails_closed_on_invalid_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        raise JSONDecodeError("invalid json", doc="", pos=0)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "invalid json" in captured.err
+
+
+def test_release_dependency_gate_fails_closed_on_unexpected_response(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        return FakeResponse({"message": "unexpected"})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 1
+
+    captured = capsys.readouterr()
+    assert "Unexpected Dependabot alerts response shape" in captured.err
+
+
+def test_release_dependency_gate_reads_paginated_dependabot_alerts(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _set_release_env(monkeypatch)
+
+    def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
+        if request.full_url.endswith("page=2"):
+            return FakeResponse([])
+        return FakeResponse(
+            [],
+            link='<https://api.github.com/repos/MarcusKorinth/aionetx/dependabot/alerts?page=2>; rel="next"',
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert main() == 0
+
+    captured = capsys.readouterr()
+    assert "inspected 0 high/critical Dependabot alert(s)" in captured.out

--- a/tests/unit/test_release_dependency_gate_script.py
+++ b/tests/unit/test_release_dependency_gate_script.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import json
-from json import JSONDecodeError
 from email.message import Message
+import json
 import runpy
 import urllib.error
 import urllib.request
@@ -274,7 +273,7 @@ def test_release_dependency_gate_fails_closed_on_invalid_json(
     _set_release_env(monkeypatch)
 
     def fake_urlopen(request: urllib.request.Request) -> FakeResponse:
-        raise JSONDecodeError("invalid json", doc="", pos=0)
+        raise json.JSONDecodeError("invalid json", doc="", pos=0)
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
 

--- a/tests/unit/test_release_workflow_structure.py
+++ b/tests/unit/test_release_workflow_structure.py
@@ -25,6 +25,21 @@ def _job_block(workflow_text: str, job_name: str) -> str:
     return workflow_text[start:end]
 
 
+def _direct_needs(job_block: str) -> set[str]:
+    inline_needs = re.search(r"^    needs: \[(?P<needs>[^\]]+)\]$", job_block, re.MULTILINE)
+    if inline_needs is not None:
+        return {need.strip() for need in inline_needs.group("needs").split(",")}
+
+    needs_start = job_block.index("    needs:\n") + len("    needs:\n")
+    steps_start = job_block.index("    steps:\n", needs_start)
+    needs_block = job_block[needs_start:steps_start]
+    return {
+        line.removeprefix("      - ").strip()
+        for line in needs_block.splitlines()
+        if line.startswith("      - ")
+    }
+
+
 def _action_step_block(action_text: str, step_name: str) -> str:
     header = f"    - name: {step_name}\n"
     start = action_text.index(header)
@@ -98,6 +113,31 @@ def test_release_reuses_setup_phases_without_hiding_publish_steps() -> None:
         workflow_text,
         "attest_provenance",
     )
+
+
+def test_release_dependency_audit_blocks_artifact_build() -> None:
+    workflow_text = _read(RELEASE_WORKFLOW_PATH)
+
+    codeql_gate = _job_block(workflow_text, "release_codeql_gate")
+    dependency_audit = _job_block(workflow_text, "release_dependency_audit")
+    verify_and_build = _job_block(workflow_text, "verify_and_build")
+
+    assert "permissions:\n      contents: read\n      security-events: read" in codeql_gate
+    assert "name: Release trust gate - dependency vulnerability audit" in dependency_audit
+    assert _direct_needs(dependency_audit) == {"verify_tag_version"}
+    assert "permissions:\n      contents: read" in dependency_audit
+    assert "vulnerability-alerts: read" in dependency_audit
+    assert "security-events: read" not in dependency_audit
+    assert "uses: actions/checkout@" in dependency_audit
+    assert "uses: actions/setup-python@" in dependency_audit
+    assert "GITHUB_TOKEN: ${{ github.token }}" in dependency_audit
+    assert "GITHUB_REPOSITORY: ${{ github.repository }}" in dependency_audit
+    assert "python scripts/ci/check_release_dependency_gate.py" in dependency_audit
+    assert "pip dependency alerts" not in dependency_audit
+    assert "High and critical dependency vulnerability findings block releases" in (
+        dependency_audit
+    )
+    assert "release_dependency_audit" in _direct_needs(verify_and_build)
 
 
 def test_capture_build_epoch_action_has_narrow_release_contract() -> None:


### PR DESCRIPTION
## Summary

Add a release dependency vulnerability gate so release artifact builds stop when high or critical Dependabot alerts are not resolved or documented as non-exploitable.

## Problems and approach

1. Problem: The pull request workflow reviewed dependency changes, but the release workflow could build artifacts without checking the repository's current high/critical dependency alert state.

   Approach: Add a release dependency audit job before `verify_and_build` that reads Dependabot alerts with `vulnerability-alerts: read` and fails before artifacts are built when a high/critical alert lacks an accepted rationale.

2. Problem: Release-path dependencies include more than Python package dependencies.

   Approach: Query high/critical Dependabot alerts across ecosystems, including GitHub Actions, instead of filtering to `pip`.

3. Problem: Dismissed alerts need a visible non-exploitability rationale to match the release policy.

   Approach: Allow dismissed or auto-dismissed alerts only when the dismissal uses `not_used` or `inaccurate` and includes a written comment. Open alerts and other dismissed states block release builds.

## Changes

- Add `scripts/ci/check_release_dependency_gate.py` for the release workflow.
- Add `release_dependency_audit` before release artifact build and publication.
- Add unit coverage for workflow wiring, alert states, accepted dismissal rationale, pagination, and fail-closed API errors.

## Related issue

Closes #88

## Checklist

- [x] All commits include a DCO `Signed-off-by` line.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section not updated because this is release CI policy enforcement, not user-facing package behavior.
- [x] Public API changes are not involved.
- [x] `ruff check .` passes locally.
- [x] `ruff format --check .` passes locally.
- [x] `mypy src` passes locally.

Local verification:

```text
.venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_release_dependency_gate_script.py tests/unit/test_release_workflow_structure.py::test_release_dependency_audit_blocks_artifact_build --timeout=60
15 passed in 0.07s

PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60
636 passed, 3 skipped, 78 deselected in 17.44s

.venv/bin/ruff check .
All checks passed!

.venv/bin/ruff format --check .
146 files already formatted

.venv/bin/mypy src
Success: no issues found in 67 source files
```
