### PR TITLE
chore(github): add maintenance issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,0 +1,76 @@
+name: Infrastructure / maintenance
+description: Propose a change to CI, tooling, packaging, developer workflow, or repository housekeeping.
+title: "[infra] "
+labels: ["type:chore", "area:repo", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for project infrastructure and maintenance work: CI pipelines, linting, formatting, type checking, test configuration, packaging metadata, dependency management, developer setup, documentation builds, repository housekeeping, and similar concerns.
+
+        If your proposal changes transport runtime behavior (lifecycle, events, backpressure, reconnect, multicast, typing, or narrow TCP `ssl=` wiring), use the [Feature request](https://github.com/MarcusKorinth/aionetx/issues/new?template=feature_request.yml) template instead.
+
+        Please report suspected vulnerabilities privately through [GitHub Private Vulnerability Reporting](https://github.com/MarcusKorinth/aionetx/security/advisories/new), not as public issues.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What friction, gap, or risk does this address?
+      placeholder: e.g. "There is no optional pre-commit setup that mirrors the repository's existing lint and format checks."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What specifically should change? Include commands, configuration snippets, or tool names where helpful.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this touch?
+      multiple: true
+      options:
+        - CI / GitHub Actions
+        - Linting / formatting
+        - Type checking
+        - Test configuration / fixtures
+        - Packaging / pyproject.toml
+        - Dependency management
+        - Developer environment setup
+        - Documentation build
+        - Repository housekeeping
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Considered alternatives
+      description: Other approaches you considered, or why the current setup is not enough.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to relevant tool documentation, related issues, or examples from other projects.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: I have searched existing issues and confirmed this is not already proposed.
+          required: true
+        - label: This proposal concerns project infrastructure, tooling, or maintenance, not transport runtime behavior.
+          required: true

--- a/tests/unit/test_issue_templates.py
+++ b/tests/unit/test_issue_templates.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_PATH = PROJECT_ROOT / ".github" / "ISSUE_TEMPLATE" / "infrastructure.yml"
+
+
+def test_maintenance_issue_template_routes_repo_upkeep_proposals() -> None:
+    text = TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert 'title: "[infra] "' in text
+    assert 'labels: ["type:chore", "area:repo", "triage"]' in text
+    assert "Feature request" in text
+    assert "feature_request.yml" in text
+    assert "transport runtime behavior" in text
+    assert "CI / GitHub Actions" in text
+    assert "Linting / formatting" in text
+    assert "Packaging / pyproject.toml" in text
+    assert "Developer environment setup" in text
+    assert "This proposal concerns project infrastructure, tooling, or maintenance" in text
+
+    proposal_start = text.index("    id: proposal")
+    proposal_end = text.index("  - type:", proposal_start + 1)
+    proposal_block = text[proposal_start:proposal_end]
+    assert "render:" not in proposal_block


### PR DESCRIPTION
## Summary

Add a dedicated issue form for infrastructure and maintenance proposals so repository upkeep no longer has to use the transport feature-request template.

## Changes

- Add `.github/ISSUE_TEMPLATE/infrastructure.yml` for CI, tooling, packaging, dependency, documentation-build, developer-setup, and repository-housekeeping proposals.
- Use existing repository labels: `type:chore`, `area:repo`, and `triage`.
- Keep the proposed-change field neutral, without a language-specific `render:` hint.
- Add a focused unit test that checks the template routing text, labels, maintenance areas, and neutral proposal field.

## Related issue

Relates to #11.
Supersedes #12 for the issue-template portion.

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior.
- [x] `CHANGELOG.md` `[Unreleased]` section updated if the change is user-visible.
  - Not needed: repository issue-template maintenance only.
- [x] If this changes a documented public contract, the relevant docs/README sections were updated in the same PR.
  - Not applicable: no public runtime contract changes.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] Public API changes are reflected in `README.md` and `docs/architecture.md` where appropriate.
  - Not applicable: no public API changes.

Local verification:

```text
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_issue_templates.py --timeout=60
1 passed in 0.02s

PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q -m "not multicast and not slow and not integration" --timeout=60
637 passed, 3 skipped, 79 deselected in 16.59s

.venv/bin/ruff check .
All checks passed!

.venv/bin/ruff format --check .
149 files already formatted

PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m mypy src
Success: no issues found in 67 source files
```