### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable user-visible changes to `aionetx` are documented in this file.
 
 ## [Unreleased]
 
-Planned contents for the initial public alpha release (`0.1.0`).
+## [0.1.0] - 2026-07-05
+
+Initial public alpha release.
 
 ### Added
 
@@ -23,7 +25,7 @@ Planned contents for the initial public alpha release (`0.1.0`).
 
 ### Changed
 
-- require Python 3.11 or newer for the initial public alpha release
+- require Python 3.11 or newer
 - Documentation now distinguishes possible future narrow TCP `ssl=` /
   `ssl.SSLContext` transport wiring from higher-layer authentication,
   certificate-management, DTLS, service-mesh, and application-security scope.

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Choose direct `asyncio` if you need very custom low-level control and are comfor
 
 ## Installation and local development
 
-After the first public release is published to PyPI, install it with:
+Install the published package from PyPI:
 
 ```bash
 pip install aionetx


### PR DESCRIPTION
## Summary

Prepare the `v0.1.0` release documentation by cutting the initial changelog entry and updating install wording for the published package.

## Changes

- Move the initial public alpha contents from planned `[Unreleased]` text into `## [0.1.0] - 2026-07-05`.
- Update the README installation section to present `pip install aionetx` as the PyPI install path.
- Leave `pyproject.toml` unchanged because `[project].version` is already `0.1.0` on current `main`.

## Related issue

Closes #48.

## Validation

- `.venv/bin/python -m pytest -q -m "not multicast and not slow and not integration" --timeout=60` - 637 passed, 3 skipped, 79 deselected
- `.venv/bin/python -m ruff check .` - passed
- `.venv/bin/python -m ruff format --check .` - passed
- `.venv/bin/python -m mypy src` - passed

## Checklist

- [x] All commits include a DCO `Signed-off-by` line (`git commit -s`) or are otherwise DCO-compliant.
- [x] Tests added or updated for new or changed behavior, or explicitly not needed because this is documentation-only.
- [x] `CHANGELOG.md` was updated for the release.
- [x] README installation wording was updated for the release.
- [x] `ruff check .` passes locally.
- [x] `mypy src` passes locally.
- [x] No public API changes were made.